### PR TITLE
[fix] Fix anchor scrolling.

### DIFF
--- a/_sass/headings.scss
+++ b/_sass/headings.scss
@@ -2,33 +2,44 @@
 
 // Headers
 .docs-component-main {
-  h1 {
-    @extend .h-c-headline;
-    @extend .h-c-headline--two;
-    @extend .h-has-top-margin;
-  }
-  h2 {
-    @extend .h-c-headline;
-    @extend .h-c-headline--three;
-    @extend .h-has-top-margin;
-  }
-  h3 {
-    @extend .h-c-headline;
-    @extend .h-c-headline--four;
-    @extend .h-has-top-margin;
-  }
+  h1,
+  h2,
+  h3,
   h4 {
     @extend .h-c-headline;
-    @extend .h-c-headline--four;
     @extend .h-has-top-margin;
+
+    // This creates a "fake block" above the header that does not show up
+    // anywhere but tricks the browser into thinking that the anchor is 80px
+    // higher than it actually is.
+    &::before {
+      display: block;
+      content: ' ';
+      height: 80px;
+      margin-top: -80px;
+      pointer-events: none;
+      visibility: hidden;
+    }
   }
+  h1 {
+    @extend .h-c-headline--two;
+  }
+  h2 {
+    @extend .h-c-headline--three;
+  }
+  h3 {
+    @extend .h-c-headline--four;
+  }
+  h4 {
+    @extend .h-c-headline--four;
 
-  h4.aip-number {
-    line-height: 1em;
+    &.aip-number {
+      line-height: 1em;
 
-    & + h1 {
-      margin-top: 0px;
-      margin-left: -2px;
+      & + h1 {
+        margin-top: 0px;
+        margin-left: -2px;
+      }
     }
   }
 }


### PR DESCRIPTION
The site headings currently scroll slightly too high, because
they scroll to position the header underneath the top bar.
This CSS fixes that.

Adapted from https://css-tricks.com/hash-tag-links-padding/
and tested to work properly here.

Fixes #120.