### PR TITLE
Change examples from "shelves" to "publishers".

### DIFF
--- a/aip/0121.md
+++ b/aip/0121.md
@@ -42,9 +42,9 @@ A resource-oriented API **should** generally be modeled as a resource
 hierarchy, where each node is either a simple resource or a collection of
 resources.
 
-A _collection_ contains resources of _the same type_. For example, a shelf (in
-a library) has a collection of books. A resource usually has fields, and
-resources may have any number of sub-resources (usually collections).
+A _collection_ contains resources of _the same type_. For example, a publisher
+has the collection of books that it publishes. A resource usually has fields,
+and resources may have any number of sub-resources (usually collections).
 
 **Note:** While there is some conceptual alignment between storage systems and
 APIs, a service with a resource-oriented API is not necessarily a database, and
@@ -90,3 +90,8 @@ have sole responsibility and authority for maintaining the application state.
 [update]: ./0134.md
 [delete]: ./0135.md
 [custom methods]: ./0136.md
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0122.md
+++ b/aip/0122.md
@@ -24,11 +24,11 @@ defined by an API **must** be unique within that API.
 Resource names are formatted according to the [URI path schema][], but without
 the leading slash:
 
-    shelves/123/books/les-miserables
+    publishers/123/books/les-miserables
     users/meagan
 
 - Resource name components **should** usually alternate between collection keys
