### PR TITLE
Fix links

### DIFF
--- a/_includes/aip-listing.html
+++ b/_includes/aip-listing.html
@@ -16,7 +16,7 @@ inclusive. {% endcomment -%}
     <tr>
       <td style="text-align: right;">{{ p.aip.id }}</td>
       <td>
-        <a href="{{ p.url }}>">{{ p.title }}</a>
+        <a href="{{ p.url }}">{{ p.title }}</a>
         {% if p.aip.state != 'approved' -%}
         <span class="aip-state aip-state-{{ p.aip.state }}">
           {{ p.aip.state | capitalize }}


### PR DESCRIPTION
I found this bug when trying to click on links from
https://aip.dev/general, because they would cause a 404 error. This was
due to an extraneous '>' character being added to the link (for example
https://aip.dev/121>), so it needs to be removed.