### PR TITLE
[AIP-203] Use the machine-readable annotation, not comments.

### DIFF
--- a/aip/0203.md
+++ b/aip/0203.md
@@ -12,11 +12,9 @@ redirect_from:
 # Field behavior documentation
 
 When defining fields in protocol buffers, it is customary to explain to users
-certain aspects of the field's behavior (e.g., whether it is required or
-optional).
-
-Additionally, it can be useful for other tools to understand this behavior (for
-example, to optimize client library signatures).
+certain aspects of the field's behavior (such as whether it is required or
+optional). Additionally, it can be useful for other tools to understand this
+behavior (for example, to optimize client library signatures).
 
 ## Guidance
 
@@ -144,4 +142,4 @@ either all optional fields should be indicated, or none of them should be.
 
 ## Changelog
 
-- **2019-06-17**: Use the machine-readable annotation, not comments.
+- **2019-06-18**: Use the machine-readable annotation, not comments.

--- a/aip/0203.md
+++ b/aip/0203.md
@@ -3,6 +3,7 @@ aip:
   id: 203
   state: approved
   created: 2018-07-17
+  updated: 2019-06-17
 permalink: /203
 redirect_from:
   - /0203
@@ -10,33 +11,37 @@ redirect_from:
 
 # Field behavior documentation
 
-When defining fields in protocol buffers, it is customary to describe that
-field's behavior (e.g., whether it is required or optional) at the beginning of
-the field's comments. For example:
+When defining fields in protocol buffers, it is customary to explain to users
+certain aspects of the field's behavior (e.g., whether it is required or
+optional).
 
-```proto
-// Required. The audio data to be recognized.
-RecognitionAudio audio = 2;
-```
+Additionally, it can be useful for other tools to understand this behavior (for
+example, to optimize client library signatures).
 
 ## Guidance
 
-The terms used to denote field behavior are "Required", "Input only", "Output
-only", and "Immutable". In all cases, the term should be used _at the
-beginning_ of the comment block and be followed by a period.
+APIs **should** use the `google.api.field_behavior` annotation to describe
+well-understood field behavior, such as a field's being required, immutable, or
+output only:
 
-It is also permissible to use the term "Optional" to describe none of the
+```proto
+// The audio data to be recognized.
+RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
+```
+
+Additionally, APIs **may** use the `OPTIONAL` value to describe none of the
 above. However, it is never mandatory to explicitly describe a field as
 optional.
 
 **Note:** The vocabulary given in this document is for _descriptive_ purposes
-only. The purpose is to consistently document this behavior for users.
+only, and does not itself add any validation. The purpose is to consistently
+document this behavior for users.
 
 ## Vocabulary
 
-### Required.
+### Required
 
-The use of `Required.` indicates that the field **must** be present (and set to
+The use of `REQUIRED` indicates that the field **must** be present (and set to
 a non-empty value) on the request or resource.
 
 A field **should** only be described as required if _either_:
@@ -65,10 +70,10 @@ integers, or the unspecified value for enums) are indistinguishable from unset
 values, and therefore setting a required field to a falsy value yields an
 error. A corollary to this is that a required boolean must be set to `true`.
 
-### Output only.
+### Output only
 
-The use of `Output only.` indicates that the field is provided in responses,
-but that including the field in a message in a request does nothing (the server
+The use of `OUTPUT_ONLY` indicates that the field is provided in responses, but
+that including the field in a message in a request does nothing (the server
 **must** ignore it and **must not** throw an error as a result of the presence
 of a value in this field on input).
 
@@ -87,9 +92,9 @@ are:
 - Derived or structured information based on original user input.
 - Properties of a resource assigned by the service which can not be altered.
 
-### Input only.
+### Input only
 
-The use of `Input only.` indicates that the field is provided in requests and
+The use of `INPUT_ONLY` indicates that the field is provided in requests and
 that the corresponding field will not be included in output.
 
 Additionally, a field should only be described as input only if it is a field
@@ -107,7 +112,7 @@ before use.
 
 ### Immutable.
 
-The use of `Immutable.` indicates that a field may be set once in a request to
+The use of `IMMUTABLE` indicates that a field may be set once in a request to
 create a resource but may not be changed thereafter.
 
 Additionally, a field **should** only be described as immutable if it is a
@@ -121,7 +126,7 @@ Potential use cases for immutable fields (this is not an exhaustive list) are:
 
 ### Optional.
 
-The use of `Optional.` indicates that a field is not required, nor covered by
+The use of `OPTIONAL` indicates that a field is not required, nor covered by
 any of the above descriptions.
 
 A field **may** be described as optional if none of the above vocabulary
@@ -136,3 +141,7 @@ either all optional fields should be indicated, or none of them should be.
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md
 [aip-214]: ./0214.md
+
+## Changelog
+
+- **2019-06-17**: Use the machine-readable annotation, not comments.


### PR DESCRIPTION
Docgen now recognizes the field annotation, which is preferable over
a specifically-formatted comment. Update the AIP to use the annotation.