### PR TITLE
[fix] Explicitly forbid arbitrary fields in standard methods.

### DIFF
--- a/aip/0131.md
+++ b/aip/0131.md
@@ -3,6 +3,7 @@ aip:
   id: 131
   state: approved
   created: 2019-01-22
+  updated: 2019-05-29
 permalink: /131
 redirect_from:
   - /0131
@@ -72,3 +73,8 @@ field in the request to be populated based on the value in the URL when the
 REST/JSON interface is used.
 
 [aip-121]: ./0121.md
+
+## Changelog
+
+- **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
+  methods.

--- a/aip/0131.md
+++ b/aip/0131.md
@@ -64,7 +64,7 @@ message GetBookRequest {
 - A resource name field **must** be included. It **should** be called `name`.
 - The comment for the `name` field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
-  **should not** contain other optional fields unless they are described in
+  **should not** contain other optional fields except those described in
   another AIP.
 
 **Note:** The `name` field in the request object corresponds to the `name`

--- a/aip/0131.md
+++ b/aip/0131.md
@@ -14,9 +14,9 @@ In REST APIs, it is customary to make a `GET` request to a resource's URI (for
 example, `/v1/shelves/{shelf}/books/{book}`) in order to retrieve that
 resource.
 
-Resource-oriented design ([AIP-121][]) honors this pattern through the
-`Get` method. These RPCs accept the URI representing that resource and return
-the resource.
+Resource-oriented design ([AIP-121][]) honors this pattern through the `Get`
+method. These RPCs accept the URI representing that resource and return the
+resource.
 
 ## Guidance
 
