### PR TITLE
[AIP-193] Errors

### DIFF
--- a/aip/0193.md
+++ b/aip/0193.md
@@ -49,7 +49,7 @@ significant complexity for users, because they usually sidestep the use of
 error codes, or move those error codes into the response message, where the
 user must write specialized error handling logic to address it.
 
-However, occasionally partial errors are necessary, particularly in large bulk
+However, occasionally partial errors are necessary, particularly in bulk
 operations where it would be hostile to users to fail an entire large request
 because of a problem with a single entry.
 

--- a/aip/0193.md
+++ b/aip/0193.md
@@ -1,0 +1,72 @@
+---
+aip:
+  id: 193
+  state: reviewing
+  created: 2019-07-26
+permalink: /193
+redirect_from:
+  - /0193
+---
+
+# Errors
+
+Error handling is an important part of designing simple and intuitive APIs.
+Consistent error handling allows developers to know how to expect to receive
+errors, and to reduce boilerplate by having common error-handling logic, rather
+than being expected to constantly add verbose error handling everywhere.
+
+## Guidance
+
+Services **must** return a [`google.rpc.Status`][] message when an API error
+occurs, and **must** use the canonical error codes defined in
+[`google.rpc.Code`][]. More information about the particular codes is available
+in the [gRPC status code documentation][].
+
+Error messages **should** help a reasonably technical user _understand_ and
+_resolve_ the issue, and **should not** assume that the user is an expert in
+your particular API, or knows anything about its underlying implementation.
+
+Error messages **should** be brief. Provide extra information in the `details`
+field. If needed, provide a link where a reader can get more information or ask
+questions to help resolve the issue.
+
+### Details
+
+Google defines a set of [standard detail payloads][details] for error details,
+which cover most common needs for API errors. Services **should** use these
+standard details messages when feasible.
+
+### Localization
+
+Error messages **must** be in English. If a localized error message is also
+required, the service **should** use [`google.rpc.LocalizedMessage`][details]
+as the `details` field.
+
+### Partial errors
+
+Most API methods **should not** support partial errors. Partial errors add
+significant complexity for users, because they usually sidestep the use of
+error codes, or move those error codes into the response message, where the
+user must write specialized error handling logic to address it.
+
+However, occasionally partial errors are necessary, particularly in large bulk
+operations where it would be hostile to users to fail an entire large request
+because of a problem with a single entry.
+
+Methods that require partial errors **should** also use [long-running
+operations][], and the method **should** put partial failure information in the
+metadata message. The errors themselves **must** still be represented with a
+[`google.rpc.Status`][] object.
+
+## Further reading
+
+- For retrying errors in client libraries, see [AIP-4221][].
+
+<!-- prettier-ignore-start -->
+[aip-4221]: ./client-libraries/4221.md
+[details]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/error_details.proto
+[grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+[`google.rpc.Code`]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/code.proto
+[`google.rpc.Status`]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/status.proto
+[long-running operations]: ./0151.md
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Toward #67.

Worth mentioning: This one varies _drastically_ from the source material. The partial error section is new, for one, but I also cut out a ton of stuff that either should be referenced rather than duplicated (the gRPC error code description) or just did not need to be there (like the client libraries paragraph).