### PR TITLE
[AIP-123] Resource types

### DIFF
--- a/aip/0123.md
+++ b/aip/0123.md
@@ -1,0 +1,68 @@
+---
+aip:
+  id: 123
+  state: reviewing
+  created: 2019-05-12
+permalink: /123
+redirect_from:
+  - /0123
+---
+
+# Resource types
+
+Most APIs expose _resources_ (their primary nouns) which users are able to
+create, retrieve, and manipulate. APIs are allowed to name their resource types
+as they see fit, and are only required to ensure uniqueness within that API.
+This means that it is possible (and often desirable) for different APIs to use
+the same type name. For example, a Memcache and Redis API would both want to
+use `Instance` as a type name.
+
+When mapping the relationships between APIs and their resources, however, it
+becomes important to have a single, globally-unique type name. Additionally,
+tools such as Kubernetes or GraphQL interact with APIs from multiple providers.
+
+## Terminology
+
+In the guidance below, we use the following terms:
+
+- **Service Name:** This is the name defined in the [service configuration][].
+  This usually (but not necessarily) matches the hostname that users use to
+  call the service. Example: `pubsub.googleapis.com`. This is equivalent to an
+  [API Group][] in Kubernetes.
+- **Type:** This is the name used for the type within the API. This usually
+  (but not necessarily) matches the name of the protobuf message. This is
+  equivalent to an [Object][] in Kubernetes.
+
+## Guidance
+
+APIs **must** define a resource type for each resource in the API, according to
+the following pattern: `{Service Name}/{Type}`. The type name **must** be
+singular and use PascalCase (UpperCamelCase).
+
+### Examples
+
+Examples of resource types include:
+
+- `pubsub.googleapis.com/Topic`
+- `pubsub.googleapis.com/Subscription`
+- `spanner.googleapis.com/Database`
+- `spanner.googleapis.com/Instance`
+- `networking.istio.io/Instance`
+
+### Annotating resource types
+
+APIs **should** annotate the resource types for each resource in the API:
+
+```proto
+message Topic {
+  option (google.api.resource) = {
+    type: "pubsub.googleapis.com/Topic"
+  };
+}
+```
+
+<!-- prettier-ignore-start -->
+[API Group]: https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups
+[Object]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+[service configuration]: https://github.com/googleapis/api-common-protos/blob/master/google/api/service.proto
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
This adds an AIP for unified resource types.

This AIP is much shorter than the internal document around unified resource types as it only covers what API producers should do, and omits the background.

Fixes #57.