### PR TITLE
[AIP-133/134/135] Add consistent LRO language.

### DIFF
--- a/aip/0133.md
+++ b/aip/0133.md
@@ -94,9 +94,9 @@ rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
 }
 ```
 
-- The response type **must** be set to resource (what the return type would be
-  if the RPC was not long-running).
-- The `response_type` and `metadata_type` fields both **must** be specified.
+- The response type **must** be set to the resource (what the return type would
+  be if the RPC was not long-running).
+- Both the `response_type` and `metadata_type` fields **must** be specified.
 
 ### User-specified IDs
 

--- a/aip/0133.md
+++ b/aip/0133.md
@@ -3,7 +3,7 @@ aip:
   id: 133
   state: reviewing
   created: 2019-01-23
-  updated: 2019-05-29
+  updated: 2019-06-10
 permalink: /133
 redirect_from:
   - /0133
@@ -41,9 +41,9 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
 - The request message **must** match the RPC name, with a `-Request` suffix.
 - The response message **must** be the resource itself. There is no
   `CreateBookResponse`.
-  - However, in the event that the request may take a significant amount of
-    time, the response message **must** return a `google.longrunning.Operation`
-    which ultimately resolves to the resource itself.
+  - If the update RPC is [long-running](#long-running-create), the response
+    message **must** be a `google.longrunning.Operation` which resolves to the
+    resource itself.
 - The HTTP verb **must** be `POST`.
 - The collection where the resource is being added **should** map to the URL
   path.
@@ -75,6 +75,28 @@ message CreateBookRequest {
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
   or another AIP.
+
+### Long-running create
+
+Some resources take longer to create a resource than is reasonable for a
+regular API request. In this situation, the API **should** use a long-running
+operation instead:
+
+```proto
+rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
+  option (google.api.http) = {
+    post: "/v1/{parent=shelves/*}/books"
+  };
+  option (google.longrunning.operation_info) = {
+    response_type: "Book"
+    metadata_type: "OperationMetadata"
+  }
+}
+```
+
+- The response type **must** be set to resource (what the return type would be
+  if the RPC was not long-running).
+- The `response_type` and `metadata_type` fields both **must** be specified.
 
 ### User-specified IDs
 
@@ -136,5 +158,6 @@ feasible, then the current state of the object).
 
 ## Changelog
 
+- **2019-06-10**: Added guidance for long-running create.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0134.md
+++ b/aip/0134.md
@@ -147,9 +147,9 @@ rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
 }
 ```
 
-- The response type **must** be set to resource (what the return type would be
-  if the RPC was not long-running).
-- The `response_type` and `metadata_type` fields both **must** be specified.
+- The response type **must** be set to the resource (what the return type would
+  be if the RPC was not long-running).
+- Both the `response_type` and `metadata_type` fields **must** be specified.
 
 ### Create or update
 

--- a/aip/0134.md
+++ b/aip/0134.md
@@ -3,7 +3,7 @@ aip:
   id: 134
   state: reviewing
   created: 2019-01-24
-  updated: 2019-05-29
+  updated: 2019-06-10
 permalink: /134
 redirect_from:
   - /0134
