### PR TITLE
[feat] Use different colors for must/should/may.

### DIFF
--- a/_sass/syntax.scss
+++ b/_sass/syntax.scss
@@ -1,7 +1,17 @@
 @import 'colors';
 
 strong.spec-directive {
-  color: $h-google-red-700;
+  &.spec-must {
+    color: $h-google-red-700;
+  }
+
+  &.spec-should {
+    color: $h-orange-700;
+  }
+
+  &.spec-may {
+    color: $h-google-green-700;
+  }
 }
 
 .highlighter-rouge {

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -27,7 +27,8 @@ $.when($.ready).then(() => {
   for (let directive of ['may', 'must', 'must not', 'should', 'should not']) {
     $('strong')
       .filter((i, el) => $(el).text() === directive)
-      .addClass('spec-directive');
+      .addClass('spec-directive')
+      .addClass(`spec-${directive.split(' ')[0]}`);
   }
 
   // Control the maximum height of the nav sidebar.


### PR DESCRIPTION
Based on comments from an in-person meeting with @jskeet and @jgeewax: Use red for must, orange for should, green for may.

<img width="1448" alt="Screen Shot 2019-06-05 at 11 08 15 AM" src="https://user-images.githubusercontent.com/4346/58948555-45ea6c00-8782-11e9-9d1d-d1abec61f736.png">
