### PR TITLE
[fix] Prohibit DELETE on custom methods.

### DIFF
--- a/aip/0136.md
+++ b/aip/0136.md
@@ -46,9 +46,7 @@ services. The bullets below apply in all three cases.
   - Custom methods that serve as an alternative to get or list methods (such as
     `Search`) **should** use `GET`. These methods **must** be idempotent and
     have no side effects.
-  - Custom methods that serve as an alternative to delete methods (such as
-    `BatchDelete`) **should** use `DELETE`.
-  - Custom methods **must not** use `PATCH`.
+  - Custom methods **should not** use `PATCH` or `DELETE`.
 - The HTTP URI **must** use a `:` character followed by the custom verb
   (`:archive` in the above example), and the verb in the URI **must** match the
   verb in the name of the RPC.


### PR DESCRIPTION
Our AIPs are inconsistent. Custom methods should use `POST` or `GET` (not `DELETE`).

Fixes #123.