### PR TITLE
Changes to avoid ATL/ATLD terminology

### DIFF
--- a/aip/0001.md
+++ b/aip/0001.md
@@ -63,25 +63,24 @@ digraph d_front_back {
 
   producer [ label="API Producer" ];
   editors [ label="AIP Editors" ];
-  atld_infra [ label="ATL-D\n(Infrastructure)" ];
-  atld_design [ label="ATL-D\n(Design)" ];
-  atl [ label="ATL" ];
+  tl_infra [ label="Infrastructure TL" ];
+  tl_design [ label="Design TL" ];
+  tl [ label="TL" ];
 
   producer -> editors;
-  editors -> atld_infra -> atl;
-  editors -> atld_design -> atl;
+  editors -> tl_infra -> tl;
+  editors -> tl_design -> tl;
 }
 ```
 
-### ATL and ATL-Ds
+### Technical leads
 
-The current ATL (area technical lead) for APIs at Google is Eric Brewer; he has
-delegated ATL responsibilities ("ATL-D") for API Infrastructure to Hong Zhang
-([@wora][]) and API Design to JJ Geewax ([@jgeewax][]). This document uses ATL
-and ATL-D consistently to refer to this role.
+The current TL (technical lead) for APIs is Eric Brewer; he has
+delegated some responsibilities for API Infrastructure to Hong Zhang
+([@wora][]) and API Design to JJ Geewax ([@jgeewax][]).
 
-As noted in the diagram above, the ATL is the final decision-maker on the AIP
-process and the point of escalation if necessary.
+As noted in the diagram above, the TL is the final decision-maker on the AIP
+process and the final point of escalation if necessary.
 
 ### Editors
 
@@ -238,7 +237,7 @@ follow-up commits to the PR.
 The editors will work together to ensure that qualified proposals do not linger
 in review.
 
-To gain final approval, an AIP **must** be approved by, at minimum, the ATL-D
+To gain final approval, an AIP **must** be approved by, at minimum, the TL
 with responsibility over the domain covered by the AIP (either design or
 infrastructure) and at least one other editor, with no editors actively
 requesting changes.


### PR DESCRIPTION
Based on feedback from Urs, we want to stick to more common and general terminology.