### PR TITLE
[AIP-210] Fix regex.

### DIFF
--- a/aip/0210.md
+++ b/aip/0210.md
@@ -76,7 +76,7 @@ number.
 
 Strings used as unique identifiers **should** limit inputs to ASCII characters,
 typically letters, numbers, hyphens, and underscores
-(`[a-zA-Z][a-zA-Z0-9_-]+`). This ensures that there are never accidental
+(`[a-zA-Z][a-zA-Z0-9_-]*`). This ensures that there are never accidental
 collisions due to normalization. If an API decides to allow all valid Unicode
 characters in unique identifiers, the API **must** reject any inputs that are
 not in Normalization Form C. Generally, unique identifiers **should not** start


### PR DESCRIPTION
The current regex implies at least two characters in each
identifier. Realistically, a minimum is probably a good idea,
but it is orthogonal to the point that this AIP is making.

Fixes #292.