-  (example: `shelves`, `books`, `users`) and resource IDs (example: `123`,
+  (example: `publishers`, `books`, `users`) and resource IDs (example: `123`,
   `les-miserables`, `meagan`).
 - Resource names **must** use the `/` character to separate individual segments
   of the resource name.
@@ -52,8 +52,8 @@ from _full resource names_ (discussed below).
 ### Collection keys
 
 The collection segments in a resource name **must** be the plural form of the
-noun used for the resource. (For example, a collection of `Shelf` resources is
-called `shelves` in the resource name.)
+noun used for the resource. (For example, a collection of `Publisher` resources
+is called `publishers` in the resource name.)
 
 - Collection segments **must** be concise American English terms.
 - Collection segments **must** be in `camelCase`.
@@ -91,8 +91,8 @@ throughout the API, or else not at all.
 ### Resource ID segments
 
 A resource ID segment identifies the resource within its parent collection. In
-the resource name `shelves/123/books/les-miserables`, `123` is the resource ID
-for the shelf, and `les-miserables` is the resource ID for the book.
+the resource name `publishers/123/books/les-miserables`, `123` is the resource
+ID for the publisher, and `les-miserables` is the resource ID for the book.
 
 - Resource IDs **may** be either always set by users (required on resource
   creation), optionally set by users (optional on resource creation,
@@ -133,7 +133,7 @@ full resource name is a schemeless URI with the owning API's service endpoint,
 followed by the relative resource name:
 
 ```
-//library.googleapis.com/shelves/123/books/les-miserables
+//library.googleapis.com/publishers/123/books/les-miserables
 //calendar.googleapis.com/users/meagan
 ```
 
@@ -144,7 +144,7 @@ URLs we use to access a resource. The latter adds two components: the protocol
 (HTTPS) and the API version:
 
 ```
-https://library.googleapis.com/v1/shelves/123/books/les-miserables
+https://library.googleapis.com/v1/publishers/123/books/les-miserables
 https://calendar.googleapis.com/v3/users/meagan
 ```
 
@@ -167,7 +167,7 @@ When defining a resource, the first field **should** be of type `string` and
 // A representation of a book in the library.
 message Book {
   // The resource name of the book.
-  // Format: shelves/{shelf_id}/books/{book_id}
+  // Format: publishers/{publisher}/books/{book}
   string name = 1;
 
   // Other fields...
@@ -183,7 +183,7 @@ name.
 // Request message for ArchiveBook
 message ArchiveBookRequest {
   // The book to archive.
-  // Format: shelves/{shelf_id}/books/{book_id}
+  // Format: publishers/{publisher}/books/{book}
   string name = 1;
 
   // Other fields...
@@ -204,8 +204,8 @@ of the request message **should** be of type `string` and **should** be called
 ```proto
 // Request message for ListBooks.
 message ListBooksRequest {
-  // The shelf to list books from.
-  // Format: shelves/{shelf_id}
+  // The publisher to list books from.
+  // Format: publishers/{publisher_id}
   string parent = 1;
 
   // Other fields (e.g. page_size, page_token, filter, etc.)...
@@ -226,15 +226,15 @@ When referencing a resource name for an unrelated resource, the field
 - Field names **should not** use the `_name` suffix.
 
 ```proto
-// A subscription resource in Pub/Sub.
-message Subscription {
-  // Name of the subscription.
-  // Format is `projects/{project_id}/subscriptions/{subscription_id}`.
+// A representation of a book in a library.
+message Book {
+  // Name of the book.
+  // Format is `publishers/{publisher}/books/{book}`
   string name = 1;
 
-  // The name of the topic from which this subscription is receiving messages.
-  // Format is `projects/{project_id}/topics/{topic_id}`.
-  string topic = 2;
+  // The shelf where the book currently sits.
+  // Format is `shelves/{shelf}`.
+  string shelf = 2;
 
   // Other fields...
 }
@@ -243,7 +243,7 @@ message Subscription {
 **Note:** When referring to other resources in this way, we use the resource
 name as the value, not just the ID component. APIs **should** use the resource
 name to reference resources when possible. If using the ID component alone is
-strictly necessary, use an `_id` suffix (e.g. `topic_id`).
+strictly necessary, use an `_id` suffix (e.g. `shelf_id`).
 
 ## Further reading
 
@@ -252,4 +252,7 @@ strictly necessary, use an `_id` suffix (e.g. `topic_id`).
 
 ## Changelog
 
-- **2019-07-30**: Changed the nested collection brevity suggestion from "may" to "should"
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.
+- **2019-07-30**: Changed the nested collection brevity suggestion from "may"
+  to "should"

--- a/aip/0122.md
+++ b/aip/0122.md
@@ -253,6 +253,7 @@ strictly necessary, use an `_id` suffix (e.g. `shelf_id`).
 ## Changelog
 
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
-  present a better example of resource ownership.
+  present a better example of resource ownership. Also changed the final
+  example from a Pub/Sub example to the usual Book example.
 - **2019-07-30**: Changed the nested collection brevity suggestion from "may"
   to "should"

--- a/aip/0131.md
+++ b/aip/0131.md
@@ -12,7 +12,7 @@ redirect_from:
 # Standard methods: Get
 
 In REST APIs, it is customary to make a `GET` request to a resource's URI (for
-example, `/v1/shelves/{shelf}/books/{book}`) in order to retrieve that
+example, `/v1/publishers/{publisher}/books/{book}`) in order to retrieve that
 resource.
 
 Resource-oriented design ([AIP-121][]) honors this pattern through the `Get`
@@ -30,7 +30,7 @@ Get methods are specified using the following pattern:
 ```proto
 rpc GetBook(GetBookRequest) returns (Book) {
   option (google.api.http) = {
-    get: "/v1/{name=shelves/*/books/*}"
+    get: "/v1/{name=publishers/*/books/*}"
   };
 }
 ```
@@ -56,7 +56,7 @@ Get methods implement a common request message pattern:
 ```proto
 message GetBookRequest {
   // The name of the book to retrieve.
-  // Format: shelves/{shelf}/books/{book}
+  // Format: publishers/{publisher}/books/{book}
   string name = 1;
 }
 ```
@@ -76,5 +76,7 @@ REST/JSON interface is used.
 
 ## Changelog
 
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0132.md
+++ b/aip/0132.md
@@ -12,8 +12,8 @@ redirect_from:
 # Standard methods: List
 
 In many APIs, it is customary to make a `GET` request to a collection's URI
-(for example, `/v1/shelves/1/books`) in order to retrieve a list of resources,
-each of which lives within that collection.
+(for example, `/v1/publishers/1/books`) in order to retrieve a list of
+resources, each of which lives within that collection.
 
 Resource-oriented design ([AIP-121][]) honors this pattern through the `List`
 method. These RPCs accept the parent collection (and potentially some other
@@ -30,7 +30,7 @@ List methods are specified using the following pattern:
 ```proto
 rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
   option (google.api.http) = {
-    get: "/v1/{parent=shelves/*}/books"
+    get: "/v1/{parent=publishers/*}/books"
   };
 }
 ```
@@ -55,7 +55,7 @@ List methods implement a common request message pattern:
 ```proto
 message ListBooksRequest {
   // The parent, which owns this collection of books.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   string parent = 1;
 
   // The maximum number of books to return. The service may return fewer than
@@ -99,7 +99,7 @@ List methods implement a common response message pattern:
 
 ```proto
 message ListBooksResponse {
-  // The books located on the applicable shelf.
+  // The books from the applicable publisher.
   repeated Book books = 1;
 
   // A token, which can be sent as `page_token` to retrieve the next page.
@@ -166,5 +166,7 @@ included.
 
 ## Changelog
 
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0132.md
+++ b/aip/0132.md
@@ -99,7 +99,7 @@ List methods implement a common response message pattern:
 
 ```proto
 message ListBooksResponse {
-  // The books from the applicable publisher.
+  // The books from the specified publisher.
   repeated Book books = 1;
 
   // A token, which can be sent as `page_token` to retrieve the next page.

--- a/aip/0133.md
+++ b/aip/0133.md
@@ -12,8 +12,8 @@ redirect_from:
 # Standard methods: Create
 
 In REST APIs, it is customary to make a `POST` request to a collection's URI
-(for example, `/v1/shelves/{shelf}/books`) in order to create a new resource
-within that collection.
+(for example, `/v1/publishers/{publisher}/books`) in order to create a new
+resource within that collection.
 
 Resource-oriented design ([AIP-121][]) honors this pattern through the `Create`
 method. These RPCs accept the parent collection and the resource to create (and
@@ -30,7 +30,7 @@ Create methods are specified using the following pattern:
 ```proto
 rpc CreateBook(CreateBookRequest) returns (Book) {
   option (google.api.http) = {
-    post: "/v1/{parent=shelves/*}/books"
+    post: "/v1/{parent=publishers/*}/books"
     body: "book"
   };
 }
@@ -62,7 +62,7 @@ Create methods implement a common request message pattern:
 ```proto
 message CreateBookRequest {
   // The parent resource where this book will be created.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   string parent = 1;
 
   // The book to create.
@@ -86,7 +86,7 @@ operation instead:
 ```proto
 rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
-    post: "/v1/{parent=shelves/*}/books"
+    post: "/v1/{parent=publishers/*}/books"
   };
   option (google.longrunning.operation_info) = {
     response_type: "Book"
@@ -101,18 +101,18 @@ rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
 
 ### User-specified IDs
 
-Sometimes, an API needs to allow a client specify the ID component of a resource
-(the last segment of the resource name) on creation. This is common if users
-are allowed to choose that portion of their resource names.
+Sometimes, an API needs to allow a client specify the ID component of a
+resource (the last segment of the resource name) on creation. This is common if
+users are allowed to choose that portion of their resource names.
 
 For example:
 
 ```
 // Using user-settable IDs.
-shelves/historical-fiction/books/les-miserables
+publishers/lacroix/books/les-miserables
 
 // Using system-generated IDs.
-shelves/012345678-abcd-cdef/books/12341234-5678-abcd
+publishers/012345678-abcd-cdef/books/12341234-5678-abcd
 ```
 
 Create RPCs **may** support this behavior by providing a `string {resource}_id`
@@ -121,7 +121,7 @@ field on the request message:
 ```proto
 message CreateBookRequest {
   // The parent resource where this book will be created.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   string parent = 1;
 
   // The book to create.
@@ -155,6 +155,8 @@ message CreateBookRequest {
 
 ## Changelog
 
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.
 - **2019-06-10**: Added guidance for long-running create.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0134.md
+++ b/aip/0134.md
@@ -12,8 +12,8 @@ redirect_from:
 # Standard methods: Update
 
 In REST APIs, it is customary to make a `PATCH` or `PUT` request to a
-resource's URI (for example, `/v1/shelves/{shelf}/books/{book}`) in order to
-update that resource.
+resource's URI (for example, `/v1/publishers/{publisher}/books/{book}`) in
+order to update that resource.
 
 Resource-oriented design ([AIP-121][]) honors this pattern through the `Update`
 method (which mirrors the REST `PATCH` behavior). These RPCs accept the URI
@@ -30,7 +30,7 @@ Update methods are specified using the following pattern:
 ```proto
 rpc UpdateBook(UpdateBookRequest) returns (Book) {
   option (google.api.http) = {
-    patch: "/v1/{book.name=shelves/*/books/*}"
+    patch: "/v1/{book.name=publishers/*/books/*}"
     body: "book"
   };
 }
@@ -69,7 +69,7 @@ message UpdateBookRequest {
   // The book to update.
   //
   // The book's `name` field is used to identify the book to be updated.
-  // Format: shelves/{shelf}/books/{book}
+  // Format: publishers/{publisher}/books/{book}
   Book book = 1;
 
   // The list of fields to be updated.
@@ -109,7 +109,7 @@ an existing resource, but this becomes a breaking change when using `PUT`.
 
 To illustrate this, consider a `PUT` request to a `Book` resource:
 
-    PUT /v1/shelves/123/books/456
+    PUT /v1/publishers/123/books/456
 
     {"title": "Mary Poppins", "author": "P.L. Travers"}
 
@@ -138,7 +138,7 @@ operation instead:
 ```proto
 rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
-    patch: "/v1/{book.name=shelves/*/books/*}"
+    patch: "/v1/{book.name=publishers/*/books/*}"
   };
   option (google.longrunning.operation_info) = {
     response_type: "Book"
@@ -175,7 +175,7 @@ In this situation, the resource **should** contain a `string etag` field:
 ```proto
 message Book {
   // The resource name of the book.
-  // Format: shelves/{shelf}/books/{book}
+  // Format: publishers/{publisher}/books/{book}
   string name = 1;
 
   // The title of the book.
@@ -222,6 +222,8 @@ so.
 
 ## Changelog
 
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.
 - **2019-06-10**: Added guidance for long-running update.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -12,8 +12,8 @@ redirect_from:
 # Standard methods: Delete
 
 In REST APIs, it is customary to make a `DELETE` request to a resource's URI
-(for example, `/v1/shelves/{shelf}/books/{book}`) in order to delete that
-resource.
+(for example, `/v1/publishers/{publisher}/books/{book}`) in order to delete
+that resource.
 
 Resource-oriented design ([AIP-121][]) honors this pattern through the `Delete`
 method. These RPCs accept the URI representing that resource and usually return
@@ -29,7 +29,7 @@ Delete methods are specified using the following pattern:
 ```proto
 rpc DeleteBook(DeleteBookRequest) returns (google.protobuf.Empty) {
   option (google.api.http) = {
-    delete: "/v1/{name=shelves/*/books/*}"
+    delete: "/v1/{name=publishers/*/books/*}"
   };
 }
 ```
@@ -62,7 +62,7 @@ Delete methods implement a common request message pattern:
 ```proto
 message DeleteBookRequest {
   // The name of the book to delete.
-  // Format: shelves/{shelf}/books/{book}
+  // Format: publishers/{publisher}/books/{book}
   string name = 1;
 }
 ```
@@ -96,7 +96,7 @@ operation instead:
 ```proto
 rpc DeleteBook(DeleteBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
-    delete: "/v1/{name=shelves/*/books/*}"
+    delete: "/v1/{name=publishers/*/books/*}"
   };
   option (google.longrunning.operation_info) = {
     response_type: "google.protobuf.Empty"
@@ -123,13 +123,13 @@ If an API allows deletion of a resource that may have child resources, the API
 explicitly opt in to a cascading delete.
 
 ```proto
-message DeleteShelfRequest {
-  // The name of the shelf to delete.
-  // Format: shelves/{shelf}
+message DeletePublisherRequest {
+  // The name of the publisher to delete.
+  // Format: publishers/{publisher}
   string name = 1;
 
-  // If set to true, any books on this shelf will also be deleted.
-  // (Otherwise, the request will only work if the shelf is empty.)
+  // If set to true, any books from this publisher will also be deleted.
+  // (Otherwise, the request will only work if the publisher has no books.)
   bool force = 2;
 }
 ```
@@ -146,7 +146,7 @@ the delete request **may** accept the etag (as either required or optional):
 ```proto
 message DeleteBookRequest {
   // The name of the book to delete.
-  // Format: shelves/{shelf}/books/{book}
+  // Format: publishers/{publisher}/books/{book}
   string name = 1;
 
   // Optional. The etag of the book.
@@ -166,6 +166,8 @@ request **must** fail with a `FAILED_PRECONDITION` error code.
 
 ## Changelog
 
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.
 - **2019-06-10**: Added guidance for long-running delete.
 - **2019-05-29**: Added an explicit prohibition on arbitrary fields in standard
   methods.

--- a/aip/0136.md
+++ b/aip/0136.md
@@ -30,7 +30,7 @@ apply consistently:
 // Archives the given book.
 rpc ArchiveBook(ArchiveBookRequest) returns (ArchiveBookResponse) {
   option (google.api.http) = {
-    post: "/v1/{name=shelves/*/books/*}:archive"
+    post: "/v1/{name=publishers/*/books/*}:archive"
     body: "*"
   };
 }
@@ -66,17 +66,17 @@ While most custom methods operate on a single resource, some resources may
 operate on a collection instead:
 
 ```proto
-// Sorts the books on the shelf.
+// Sorts the books from this publisher.
 rpc SortBooks(SortBooksRequest) returns (SortBooksResponse) {
   option (google.api.http) = {
-    post: "/v1/{shelf=shelves/*}/books:sort"
+    post: "/v1/{publisher=publishers/*}/books:sort"
     body: "*"
   };
 }
 ```
 
 - If the collection has a parent, the field name in the request message
-  **should** be the target resource's singular noun (`shelf` in the above
+  **should** be the target resource's singular noun (`publisher` in the above
   example). If word separators are necessary, `snake_case` **must** be used.
 - The collection key (`books` in the above example) **must** be literal.
 
@@ -106,3 +106,8 @@ rpc TranslateText(TranslateTextRequest) returns (TranslateTextResponse) {
 - Stateless methods **must** use `POST` if they involve billing.
 
 [aip-121]: ./0121.md
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0151.md
+++ b/aip/0151.md
@@ -29,7 +29,7 @@ ultimate response message.
 // Write a book.
 rpc WriteBook(WriteBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
-    post: "/v1/{parent=shelves/*}/books}:write"
+    post: "/v1/{parent=publishers/*}/books}:write"
     body: "*"
   };
   option (google.longrunning.operation_info) = {
@@ -90,3 +90,8 @@ has elapsed after the operation completed.
 [node.js `promise`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises
 [python `future`]: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future
 <!-- prettier-ignore-end -->
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0155.md
+++ b/aip/0155.md
@@ -29,7 +29,7 @@ those of standard methods) in order to uniquely identify particular requests.
 ```proto
 message CreateBookRequest {
   // The parent resource where this book will be created.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   string parent = 1;
 
   // The book to create.
@@ -65,3 +65,8 @@ longer feasible to return an identical success response.
 In this situation, the method **may** return the current state of the resource
 instead. In other words, it is permissible to substitute the historical success
 response with a similar response that reflects more current data.
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0158.md
+++ b/aip/0158.md
@@ -26,7 +26,7 @@ pagination to an existing method.
 // The request structure for listing books.
 message ListBooksRequest {
   // The parent, which owns this collection of books.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   string parent = 1;
 
   // The maximum number of books to return. The service may return fewer than
@@ -45,7 +45,7 @@ message ListBooksRequest {
 
 // The response structure from listing books.
 message ListBooksResponse {
-  // The books located on the applicable shelf.
+  // The books from the applicable publisher.
   repeated Book books = 1;
 
   // A token, which can be send as `page_token` to retrieve the next page.
@@ -134,4 +134,6 @@ paginate) is reasonable for initially-small collections.
 
 ## Changelog
 
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.
 - **2019-07-19**: Update the opacity requirement from "should" to "must".

--- a/aip/0158.md
+++ b/aip/0158.md
@@ -45,7 +45,7 @@ message ListBooksRequest {
 
 // The response structure from listing books.
 message ListBooksResponse {
-  // The books from the applicable publisher.
+  // The books from the specified publisher.
   repeated Book books = 1;
 
   // A token, which can be send as `page_token` to retrieve the next page.

--- a/aip/0159.md
+++ b/aip/0159.md
@@ -21,7 +21,7 @@ users to specify a `-` as a wildcard character in a standard [`List`][aip-132]
 method:
 
 ```
-GET /v1/shelves/-/books?filter=...
+GET /v1/publishers/-/books?filter=...
 ```
 
 - The URL pattern **must** still be specified with `*` and permit the
@@ -45,7 +45,7 @@ wildcard collection ID `-` for all parent collections within which the resource
 is unique:
 
 ```
-GET https://example.googleapis.com/v1/shelves/-/books/{book}
+GET https://example.googleapis.com/v1/publishers/-/books/{book}
 ```
 
 - The URL pattern **must** still be specified with `*` and permit the
@@ -55,7 +55,12 @@ GET https://example.googleapis.com/v1/shelves/-/books/{book}
 - The resource name in the response **must** use the canonical name of the
   resource, with actual parent collection identifiers (instead of `-`). For
   example, the request above returns a resource with a name like
-  `shelves/123/books/456`, _not_ `shelves/-/books/456`.
+  `publishers/123/books/456`, _not_ `publishers/-/books/456`.
 
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0192.md
+++ b/aip/0192.md
@@ -40,7 +40,7 @@ first sentence of each comment **should** omit the subject and be in the
 third-person present tense:
 
 ```proto
-// Creates a book from the given publisher.
+// Creates a book under the given publisher.
 rpc CreateBook(CreateBookRequest) returns (Book) {
   option (google.api.http) = {
     post: "/v1/{parent=publishers/*}/books"

--- a/aip/0192.md
+++ b/aip/0192.md
@@ -40,10 +40,10 @@ first sentence of each comment **should** omit the subject and be in the
 third-person present tense:
 
 ```proto
-// Creates a book on the given shelf.
+// Creates a book from the given publisher.
 rpc CreateBook(CreateBookRequest) returns (Book) {
   option (google.api.http) = {
-    post: "/v1/{parent=shelves/*}/books"
+    post: "/v1/{parent=publishers/*}/books"
     body: "book"
   };
 }
@@ -102,3 +102,8 @@ Non-public links, internal implementation notes (such as `TODO` and `FIXME`
 directives), and other such material **must** be marked as internal.
 
 [commonmark]: https://commonmark.org/
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0231.md
+++ b/aip/0231.md
@@ -21,7 +21,7 @@ APIs **may** support Batch Get using the following pattern:
 ```proto
 rpc BatchGetBooks(BatchGetBooksRequest) returns (BatchGetBooksResponse) {
   option (google.api.http) = {
-    get: "/v1/{parent=shelves/*}/books:batchGet"
+    get: "/v1/{parent=publishers/*}/books:batchGet"
   };
 }
 ```
@@ -49,7 +49,7 @@ pattern:
 ```proto
 message BatchGetBooksRequest {
   // The parent resource shared by all books being retrieved.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   // If this is set, the parent field in the GetBookRequest messages
   // must either be empty or match this field.
   string parent = 1;
@@ -101,3 +101,8 @@ message BatchGetBooksResponse {
   request.
 
 [request-message]: ./0131.md#request-message
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0233.md
+++ b/aip/0233.md
@@ -20,7 +20,7 @@ APIs **may** support Batch Create using the following pattern:
 ```proto
 rpc BatchCreateBooks(BatchCreateBooksRequest) returns (BatchCreateBooksResponse) {
   option (google.api.http) = {
-    post: "/v1/{parent=shelves/*}/books:batchCreate"
+    post: "/v1/{parent=publishers/*}/books:batchCreate"
     body: "*"
   };
 }
@@ -52,7 +52,7 @@ following pattern:
 ```proto
 message BatchCreateBookRequest {
   // The parent resource shared by all books being created.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   // If this is set, the parent field in the CreateBookRequest messages
   // must either be empty or match this field.
   string parent = 1;
@@ -101,3 +101,8 @@ message BatchCreateBooksResponse {
   resources that were created.
 
 [request-message]: ./0133.md#request-message
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0234.md
+++ b/aip/0234.md
@@ -20,7 +20,7 @@ APIs **may** support Batch Update using the following pattern:
 ```proto
 rpc BatchUpdateBooks(BatchUpdateBooksRequest) returns (BatchUpdateBooksResponse) {
   option (google.api.http) = {
-    post: "/v1/{parent=shelves/*}/books:batchUpdate"
+    post: "/v1/{parent=publishers/*}/books:batchUpdate"
     body: "*"
   };
 }
@@ -52,7 +52,7 @@ following pattern:
 ```proto
 message BatchUpdateBookRequest {
   // The parent resource shared by all books being updated.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   // If this is set, the parent field in the UpdateBookRequest messages
   // must either be empty or match this field.
   string parent = 1;
@@ -100,3 +100,8 @@ message BatchUpdateBooksResponse {
   resources that were updated.
 
 [request-message]: ./0134.md#request-message
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/0235.md
+++ b/aip/0235.md
@@ -20,7 +20,7 @@ Batch delete methods are specified using the following pattern:
 ```proto
 rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
   option (google.api.http) = {
-    post: "/v1/{parent=shelves/*}/books:batchDelete"
+    post: "/v1/{parent=publishers/*}/books:batchDelete"
     body: "*"
   };
 }
@@ -54,7 +54,7 @@ following pattern:
 ```proto
 message BatchDeleteBooksRequest {
   // The parent resource shared by all books being deleted.
-  // Format: shelves/{shelf}
+  // Format: publishers/{publisher}
   // If this is set, the parent field in the DeleteBookRequest messages
   // must either be empty or match this field.
   string parent = 1;
@@ -108,3 +108,8 @@ message BatchDeleteBooksResponse {
   resources that were soft-deleted.
 
 [request-message]: ./0135.md#request-message
+
+## Changelog
+
+- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.


### PR DESCRIPTION
There is broad agreement that `shelves/*/books/*` is a poor
example of a resource hierarchy, as moving a book from one shelf
to another is a common operation and so a shelf should be a
property of a Book resource, not a parent. In fact, we often
give disclaimers about this when teaching the API design class.

Publishers is a better natural parent for a book. A book can
(and does) theoretically change publishers, but it is an expensive
operation and it also makes sense that its resource name would
change in this situation (the new book would have a new ISBN,
etc. -- it is really an equivalent but not identical book once
this happens).