### PR TITLE
[fix] Specify encoding of header params in 4222

### DIFF
--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -35,9 +35,28 @@ In this case, the applicable variable is `parent`, and it refers to the
 `CreateTopicRequest` to the method (or once the client library has built it, in
 the case of method overloads), the client library must extract the key
 and value, and append them to the `x-goog-request-params` header. The key-value
-pairs **must** be URL-encoded per [RFC 6570][], section 3.2.2 [Simple String
-Expansion][]. Much like URL parameters, if there is more than one key-value
-pair, the `&` character is used as the separator.
+pairs **must** be URL-encoded per [RFC 6570 §3.2.2][]. This can be done with
+standard library URL encoding. For example, adding this header to a gRPC request
+in Go:
+
+```go
+import (
+  "fmt"
+  "net/url"
+
+  "google.golang.org/grpc/metadata"
+)
+
+func DeleteFoo(req *DeleteFooRequest) (*DeleteFooResponse)
+  md := metadata.Pairs("x-goog-request-params",
+    url.QueryEscape("parent="+req.GetParent()))
+
+  // ...
+}
+```
+
+Much like URL parameters, if there is more than one key-value pair, the `&`
+character is used as the separator.
 
 **Note:** There is no additional annotation used for this; the presence of the
 key in any of the standard fields (`get`, `post`, `put`, `patch`, `delete`) on
@@ -45,8 +64,7 @@ the [`google.api.http`][http] annotation is sufficient.
 
 <!-- prettier-ignore -->
 [http]: https://github.com/googleapis/api-common-protos/blob/master/google/api/http.proto
-[rfc 6570]: https://tools.ietf.org/html/rfc6570
-[simple string expansion]: https://tools.ietf.org/html/rfc6570#section-3.2.2
+[rfc 6570 §3.2.2]: https://tools.ietf.org/html/rfc6570#section-3.2.2
 
 ## Changelog
 

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -4,7 +4,7 @@ aip:
   scope: client-libraries
   state: approved
   created: 2018-06-22
-  updated: 2019-05-09
+  updated: 2019-06-20
 permalink: /client-libraries/4222
 redirect_from:
   - /4222
@@ -19,7 +19,7 @@ routing.
 
 ## Guidance
 
-Code generators should look at URL-based variables declared in the
+Code generators **should** look at URL-based variables declared in the
 [`google.api.http`][http] annotation and transcribe these into the
 `x-goog-request-params` header in unary calls. A URL-based variable is a
 variable declared as a key in curly braces in the URI string. For example:
@@ -33,10 +33,10 @@ rpc CreateTopic(CreateTopicRequest) {
 In this case, the applicable variable is `parent`, and it refers to the
 `parent` field in `CreateTopicRequest`. When the user provides an instance of
 `CreateTopicRequest` to the method (or once the client library has built it, in
-the case of method overloads), the client library should then extract the key
-and value, URL-encode them, and append them to the `x-goog-request-params`
-header. Much like URL parameters, if there is more than one key-value pair, the
-`&` character is used as the separator.
+the case of method overloads), the client library **must** extract the key
+and value, which **must** then be URL-encoded, and then appended to the
+`x-goog-request-params` header. Much like URL parameters, if there is more than
+one key-value pair, the `&` character is used as the separator.
 
 **Note:** There is no additional annotation used for this; the presence of the
 key in any of the standard fields (`get`, `post`, `put`, `patch`, `delete`) on
@@ -44,3 +44,7 @@ the [`google.api.http`][http] annotation is sufficient.
 
 <!-- prettier-ignore -->
 [http]: https://github.com/googleapis/api-common-protos/blob/master/google/api/http.proto
+
+## Changelog
+
+- **2019-06-20**: Specify encoding of header parameters.

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -33,10 +33,11 @@ rpc CreateTopic(CreateTopicRequest) {
 In this case, the applicable variable is `parent`, and it refers to the
 `parent` field in `CreateTopicRequest`. When the user provides an instance of
 `CreateTopicRequest` to the method (or once the client library has built it, in
-the case of method overloads), the client library **must** extract the key
-and value, which **must** then be URL-encoded, and then appended to the
-`x-goog-request-params` header. Much like URL parameters, if there is more than
-one key-value pair, the `&` character is used as the separator.
+the case of method overloads), the client library must extract the key
+and value, and append them to the `x-goog-request-params` header. The key-value
+pairs **must** be URL-encoded per [RFC 6570][], section 3.2.2 [Simple String
+Expansion][]. Much like URL parameters, if there is more than one key-value
+pair, the `&` character is used as the separator.
 
 **Note:** There is no additional annotation used for this; the presence of the
 key in any of the standard fields (`get`, `post`, `put`, `patch`, `delete`) on
@@ -44,6 +45,8 @@ the [`google.api.http`][http] annotation is sufficient.
 
 <!-- prettier-ignore -->
 [http]: https://github.com/googleapis/api-common-protos/blob/master/google/api/http.proto
+[rfc 6570]: https://tools.ietf.org/html/rfc6570
+[simple string expansion]: https://tools.ietf.org/html/rfc6570#section-3.2.2
 
 ## Changelog
 

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -40,19 +40,8 @@ standard library URL encoding. For example, adding this header to a gRPC request
 in Go:
 
 ```go
-import (
-  "fmt"
-  "net/url"
-
-  "google.golang.org/grpc/metadata"
-)
-
-func DeleteFoo(req *DeleteFooRequest) (*DeleteFooResponse)
-  md := metadata.Pairs("x-goog-request-params",
-    url.QueryEscape("parent="+req.GetParent()))
-
-  // ...
-}
+md := metadata.Pairs("x-goog-request-params",
+  url.QueryEscape("parent="+req.GetParent()))
 ```
 
 Much like URL parameters, if there is more than one key-value pair, the `&`


### PR DESCRIPTION
Strictly require the `x-goog-request-params` value to be URL-encoded.