### PR TITLE
Specify the type of error for a Cascading Delete

### DIFF
--- a/aip/0135.md
+++ b/aip/0135.md
@@ -135,7 +135,7 @@ message DeleteShelfRequest {
 }
 ```
 
-The API **must** fail with an error if the `force` field is not set and child
+The API **must** fail with a `FAILED_PRECONDTION` error if the `force` field is not set and child
 resources are present.
 
 ### Protected deletes

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -135,8 +135,8 @@ message DeleteShelfRequest {
 }
 ```
 
-The API **must** fail with a `FAILED_PRECONDTION` error if the `force` field is not set and child
-resources are present.
+The API **must** fail with a `FAILED_PRECONDTION` error if the `force` field
+is not set and child resources are present.
 
 ### Protected deletes
 


### PR DESCRIPTION
FAILED_PRECONDITION where the precondition is that there not be any child resources.