### PR TITLE
Add draft AIP for naming convention for bazel protobuf targets.

### DIFF
--- a/aip/client-libraries/4234.md
+++ b/aip/client-libraries/4234.md
@@ -1,0 +1,103 @@
+---
+aip:
+  id: 4234
+  scope: client-libraries
+  state: draft
+  created: 2019-06-28
+  updated: 2019-07-01
+permalink: /client-libraries/4234
+redirect_from:
+  - /4234
+---
+
+# Bazel protobuf targets
+
+When using Bazel to compile protobuf and generate message libraries and RPC service
+libraries, the naming choice for these targets has implications on derivative targets, and
+those target names have implications for per-language integrations. By applying a common
+approach to how individual `.proto` files are combined into targets, and to what those
+targets are named, clients can have a uniform experience from API to API.
+
+Some of the various language constraints are as follows:
+
+*   Java's `option java_outer_classname`: per the API style guide is the name of
+    the proto file, with "Proto" appended. Unless `option java_multiple_files` is true,
+    the file name defines the packaging of the types.
+*   Go's target names will define the import path for the result. However, Go's package
+    names have a more restrictive character set (e.g., no dashes), and in some cases, that
+    means that the import path and package name will disagree. This interferes with some
+    tooling.
+
+## Guidance
+
+### Targets
+
+In the following file name cases, if the service name or resource name is more than one
+word, they should be separated by underscores.
+
+#### Services and request/response messages
+
+Individual services along with their request and response messages **should** live in
+separate `proto_library` targets, named `{service}_service_proto`.
+
+**NOTE:** Services **should** not share request or response messages. Reuse of resources
+or common messages is preferred.
+    
+#### Resource messages
+
+*   Resources that are a primary resource for an individual service, **should** be 
+    in a `proto_library` target named `{resource}_proto`.
+*   Otherwise, per-service resources **should** be in a `proto_library` target named 
+    `{service}_resources_proto`.
+*   If there are remaining shared resources, they **should** be in a `proto_library`
+    target named `resources_proto`.
+    
+#### Additional messages
+
+Remaining necessary messages **should** be in a `proto_library` target named
+`common_proto`.
+
+### `.proto` file naming convention
+
+In the case where there's a single `.proto` file in the `srcs` of the
+`proto_library`, it should be named by replacing the `_proto` suffix with `.proto`.
+
+### `{lang}_proto_library` naming convention
+
+The per-language rules, e.g., `cc_proto_library`, **should** be named by replacing the
+`_proto` suffix on the `proto_library` target with `_{lang}_proto`. e.g.,
+
+```
+proto_library(name = "foo_proto", …)
+cc_proto_library(name = "foo_cc_proto", deps = [":foo_proto"], …)
+```
+
+### `{lang}_{rpc}_library` naming convention
+
+The per-language, per-RPC rules, e.g., `cc_grpc_library`, **should** be named by replacing
+the `_proto` suffix on the `{lang}_proto_library` target with `_{rpc}`. e.g.,
+
+```
+cc_proto_library(name = "bar_service_cc_proto", deps = [":bar_service_proto"], …)
+cc_grpc_library(
+    name = "bar_service_cc_grpc",
+    srcs = [":bar_service_proto"],
+    deps = [":bar_service_cc_proto"],
+    …
+)
+```
+
+### Adding services
+
+If in the course of an alpha or beta period for an API, one or more new services are added
+or resources are made shared or specific such that they'd belong to a different or new
+`proto_library` target,
+
+*   Prefer incrementing the _Y_ of vXalphaY to a new version and making the changes
+    there, allowing clients to update at their leisure.
+*   If the change is to be made intra-version, then use the [`import public`
+    declaration][] to preserve the set of messages exposed by the older target(s) during
+    the conversion or deprecation period, if applicable. **NOTE:** `import public` works
+    with messages, not with RPC services.
+   
+[`import public` declaration]: https://developers.google.com/protocol-buffers/docs/proto3#importing-definitions


### PR DESCRIPTION
Draft to resolve issue #139.