### PR TITLE
[fix] Update the AIP-158 opacity requirement from should to must.

### DIFF
--- a/aip/0158.md
+++ b/aip/0158.md
@@ -84,8 +84,8 @@ message ListBooksResponse {
 
 ### Opacity
 
-Page tokens provided by APIs **should** be opaque (but URL-safe) strings, and
-**should not** be user-parseable. This is because if users are able to
+Page tokens provided by APIs **must** be opaque (but URL-safe) strings, and
+**must not** be user-parseable. This is because if users are able to
 deconstruct these, _they will do so_. This effectively makes the implementation
 details of your API's pagination become part of the API surface, and it becomes
 impossible to update those details without breaking users.
@@ -131,3 +131,7 @@ value. Implementing an in-memory version (which might fetch everything then
 paginate) is reasonable for initially-small collections.
 
 [list]: ./0132.md
+
+## Changelog
+
+- **2019-07-19**: Update the opacity requirement from "should" to "must".


### PR DESCRIPTION
A Googler taking the internal API exam noted that this AIP claims
"should" for page token opacity, but the exam says "must".

I assert that "must" is correct, and the AIP should be updated.