### PR TITLE
Fix #103 - Fixed broken redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 markdown: kramdown
 plugins:
   - jekyll-redirect-from
-url: https://github.com/googleapis/aip
+url: https://aip.dev
 include:
   - CONTRIBUTING.md
 defaults:


### PR DESCRIPTION
This was leftover from before our launch of aip.dev.