### PR TITLE
Add clarification around error responses

### DIFF
--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -4,7 +4,7 @@ aip:
   scope: cloud
   state: approved
   created: 2018-12-26
-  updated: 2019-06-10
+  updated: 2019-06-19
 permalink: /cloud/2510
 redirect_from:
   - /2510
@@ -49,6 +49,10 @@ However, the project number is the canonical identifier, and therefore APIs
 **must** use project numbers in responses, regardless of whether they were sent
 a project ID or a project number.
 
+An exception is for error responses, which **must** return the
+originally-provided value without modification. Error responses **must not**
+perform any translation between project IDs and project numbers.
+
 ### Internal Google services
 
 Internal Google services **must** use project numbers for internal data storage
@@ -79,4 +83,5 @@ folders.
 
 ## Changelog
 
+- **2019-06-19**: Clarify how error messages should be treated
 - **2019-06-10**: Minor language and organization tweaks


### PR DESCRIPTION
Per internal conversation with Hong, errors should *not* perform any translations.