### PR TITLE
[feat] Remove the state column, replace with a badge.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 _includes/aip-nav.html
+_includes/svgs.html
 _sass/colors.scss

--- a/_includes/aip-listing.html
+++ b/_includes/aip-listing.html
@@ -1,3 +1,6 @@
+{% comment %} When this file is included, it *must* be sent a `start` and `end`
+value. This determines which AIPs are rendered in the table. Both values are
+inclusive. {% endcomment -%}
 <table class="aip-listing">
   <thead>
     <tr>

--- a/_includes/aip-listing.html
+++ b/_includes/aip-listing.html
@@ -1,0 +1,26 @@
+<table class="aip-listing">
+  <thead>
+    <tr>
+      <th style="text-align: right;">Number</th>
+      <th>Title</th>
+    </tr>
+  </thead>
+  <tbody>
+    {%- for p in site.pages %}
+    <!-- prettier-ignore -->
+    {%- if p.aip and p.aip.id >= include.start and p.aip.id <= include.end and
+    'approved,reviewing,draft' contains p.aip.state %}
+    <tr>
+      <td style="text-align: right;">{{ p.aip.id }}</td>
+      <td>
+        <a href="{{ p.url }}>">{{ p.title }}</a>
+        {% if p.aip.state != 'approved' -%}
+        <span class="aip-state aip-state-{{ p.aip.state }}">
+          {{ p.aip.state | capitalize }}
+        </span>
+        {% endif -%}
+      </td>
+    </tr>
+    {%- endif %} {%- endfor %}
+  </tbody>
+</table>

--- a/_sass/aip/badges.scss
+++ b/_sass/aip/badges.scss
@@ -1,0 +1,18 @@
+@import 'colors';
+
+.aip-state {
+  border-radius: 4px;
+  font-size: 0.75em;
+  margin-left: 10px;
+  padding: 2px 5px;
+}
+
+.aip-state-reviewing {
+  background-color: $h-google-blue-50;
+  border: 1px solid $h-google-blue-200;
+}
+
+.aip-state-draft {
+  background-color: $h-google-yellow-50;
+  border: 1px solid $h-google-yellow-200;
+}

--- a/aip/general.md
+++ b/aip/general.md
@@ -11,42 +11,12 @@ The following AIPs apply to work across all APIs generally.
 
 ### Meta-AIPs (AIPs about AIPs)
 
-<!-- prettier-ignore-start -->
-
-| Number | Title | State |
-| -----: | ----- | ----- |
-{% for p in site.pages -%}
-{% if p.aip and p.aip.id < 100 -%}
-| {{ p.aip.id }} | [{{ p.title }}]({{ p.url }}) | {{ p.aip.state | capitalize }} |
-{% endif -%}
-{% endfor %}
-
-<!-- prettier-ignore-end -->
+{% include aip-listing.html start=1 end=99 %}
 
 ### Process
 
-<!-- prettier-ignore-start -->
-
-| Number | Title | State |
-| -----: | ----- | ----- |
-{% for p in site.pages -%}
-{% if p.aip and p.aip.id >= 100 and p.aip.id < 120 -%}
-| {{ p.aip.id }} | [{{ p.title }}]({{ p.url }}) | {{ p.aip.state | capitalize }} |
-{% endif -%}
-{% endfor %}
-
-<!-- prettier-ignore-end -->
+{% include aip-listing.html start=100 end=119 %}
 
 ### Guidance
 
-<!-- prettier-ignore-start -->
-
-| Number | Title | State |
-| -----: | ----- | ----- |
-{% for p in site.pages -%}
-{% if p.aip and p.aip.id >= 120 and p.aip.id < 1000 -%}
-| {{ p.aip.id }} | [{{ p.title }}]({{ p.url }}) | {{ p.aip.state | capitalize }} |
-{% endif -%}
-{% endfor %}
-
-<!-- prettier-ignore-end -->
+{% include aip-listing.html start=120 end=999 %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -11,6 +11,7 @@
 @import 'syntax';
 @import 'tables';
 
+@import 'aip/badges';
 @import 'aip/breadcrumbs';
 @import 'aip/header';
 @import 'aip/hero';


### PR DESCRIPTION
This PR removes the "state" column from the general AIP index and replaces it with a "Reviewing" or "Draft" badge for AIPs in those states (and removes other states from the list entirely).

This change only affects the "general" page to avoid needing everyone from every team to approve.
After this is merged, I will send individual PRs to each team to migrate their indexes.