@@ -62,6 +62,9 @@ message GetBookRequest {
 
 - A resource name field **must** be included. It **should** be called `name`.
 - The comment for the `name` field **should** document the resource pattern.
+- The request message **must not** contain any other required fields, and
+  **should not** contain other optional fields unless they are described in
+  another AIP.
 
 **Note:** The `name` field in the request object corresponds to the `name`
 variable in the `google.api.http` annotation on the RPC. This causes the `name`

--- a/aip/0132.md
+++ b/aip/0132.md
@@ -3,6 +3,7 @@ aip:
   id: 132
   state: reviewing
   created: 2019-01-21
+  updated: 2019-05-29
 permalink: /132
 redirect_from:
   - /0132
@@ -162,3 +163,8 @@ included.
 [aip-121]: ./0121.md
 [aip-158]: ./0158.md
 [soft delete]: ./0135.md#soft-delete
+
+## Changelog
+
+- **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
+  methods.

--- a/aip/0132.md
+++ b/aip/0132.md
@@ -90,8 +90,8 @@ message ListBooksRequest {
 - The request message **may** include fields for common design patterns germane
   to list methods, such as `string filter` and `string order_by`.
 - The request message **must not** contain any other required fields, and
-  **should not** contain other optional fields unless they are described in
-  this or another AIP.
+  **should not** contain other optional fields except those described in this
+  or another AIP.
 
 ### Response message
 

--- a/aip/0132.md
+++ b/aip/0132.md
@@ -14,9 +14,9 @@ In many APIs, it is customary to make a `GET` request to a collection's URI
 (for example, `/v1/shelves/1/books`) in order to retrieve a list of resources,
 each of which lives within that collection.
 
-Resource-oriented design ([AIP-121][]) honors this pattern through the
-`List` method. These RPCs accept the parent collection (and potentially some
-other parameters), and return a list of responses matching that input.
+Resource-oriented design ([AIP-121][]) honors this pattern through the `List`
+method. These RPCs accept the parent collection (and potentially some other
+parameters), and return a list of responses matching that input.
 
 ## Guidance
 
@@ -88,6 +88,9 @@ message ListBooksRequest {
 - The `page_token` field **must** be included on all list request messages.
 - The request message **may** include fields for common design patterns germane
   to list methods, such as `string filter` and `string order_by`.
+- The request message **must not** contain any other required fields, and
+  **should not** contain other optional fields unless they are described in
+  this or another AIP.
 
 ### Response message
 

--- a/aip/0133.md
+++ b/aip/0133.md
@@ -14,10 +14,9 @@ In REST APIs, it is customary to make a `POST` request to a collection's URI
 (for example, `/v1/shelves/{shelf}/books`) in order to create a new resource
 within that collection.
 
-Resource-oriented design ([AIP-121][]) honors this pattern through the
-`Create` method. These RPCs accept the parent collection and the resource to
-create (and potentially some other parameters), and return the created
-resource.
+Resource-oriented design ([AIP-121][]) honors this pattern through the `Create`
+method. These RPCs accept the parent collection and the resource to create (and
+potentially some other parameters), and return the created resource.
 
 ## Guidance
 
@@ -72,6 +71,9 @@ message CreateBookRequest {
 - A `parent` field **must** be included unless the resource being listed is a
   top-level resource. It **should** be called `parent`.
 - The resource field **must** be included and **must** map to the POST body.
+- The request message **must not** contain any other required fields, and
+  **should not** contain other optional fields unless they are described in
+  this or another AIP.
 
 ### User-specified IDs
 

--- a/aip/0133.md
+++ b/aip/0133.md
@@ -3,6 +3,7 @@ aip:
   id: 133
   state: reviewing
   created: 2019-01-23
+  updated: 2019-05-29
 permalink: /133
 redirect_from:
   - /0133
@@ -132,3 +133,8 @@ feasible, then the current state of the object).
 
 [aip-121]: ./0121.md
 [aip-122]: ./0122.md
+
+## Changelog
+
+- **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
+  methods.

--- a/aip/0133.md
+++ b/aip/0133.md
@@ -73,8 +73,8 @@ message CreateBookRequest {
   top-level resource. It **should** be called `parent`.
 - The resource field **must** be included and **must** map to the POST body.
 - The request message **must not** contain any other required fields, and
-  **should not** contain other optional fields unless they are described in
-  this or another AIP.
+  **should not** contain other optional fields except those described in this
+  or another AIP.
 
 ### User-specified IDs
 

--- a/aip/0134.md
+++ b/aip/0134.md
@@ -86,8 +86,8 @@ message UpdateBookRequest {
   - The fields used in the field mask correspond to the resource being updated
     (not the request message).
 - The request message **must not** contain any other required fields, and
-  **should not** contain other optional fields unless they are described in
-  this or another AIP.
+  **should not** contain other optional fields except those described in this
+  or another AIP.
 
 ### Side effects
 

--- a/aip/0134.md
+++ b/aip/0134.md
@@ -14,9 +14,9 @@ In REST APIs, it is customary to make a `PATCH` or `PUT` request to a
 resource's URI (for example, `/v1/shelves/{shelf}/books/{book}`) in order to
 update that resource.
 
-Resource-oriented design ([AIP-121][]) honors this pattern through the
-`Update` method (which mirrors the REST `PATCH` behavior). These RPCs accept
-the URI representing that resource and return the resource.
+Resource-oriented design ([AIP-121][]) honors this pattern through the `Update`
+method (which mirrors the REST `PATCH` behavior). These RPCs accept the URI
+representing that resource and return the resource.
 
 ## Guidance
 
@@ -76,14 +76,17 @@ message UpdateBookRequest {
 }
 ```
 
-- A `name` field **must** be included in the resource message. It **should**
-  be called `name`.
+- A `name` field **must** be included in the resource message. It **should** be
+  called `name`.
 - The comment for the field **should** document the resource pattern.
 - A field mask **should** be included in order to support partial update. It
   **must** be of type `google.protobuf.FieldMask`, and it **should** be called
   `update_mask`.
   - The fields used in the field mask correspond to the resource being updated
     (not the request message).
+- The request message **must not** contain any other required fields, and
+  **should not** contain other optional fields unless they are described in
+  this or another AIP.
 
 ### Side effects
 
@@ -169,8 +172,8 @@ message Book {
 The `etag` field **may** be either required or optional. If it is set, then the
 request **must** succeed if and only if the provided etag matches the
 server-computed value, and **must** fail with a `FAILED_PRECONDITION` error
-otherwise. The `update_mask` field in the request does not affect the
-behavior of the `etag` field, as it is not a field *being* updated.
+otherwise. The `update_mask` field in the request does not affect the behavior
+of the `etag` field, as it is not a field _being_ updated.
 
 ### Expensive fields
 

--- a/aip/0134.md
+++ b/aip/0134.md
@@ -3,6 +3,7 @@ aip:
   id: 134
   state: reviewing
   created: 2019-01-24
+  updated: 2019-05-29
 permalink: /134
 redirect_from:
   - /0134
@@ -196,3 +197,8 @@ so.
 [aip-121]: ./0121.md
 [create]: ./0133.md
 [state fields]: ./0216.md
+
+## Changelog
+
+- **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
+  methods.

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -67,8 +67,8 @@ message DeleteBookRequest {
 - A `name` field **must** be included. It **should** be called `name`.
 - The comment for the field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
-  **should not** contain other optional fields unless they are described in
-  this or another AIP.
+  **should not** contain other optional fields except those described in this
+  or another AIP.
 
 ### Soft delete
 

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -3,6 +3,7 @@ aip:
   id: 135
   state: reviewing
   created: 2019-01-24
+  updated: 2019-05-29
 permalink: /135
 redirect_from:
   - /0135
@@ -167,3 +168,8 @@ request **must** fail with a `FAILED_PRECONDITION` error code.
 [aip-136]: ./0136.md
 [aip-214]: ./0214.md
 [etag]: ./0134.md#etags
+
+## Changelog
+
+- **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
+  methods.

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -14,9 +14,9 @@ In REST APIs, it is customary to make a `DELETE` request to a resource's URI
 (for example, `/v1/shelves/{shelf}/books/{book}`) in order to delete that
 resource.
 
-Resource-oriented design ([AIP-121][]) honors this pattern through the
-`Delete` method. These RPCs accept the URI representing that resource and
-usually return an empty response.
+Resource-oriented design ([AIP-121][]) honors this pattern through the `Delete`
+method. These RPCs accept the URI representing that resource and usually return
+an empty response.
 
 ## Guidance
 
@@ -65,6 +65,9 @@ message DeleteBookRequest {
 
 - A `name` field **must** be included. It **should** be called `name`.
 - The comment for the field **should** document the resource pattern.
+- The request message **must not** contain any other required fields, and
+  **should not** contain other optional fields unless they are described in
+  this or another AIP.
 
 ### Soft delete
 
@@ -135,8 +138,8 @@ message DeleteShelfRequest {
 }
 ```
 
-The API **must** fail with a `FAILED_PRECONDTION` error if the `force` field
-is not set and child resources are present.
+The API **must** fail with a `FAILED_PRECONDTION` error if the `force` field is
+not set and child resources are present.
 
 ### Protected deletes
 


### PR DESCRIPTION
Fixes #125.