### PR TITLE
[AIP-127] gRPC Transcoding

### DIFF
--- a/aip/0127.md
+++ b/aip/0127.md
@@ -58,7 +58,7 @@ message CreateBookRequest {
 ```
 
 - The first key (`post` in this example) corresponds to the HTTP method. RPCs
-  **may** use `get`, `post`, `patch`, and `delete`.
+  **may** use `get`, `post`, `patch`, or `delete`.
   - RPCs **must** use the prescribed HTTP verb for each standard method, as
     discussed in [AIP-131][], [AIP-132][], [AIP-133][], [AIP-134][], and
     [AIP-135][]

--- a/aip/0127.md
+++ b/aip/0127.md
@@ -83,7 +83,7 @@ message CreateBookRequest {
 
 ### Multiple URI bindings
 
-Occasionally, an RPC needs to correspond to more than one HTTP path:
+Occasionally, an RPC needs to correspond to more than one URI:
 
 ```proto
 rpc CreateBook(CreateBookRequest) returns (Book) {

--- a/aip/0127.md
+++ b/aip/0127.md
@@ -21,7 +21,7 @@ pattern.
 
 APIs **must** provide HTTP definitions for each RPC that they define, except
 for bi-directional streaming RPCs, which can not be natively supported using
-HTTP/1.1. When providing a bi-directional streaming method, an API **must**
+HTTP/1.1. When providing a bi-directional streaming method, an API **should**
 also offer an alternative method that does not rely on bi-directional
 streaming.
 

--- a/aip/0127.md
+++ b/aip/0127.md
@@ -73,10 +73,11 @@ message CreateBookRequest {
   - URIs **must** use the `*` character to represent ID components, which
     matches all URI-safe characters except for `/`. URIs **may** use `**` as
     the final segment of a URI if matching `/` is required.
-- The `body` key defines which field in the request will be sent sent as the HTTP body.
-  If the body is `*`, then this indicates that the request object itself is the
-  HTTP body.
-  - RPCs **must not** define a `body` at all for GET or DELETE requests.
+- The `body` key defines which field in the request will be sent sent as the
+  HTTP body. If the body is `*`, then this indicates that the request object
+  itself is the HTTP body.
+  - RPCs **must not** define a `body` at all for RPCs that use the `GET` or
+    `DELETE` HTTP verbs.
   - RPCs **must** use the prescribed `body` for Create ([AIP-133][]) and Update
     ([AIP-134][]) requests.
   - RPCs **should** use the prescribed `body` for custom methods ([AIP-136][]).

--- a/aip/0127.md
+++ b/aip/0127.md
@@ -73,7 +73,7 @@ message CreateBookRequest {
   - URIs **must** use the `*` character to represent ID components, which
     matches all URI-safe characters except for `/`. URIs **may** use `**` as
     the final segment of a URI if matching `/` is required.
-- The `body` key defines which field in the request is sent as the HTTP body.
+- The `body` key defines which field in the request will be sent sent as the HTTP body.
   If the body is `*`, then this indicates that the request object itself is the
   HTTP body.
   - RPCs **must not** define a `body` at all for GET or DELETE requests.

--- a/aip/0127.md
+++ b/aip/0127.md
@@ -8,7 +8,7 @@ redirect_from:
   - /0127
 ---
 
-# HTTP & gRPC Transcoding
+# HTTP and gRPC Transcoding
 
 APIs that follow [resource-oriented design][aip-121] are defined as [RPC][]
 APIs, but the resource-oriented design framework allows those APIs to also be

--- a/aip/0127.md
+++ b/aip/0127.md
@@ -1,0 +1,119 @@
+---
+aip:
+  id: 127
+  state: reviewing
+  created: 2019-08-22
+permalink: /127
+redirect_from:
+  - /0127
+---
+
+# HTTP & gRPC Transcoding
+
+APIs that follow [resource-oriented design][aip-121] are defined as [RPC][]
+APIs, but the resource-oriented design framework allows those APIs to also be
+presented as APIs that largely follow REST/JSON conventions. This is important
+in order to give developers cognitive leverage: over 80% of the public APIs
+available follow most REST conventions, and developers are accustomed to that
+pattern.
+
+## Guidance
+
+APIs **must** provide HTTP definitions for each RPC that they define, except
+for bi-directional streaming RPCs, which can not be natively supported using
+HTTP/1.1. When providing a bi-directional streaming method, an API **must**
+also offer an alternative method that does not rely on bi-directional
+streaming.
+
+### HTTP method and path
+
+When using protocol buffers, each RPC **must** define the HTTP method and path
+using the `google.api.http` annotation:
+
+```proto
+rpc CreateBook(CreateBookRequest) returns (Book) {
+  option (google.api.http) = {
+    post: "/v1/{parent=publishers/*}/books/*"
+    body: "book"
+  };
+}
+
+message CreateBookRequest {
+  // The publisher who will publish this book.
+  // When using HTTP/JSON, this field is automatically populated based
+  // on the URI, because of the `{parent=publishers/*}` syntax.
+  string parent = 1;
+
+  // The book to create.
+  // When using HTTP/JSON, this field is populated based on the HTTP body,
+  // because of the `body: "book"` syntax.
+  Book book = 2;
+
+  // The user-specified ID for the book.
+  // When using HTTP/JSON, this field is populated based on a query string
+  // argument, such as `?book_id=foo`. This is the fallback for fields that
+  // are not included in either the URI or the body.
+  string book_id = 3;
+}
+```
+
+- The first key (`post` in this example) corresponds to the HTTP method. RPCs
+  **may** use `get`, `post`, `patch`, and `delete`.
+  - RPCs **must** use the prescribed HTTP verb for each standard method, as
+    discussed in [AIP-131][], [AIP-132][], [AIP-133][], [AIP-134][], and
+    [AIP-135][]
+  - RPCs **should** use the prescribed HTTP verb for custom methods, as
+    discussed in [AIP-136][].
+  - RPCs **should not** use `put` or `custom`.
+- The corresponding value represents the URI.
+  - URIs **must** use the `{foo=bar/*}` syntax to represent a variable that
+    should be populated in the request proto. When extracting a [resource
+    name][aip-122], the variable **must** include the entire resource name, not
+    just the ID component.
+  - URIs **must** use the `*` character to represent ID components, which
+    matches all URI-safe characters except for `/`. URIs **may** use `**` as
+    the final segment of a URI if matching `/` is required.
+- The `body` key defines which field in the request is sent as the HTTP body.
+  If the body is `*`, then this indicates that the request object itself is the
+  HTTP body.
+  - RPCs **must not** define a `body` at all for GET or DELETE requests.
+  - RPCs **must** use the prescribed `body` for Create ([AIP-133][]) and Update
+    ([AIP-134][]) requests.
+  - RPCs **should** use the prescribed `body` for custom methods ([AIP-136][]).
+
+### Multiple URI bindings
+
+Occasionally, an RPC needs to correspond to more than one HTTP path:
+
+```proto
+rpc CreateBook(CreateBookRequest) returns (Book) {
+  option (google.api.http) = {
+    post: "/v1/{parent=publishers/*}/books"
+    body: "book"
+    additional_bindings: {
+      post: "/v1/{parent=authors/*}/books"
+      body: "book"
+    }
+    additional_bindings: {
+      post: "/v1/books"
+      body: "book"
+    }
+  }
+}
+```
+
+- RPCs **may** define any number of additional bindings. The structure is
+  identical to the `google.api.http` annotation (in fact, it is a recursive
+  reference).
+- RPCs **must not** define an additional binding within an additional binding.
+- The `body` clause **must** be identical in the top-level annotation and each
+  additional binding.
+
+[aip-121]: ./0121.md
+[aip-122]: ./0122.md
+[aip-131]: ./0131.md
+[aip-132]: ./0132.md
+[aip-133]: ./0133.md
+[aip-134]: ./0134.md
+[aip-135]: ./0135.md
+[aip-136]: ./0136.md


### PR DESCRIPTION
This adds an AIP offering guidance around the `google.api.http` annotation.

Note to reviewers: This one was a bit tough to write, because it straddles the fence between "what you should do" (the purpose of AIPs generally) and "let me explain how this stuff works". Very open to suggestions to improve some of the awkward bits.

Fixes #253.