### PR TITLE
[AIP-2510] Add an exception for foreign resource names.

### DIFF
--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -54,7 +54,7 @@ There are two exceptions to this rule:
 - Error responses **must** return the originally-provided value without
   modification. Error responses **must not** perform any translation between
   project IDs and project numbers.
-- If a service is receiving a resource name for a resource that the service
+- If a service receives a resource name for a resource that the service
   does not own, it **should not** perform any translation between project IDs
   and project numbers for those resource names.
 

--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -49,9 +49,14 @@ However, the project number is the canonical identifier, and therefore APIs
 **must** use project numbers in responses, regardless of whether they were sent
 a project ID or a project number.
 
-An exception is for error responses, which **must** return the
-originally-provided value without modification. Error responses **must not**
-perform any translation between project IDs and project numbers.
+There are two exceptions to this rule:
+
+- Error responses **must** return the originally-provided value without
+  modification. Error responses **must not** perform any translation between
+  project IDs and project numbers.
+- If a service is receiving a resource name for a resource that the service
+  does not own, it **should not** perform any translation between project IDs
+  and project numbers for those resource names.
 
 ### Internal Google services
 
@@ -83,5 +88,6 @@ folders.
 
 ## Changelog
 
+- **2019-08-11**: Add an exception for resources that a service does not own.
 - **2019-06-19**: Clarify how error messages should be treated
 - **2019-06-10**: Minor language and organization tweaks


### PR DESCRIPTION
Adds an explicit exception from this guidance for
resource names owned by a different service.