@@ -41,9 +41,9 @@ rpc UpdateBook(UpdateBookRequest) returns (Book) {
 - The request message **must** match the RPC name, with a `-Request` suffix.
 - The response message **must** be the resource itself. (There is no
   `UpdateBookResponse`.)
-  - However, in the event that the request may take a significant amount of
-    time, the response message **must** return a `google.longrunning.Operation`
-    which ultimately resolves to the resource itself.
+  - If the update RPC is [long-running](#long-running-update), the response
+    message **must** be a `google.longrunning.Operation` which resolves to the
+    resource itself.
 - The method **should** support partial resource update, and the HTTP verb
   **should** be `PATCH`.
   - If the method only supports full update, then the HTTP verb **should** be
@@ -129,6 +129,28 @@ If a rating is set on a book, and the existing `PUT` request was executed, it
 would wipe out the book's rating. A `PUT` request wiped out data because the
 previous version did not know about it.
 
+### Long-running update
+
+Some resources take longer to update a resource than is reasonable for a
+regular API request. In this situation, the API **should** use a long-running
+operation instead:
+
+```proto
+rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
+  option (google.api.http) = {
+    patch: "/v1/{book.name=shelves/*/books/*}"
+  };
+  option (google.longrunning.operation_info) = {
+    response_type: "Book"
+    metadata_type: "OperationMetadata"
+  }
+}
+```
+
+- The response type **must** be set to resource (what the return type would be
+  if the RPC was not long-running).
+- The `response_type` and `metadata_type` fields both **must** be specified.
+
 ### Create or update
 
 If the API accepts client-assigned resource names, the server **may** allow the
@@ -200,5 +222,6 @@ so.
 
 ## Changelog
 
+- **2019-06-10**: Added guidance for long-running update.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -3,7 +3,7 @@ aip:
   id: 135
   state: reviewing
   created: 2019-01-24
-  updated: 2019-05-29
+  updated: 2019-06-10
 permalink: /135
 redirect_from:
   - /0135
@@ -37,9 +37,12 @@ rpc DeleteBook(DeleteBookRequest) returns (google.protobuf.Empty) {
 - The RPC's name **must** begin with the word `Delete`. The remainder of the
   RPC name **should** be the singular form of the resource's message name.
 - The request message **must** match the RPC name, with a `-Request` suffix.
-- The response message **should** be `google.protobuf.Empty`. However, if the
-  resource will take time to delete (see below), the response message **may**
-  be the resource itself. There is no `DeleteBookResponse`.
+- The response message **should** be `google.protobuf.Empty`.
+  - If the resource is [soft deleted](#soft-delete), the response message
+    **should** be the resource itself.
+  - If the delete RPC is [long-running](#long-running-delete), the response
+    message **must** be a `google.longrunning.Operation` which resolves to the
+    correct response.
 - The HTTP verb **must** be `DELETE`.
 - The request message field receiving the resource name **should** map to the
   URL path.
@@ -84,6 +87,30 @@ those resources, including automatic purging after a reasonable time (such as
 30 days), allowing users to [set an expiry time][aip-214], or retaining the
 resources indefinitely.
 
+### Long-running delete
+
+Some resources take longer to delete a resource than is reasonable for a
+regular API request. In this situation, the API **should** use a long-running
+operation instead:
+
+```proto
+rpc DeleteBook(DeleteBookRequest) returns (google.longrunning.Operation) {
+  option (google.api.http) = {
+    delete: "/v1/{name=shelves/*/books/*}"
+  };
+  option (google.longrunning.operation_info) = {
+    response_type: "google.protobuf.Empty"
+    metadata_type: "OperationMetadata"
+  }
+}
+```
+
+- The response type **must** be set to the appropriate return type if the RPC
+  was not long-running: `google.protobuf.Empty` for most Delete RPCs, or the
+  resource itself for [soft delete](#soft-delete).
+- The `response_type` and `metadata_type` fields both **must** be specified
+  (even if they are `google.protobuf.Empty`).
+
 ### Batch delete
 
 Some APIs need to allow users to delete multiple resources at once. APIs
@@ -116,7 +143,7 @@ accidentally delete important data).
 Batch deletes **should** be atomic: either the entire request succeeds, or none
 of it does. Partial failures **should not** be supported.
 
-### Cascading deletes
+### Cascading delete
 
 Sometimes, it may be necessary for users to be able to delete a resource as
 well as all applicable child resources. However, since deletion is usually
@@ -142,7 +169,7 @@ message DeleteShelfRequest {
 The API **must** fail with a `FAILED_PRECONDTION` error if the `force` field is
 not set and child resources are present.
 
-### Protected deletes
+### Protected delete
 
 Sometimes, it may be necessary for users to ensure that no changes have been
 made to a resource that is being deleted. If a resource provides an [etag][],
@@ -171,5 +198,6 @@ request **must** fail with a `FAILED_PRECONDITION` error code.
 
 ## Changelog
 
+- **2019-06-10**: Added guidance for long-running delete.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -108,7 +108,7 @@ rpc DeleteBook(DeleteBookRequest) returns (google.longrunning.Operation) {
 - The response type **must** be set to the appropriate return type if the RPC
   was not long-running: `google.protobuf.Empty` for most Delete RPCs, or the
   resource itself for [soft delete](#soft-delete).
-- The `response_type` and `metadata_type` fields both **must** be specified
+- Both the `response_type` and `metadata_type` fields **must** be specified
   (even if they are `google.protobuf.Empty`).
 
 ### Batch delete


### PR DESCRIPTION
This PR adds consistent LRO language and an example for
using long-running operations with create, update, or delete.

Fixes #134