### PR TITLE
[fix] Fix double breadcrumb on `/home`.

### DIFF
--- a/_includes/aip-breadcrumb.html
+++ b/_includes/aip-breadcrumb.html
@@ -1,5 +1,5 @@
 <nav
-  class="h-c-breadcrumbs h-u-mt-std{% if page.url == '/' %} no-breadcrumb{% endif %}"
+  class="h-c-breadcrumbs h-u-mt-std{% if page.url == '/home' %} no-breadcrumb{% endif %}"
   aria-label="You are here."
 >
   <ol class="h-c-breadcrumbs__list aip-breadcrumbs">


### PR DESCRIPTION
The change in #227 moved the AIP listing from `/` to `/home`,
which broke this logic and causes [a double breadcrumb](https://aip.dev/home).
This fixes it.