### PR TITLE
[feat] Move Cloud AIPs to the new index.

### DIFF
--- a/aip/cloud/index.md
+++ b/aip/cloud/index.md
@@ -13,31 +13,11 @@ The following AIPs apply to work on APIs on Google Cloud Platform.
 
 ### Google Cloud Platform APIs
 
-<!-- prettier-ignore-start -->
-
-| Number | Title | State |
-| -----: | ----- | ----- |
-{% for p in site.pages -%}
-{% if p.aip and p.aip.id >= 2500 and p.aip.id < 2600 -%}
-| {{ p.aip.id }} | [{{ p.title }}]({{ p.url }}) | {{ p.aip.state | capitalize }} |
-{% endif -%}
-{% endfor %}
-
-<!-- prettier-ignore-end -->
+{% include aip-listing.html start=2500 end=2599 %}
 
 ### Cloud SDK
 
 The following AIPs apply to work on the command-line interface for the Cloud
 SDK.
 
-<!-- prettier-ignore-start -->
-
-| Number | Title | State |
-| -----: | ----- | ----- |
-{% for p in site.pages -%}
-{% if p.aip and p.aip.id >= 2600 and p.aip.id < 2700 -%}
-| {{ p.aip.id }} | [{{ p.title }}]({{ p.url }}) | {{ p.aip.state | capitalize }} |
-{% endif -%}
-{% endfor %}
-
-<!-- prettier-ignore-end -->
+{% include aip-listing.html start=2600 end=2699 %}


### PR DESCRIPTION
This uses the new include file for Cloud AIP listings,
so that code is not repeated.