### PR TITLE
[AIP-162] Resource revisions

### DIFF
--- a/aip/0162.md
+++ b/aip/0162.md
@@ -288,6 +288,18 @@ message DeleteBookRevisionRequest {
 - If the resource supports soft delete, then revisions of that resource
   **should** also support soft delete.
 
+## Appendix: Character Collision
+
+Most resource names have a restrictive set of characters, but some are very
+open. For example, Google Cloud Storage allows the `@` character in filenames,
+which are part of the resource name, and therefore uses the `#` character to
+indicate a revision.
+
+APIs **should** avoid permitting the `@` character in resource names, and if
+APIs that do permit it need to support resources with revisions, they
+**should** pick an appropriate separator depending on how and where the API is
+used, and **must** clearly document it.
+
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md
 [aip-135]: ./0135.md

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -180,6 +180,9 @@ parent revisions by accepting the `@-` syntax. For example:
 
     GET /v1/publishers/123/books/les-miserables@-/pages
 
+APIs **should not** include multiple levels of resources with revisions, as
+this quickly becomes difficult to reason about.
+
 ### Committing revisions
 
 Depending on the resource, different APIs may have different strategies for

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -68,7 +68,7 @@ should error with `INVALID_ARGUMENT` if one is given.
 **Important:** APIs **must not** require a revision ID, and **must** default to
 the current revision if one is not provided, except in methods specifically
 dealing with the revision history (such as rollback) where failing to require
-it would not make sense.
+it would not make sense (or lead to dangerous mistakes).
 
 ### Getting a revision
 
@@ -253,6 +253,40 @@ resource with a _new_ revision ID, rather than reusing the original ID. This
 avoids problems with representing the same revision being active for multiple
 ranges of time.
 
+### Removing revisions
+
+Revisions are sometimes expensive to store, and there are valid use cases to
+want to remove one or more revisions from a resource's revision history.
+
+APIs **may** define a method to delete revisions, with a structure similar to
+`Delete` ([AIP-135][]) methods:
+
+```proto
+rpc DeleteBookRevision(DeleteBookRevisionRequest)
+    returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    delete: "/v1/{name=publishers/*/books/*}:deleteRevision"
+  }
+}
+
+message DeleteBookRevisionRequest {
+  // The name of the book revision to be deleted, with a revision ID explicitly
+  // included.
+  //
+  // Example: publishers/123/books/les-miserables@c7cfa2a8
+  string name = 1;
+}
+```
+
+- The explicit resource ID **must** be required (the method **must** fail with
+  `INVALID_ARGUMENT` if it is not provided, and **must not** default to the
+  latest revision).
+- The API **must not** overload the `DeleteBook` method to serve both purposes
+  (this could lead to dangerous or confusing mistakes).
+- If the resource supports soft delete, then revisions of that resource
+  **should** also support soft delete.
+
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md
+[aip-135]: ./0135.md
 [aip-142]: ./0142.md

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -60,6 +60,10 @@ message Book {
 - The resource **must** contain a `revision_create_time` field, which
   **should** be a `google.protobuf.Timestamp` (see [AIP-142][]).
 
+**Note:** A randomly generated string is preferred over other methods, such as
+an auto-incrementing integer, because there is often a need to delete or revert
+revisions, and a randomly generated string holds up better in those situations.
+
 ### Referencing revisions
 
 When it is necessary to refer to a specific revision of a resource, APIs
@@ -67,6 +71,10 @@ When it is necessary to refer to a specific revision of a resource, APIs
 example:
 
     publishers/123/books/les-miserables@c7cfa2a8
+
+**Note:** The `@` character is selected because it is the only character
+permitted by [RFC 1738 §2.2][] for special meaning within a URI scheme that is
+not already used elsewhere.
 
 APIs **should** generally accept a resource reference at a particular revision
 in any place where they ordinarily accept the resource name. However, they
@@ -304,3 +312,4 @@ used, and **must** clearly document it.
 [aip-132]: ./0132.md
 [aip-135]: ./0135.md
 [aip-142]: ./0142.md
+[rfc 1738 §2.2]: https://tools.ietf.org/html/rfc1738

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -37,7 +37,7 @@ message Book {
   // The revision ID of the book.
   // This is automatically changed whenever the contents of the book
   // change in any way.
-  string revision_id = 99 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string revision_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 ```
 

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -52,8 +52,8 @@ message Book {
 ```
 
 - The resource **must** contain a `revision_id` field, which **should** be a
-  string and contain a short, automatically-generated hash. A good rule of
-  thumb is the last eight characters of a UUID4.
+  string and contain a short, automatically-generated random string. A good
+  rule of thumb is the last eight characters of a UUID4.
   - The `revision_id` field **must** document when new revisions are created
     (see [committing revisions](#committing-revisions) below).
   - The `revision_id` field **should** document the format of revision IDs.

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -36,7 +36,9 @@ message Book {
 
   // The revision ID of the book.
   // A new revision is committed whenever the book is changed in any way.
-  string revision_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string revision_id = 5 [
+    (google.api.field_behavior) = IMMUTABLE,
+    (google.api.field_behavior) = OUTPUT_ONLY];
 
   // The timestamp that the revision was created.
   google.protobuf.Timestamp revision_create_time = 6

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -40,6 +40,7 @@ message Book {
 
   // The revision ID of the book.
   // A new revision is committed whenever the book is changed in any way.
+  // The format is an 8-character hexadecimal string.
   string revision_id = 5 [
     (google.api.field_behavior) = IMMUTABLE,
     (google.api.field_behavior) = OUTPUT_ONLY];
@@ -55,6 +56,7 @@ message Book {
   thumb is the last eight characters of a UUID4.
   - The `revision_id` field **must** document when new revisions are created
     (see [committing revisions](#committing-revisions) below).
+  - The `revision_id` field **should** document the format of revision IDs.
 - The resource **must** contain a `revision_create_time` field, which
   **should** be a `google.protobuf.Timestamp` (see [AIP-142][]).
 
@@ -100,12 +102,6 @@ APIs **must** return a `name` value corresponding to what the user sent. If the
 user sent a name with no revision ID, the returned `name` string **must not**
 include the revision ID either. Similarly, if the user sent a name with a
 revision ID, the returned `name` string **must** explicitly include it.
-
-APIs **should** allow users to specify a `@` with no revision ID to indicate
-that the user wants the latest revision, but for the revision ID to be
-explicitly included in the `name` field in the response:
-
-    publishers/123/books/les-miserables@
 
 ### Listing revisions
 
@@ -159,7 +155,8 @@ While revision listing methods are mostly similar to standard `List` methods
     object **may** only populate the `string name`, `string revision_id`, and
     `google.protobuf.Timestamp revision_create_time` fields instead. The
     `string name` field **must** include the resource name and an explicit
-    revision ID, which can be used for an explicit `Get` request.
+    revision ID, which can be used for an explicit `Get` request. The API
+    **must** document that it will do this.
 
 ### Child resources
 
@@ -213,10 +210,7 @@ rpc CommitBook(CommitBookRequest) returns (Book) {
 - The method **must** use the `POST` HTTP verb.
 - The method **should** return the resource, and the resource name **must**
   include the revision ID.
-
-The request message **must** include the `name` field, and **may** include any
-additional metadata about the revision (such as a description), which
-**should** then be included in revision objects.
+- The request message **must** include the `name` field.
 
 ### Rollback
 

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -35,16 +35,22 @@ message Book {
   // Other fields…
 
   // The revision ID of the book.
-  // This is automatically changed whenever the contents of the book
-  // change in any way.
+  // A new revision is committed whenever the book is changed in any way.
   string revision_id = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The timestamp that the revision was created.
+  google.protobuf.Timestamp revision_create_time = 6
+    [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 ```
 
-- The `revision_id` field **should** be a string and contain a short,
-  automatically-generated hash. A good rule of thumb is the last eight
-  characters of a UUID4.
-- The field **must** document when new revisions are created.
+- The resource **must** contain a `revision_id` field, which **should** be a
+  string and contain a short, automatically-generated hash. A good rule of
+  thumb is the last eight characters of a UUID4.
+  - The `revision_id` field **must** document when new revisions are created
+    (see [committing revisions](#committing-revisions) below).
+- The resource **must** contain a `revision_create_time` field, which
+  **should** be a `google.protobuf.Timestamp` (see [AIP-142][]).
 
 ### Referencing revisions
 
@@ -55,8 +61,9 @@ example:
     publishers/123/books/les-miserables@c7cfa2a8
 
 APIs **should** generally accept a resource reference at a particular revision
-in any place where they ordinarily accept the resource name, except in
-situations that mutate the resource.
+in any place where they ordinarily accept the resource name. However, they
+**must not** accept a resource in situations that mutate the resource, and
+should error with `INVALID_ARGUMENT` if one is given.
 
 **Important:** APIs **must not** require a revision ID, and **must** default to
 the current revision if one is not provided, except in methods specifically
@@ -113,7 +120,7 @@ message ListBookRevisionsRequest {
 
 message ListBookRevisionsResponse {
   // The revisions of the book.
-  repeated BookRevision book_revisions = 1;
+  repeated Book books = 1;
 
   // A token that can be sent as `page_token` to retrieve the next page.
   // If this field is omitted, there are no subsequent pages.
@@ -129,48 +136,30 @@ While revision listing methods are mostly similar to standard `List` methods
   books).
 - The URI **must** end with `:listRevisions`.
 - Revisions **must** be ordered in reverse chronological order.
-
-The revision object **should** only be used by the revision list method:
-
-```proto
-message BookRevision {
-  // A representation of the book at this revision.
-  // The `name` field always includes an explicit revision ID.
-  Book book = 1;
-
-  // The date that this revision was created.
-  google.protobuf.Timestamp create_time = 2;
-}
-```
-
-- Revision objects **should** include a representation of the resource as of
-  that revision.
-  - The `string name` field in the resource **must** include an explicit
-    revision ID.
+- The returned resources **must** include an explicit revision ID in the
+  resource's `name` field.
   - If providing the full resource is expensive or infeasible, the revision
-    object **may** include a `string name` field instead, which **must**
-    include the resource name and an explicit revision ID.
-- Revision objects **must** include the timestamp when the revision was
-  created, which **should** be called `create_time`.
-- Revision objects **may** include other information, such as a description or
-  other metadata, if desired.
+    object **may** only populate the `string name`, `string revision_id`, and
+    `google.protobuf.Timestamp revision_create_time` fields instead. The
+    `string name` field **must** include the resource name and an explicit
+    revision ID, which can be used for an explicit `Get` request.
 
-### Snapshotting revisions
+### Committing revisions
 
 Depending on the resource, different APIs may have different strategies for
-when to snapshot a new revision, such as:
+when to commit a new revision, such as:
 
-- Snapshot a new revision any time that there is a change
-- Snapshot a new revision when something important happens
-- Snapshot a new revision when the user specifically asks
+- Commit a new revision any time that there is a change
+- Commit a new revision when something important happens
+- Commit a new revision when the user specifically asks
 
-APIs **may** use any of these strategies. APIs that want to snapshot a revision
-on user request **should** handle this with a `Snapshot` custom method:
+APIs **may** use any of these strategies. APIs that want to commit a revision
+on user request **should** handle this with a `Commit` custom method:
 
 ```proto
-rpc SnapshotBook(SnapshotBookRequest) returns (Book) {
+rpc CommitBook(CommitBookRequest) returns (Book) {
   option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*}:snapshot"
+    post: "/v1/{name=publishers/*/books/*}:commit"
     body: "*"
   }
 }
@@ -227,3 +216,4 @@ ranges of time.
 
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md
+[aip-142]: ./0142.md

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -90,6 +90,17 @@ message GetBookRequest {
 If the user passes a revision ID that does not exist, the API **must** fail
 with a `NOT_FOUND` error.
 
+APIs **must** return a `name` value corresponding to what the user sent. If the
+user sent a name with no revision ID, the returned `name` string **must not**
+include the revision ID either. Similarly, if the user sent a name with a
+revision ID, the returned `name` string **must** explicitly include it.
+
+APIs **should** allow users to specify a `@` with no revision ID to indicate
+that the user wants the latest revision, but for the revision ID to be
+explicitly included in the `name` field in the response:
+
+    publishers/123/books/les-miserables@
+
 ### Listing revisions
 
 APIs implementing resource revisions **should** provide a custom method for
@@ -143,6 +154,31 @@ While revision listing methods are mostly similar to standard `List` methods
     `google.protobuf.Timestamp revision_create_time` fields instead. The
     `string name` field **must** include the resource name and an explicit
     revision ID, which can be used for an explicit `Get` request.
+
+### Child resources
+
+Resources with a revision history **may** have child resources. If they do,
+there are two potential variants:
+
+- Child resources where each child resource is a child of the parent resource
+  as a whole.
+- Child resources where each child resource is a child of _a single revision
+  of_ the parent resource.
+
+If a child resource is a child of a single revision, the child resource's name
+**must** always explicitly include the parent's resource ID:
+
+    publishers/123/books/les-miserables@c7cfa2a8/pages/42
+
+In `List` requests for such resources, the service **should** default to the
+latest revision of the parent if the user does not specify one, but **must**
+explicitly include the parent's revision ID in the `name` field of resources in
+the response.
+
+If necessary, APIs **may** explicitly support listing child resources across
+parent revisions by accepting the `@-` syntax. For example:
+
+    GET /v1/publishers/123/books/les-miserables@-/pages
 
 ### Committing revisions
 

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -20,6 +20,10 @@ this:
   given point in time. In these cases, it may be desirable to snapshot the
   resource for reference later.
 
+**Note:** We use the word _revision_ to refer to a historical reference for a
+particular resource, and intentionally avoid the term _version_, which refers
+to the version of an API as a whole.
+
 ## Guidance
 
 APIs **may** store a revision history for a resource if it is useful to users.
@@ -255,7 +259,7 @@ resource with a _new_ revision ID, rather than reusing the original ID. This
 avoids problems with representing the same revision being active for multiple
 ranges of time.
 
-### Removing revisions
+### Deleting revisions
 
 Revisions are sometimes expensive to store, and there are valid use cases to
 want to remove one or more revisions from a resource's revision history.
@@ -270,7 +274,9 @@ rpc DeleteBookRevision(DeleteBookRevisionRequest)
     delete: "/v1/{name=publishers/*/books/*}:deleteRevision"
   }
 }
+```
 
+```proto
 message DeleteBookRevisionRequest {
   // The name of the book revision to be deleted, with a revision ID explicitly
   // included.

--- a/aip/0162.md
+++ b/aip/0162.md
@@ -1,0 +1,229 @@
+---
+aip:
+  id: 162
+  state: draft
+  created: 2019-09-17
+permalink: /162
+redirect_from:
+  - /0162
+---
+
+# Resource Revisions
+
+Some APIs need to have resources with a revision history, where users can
+reason about the state of the resource over time. There are several reasons for
+this:
+
+- Users may want to be able to roll back to a previous revision, or diff
+  against a previous revision.
+- An API may create data which is derived in some way from a resource at a
+  given point in time. In these cases, it may be desirable to snapshot the
+  resource for reference later.
+
+## Guidance
+
+APIs **may** store a revision history for a resource if it is useful to users.
+
+APIs implementing resources with a revision history **must** provide a
+`revision_id` field on the resource:
+
+```proto
+message Book {
+  // The name of the book.
+  string name = 1;
+
+  // Other fields…
+
+  // The revision ID of the book.
+  // This is automatically changed whenever the contents of the book
+  // change in any way.
+  string revision_id = 99 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+```
+
+- The `revision_id` field **should** be a string and contain a short,
+  automatically-generated hash. A good rule of thumb is the last eight
+  characters of a UUID4.
+- The field **must** document when new revisions are created.
+
+### Referencing revisions
+
+When it is necessary to refer to a specific revision of a resource, APIs
+**must** use the following syntax: `{resource_name}@{revision_id}`. For
+example:
+
+    publishers/123/books/les-miserables@c7cfa2a8
+
+APIs **should** generally accept a resource reference at a particular revision
+in any place where they ordinarily accept the resource name, except in
+situations that mutate the resource.
+
+**Important:** APIs **must not** require a revision ID, and **must** default to
+the current revision if one is not provided, except in methods specifically
+dealing with the revision history (such as rollback) where failing to require
+it would not make sense.
+
+### Getting a revision
+
+APIs implementing resource revisions **should** accept a resource name with a
+revision ID in the standard `Get` method ([AIP-131][]):
+
+```proto
+message GetBookRequest {
+  // The name of the book.
+  //   Example: publishers/123/books/les-miserables
+  //
+  // In order to retrieve a previous revision of the book, also provide
+  // the revision ID.
+  //   Example: publishers/123/books/les-miserables@c7cfa2a8
+  string name = 1;
+}
+```
+
+If the user passes a revision ID that does not exist, the API **must** fail
+with a `NOT_FOUND` error.
+
+### Listing revisions
+
+APIs implementing resource revisions **should** provide a custom method for
+listing the revision history for a resource, with a structure similar to
+standard `List` methods ([AIP-132][]):
+
+```proto
+rpc ListBookRevisions(ListBookRevisionsRequest)
+    returns (ListBookRevisionsResponse) {
+  option (google.api.http) = {
+    get: "/v1/{name=publishers/*/books/*}:listRevisions"
+  }
+}
+```
+
+```proto
+message ListBookRevisionsRequest {
+  // The name of the book to list revisions for.
+  string name = 1;
+
+  // The maximum number of revisions to return per page.
+  int32 page_size = 2;
+
+  // The page token, received from a previous ListBookRevisions call.
+  // Provide this to retrieve the subsequent page.
+  string page_token = 3;
+}
+
+message ListBookRevisionsResponse {
+  // The revisions of the book.
+  repeated BookRevision book_revisions = 1;
+
+  // A token that can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are no subsequent pages.
+  string next_page_token = 2;
+}
+```
+
+While revision listing methods are mostly similar to standard `List` methods
+([AIP-132][]), the following important differences apply:
+
+- The first field in the request message **must** be called `name` rather than
+  `parent` (this is listing revisions for a specific book, not a collection of
+  books).
+- The URI **must** end with `:listRevisions`.
+- Revisions **must** be ordered in reverse chronological order.
+
+The revision object **should** only be used by the revision list method:
+
+```proto
+message BookRevision {
+  // A representation of the book at this revision.
+  // The `name` field always includes an explicit revision ID.
+  Book book = 1;
+
+  // The date that this revision was created.
+  google.protobuf.Timestamp create_time = 2;
+}
+```
+
+- Revision objects **should** include a representation of the resource as of
+  that revision.
+  - The `string name` field in the resource **must** include an explicit
+    revision ID.
+  - If providing the full resource is expensive or infeasible, the revision
+    object **may** include a `string name` field instead, which **must**
+    include the resource name and an explicit revision ID.
+- Revision objects **must** include the timestamp when the revision was
+  created, which **should** be called `create_time`.
+- Revision objects **may** include other information, such as a description or
+  other metadata, if desired.
+
+### Snapshotting revisions
+
+Depending on the resource, different APIs may have different strategies for
+when to snapshot a new revision, such as:
+
+- Snapshot a new revision any time that there is a change
+- Snapshot a new revision when something important happens
+- Snapshot a new revision when the user specifically asks
+
+APIs **may** use any of these strategies. APIs that want to snapshot a revision
+on user request **should** handle this with a `Snapshot` custom method:
+
+```proto
+rpc SnapshotBook(SnapshotBookRequest) returns (Book) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*}:snapshot"
+    body: "*"
+  }
+}
+```
+
+- The method **must** use the `POST` HTTP verb.
+- The method **should** return the resource, and the resource name **must**
+  include the revision ID.
+
+The request message **must** include the `name` field, and **may** include any
+additional metadata about the revision (such as a description), which
+**should** then be included in revision objects.
+
+### Rollback
+
+A common use case for a resource with a revision history is the ability to roll
+back to a given revision. APIs **should** handle this with a `Rollback` custom
+method:
+
+```proto
+rpc RollbackBook(RollbackBookRequest) returns (Book) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*}:rollback"
+    body: "*"
+  }
+}
+```
+
+- The method **must** use the `POST` HTTP verb.
+- The method **should** return the resource, and the resource name **must**
+  include the revision ID.
+
+```proto
+message RollbackBookRequest {
+  // The book being rolled back.
+  string name = 1;
+
+  // The revision ID to roll back to.
+  // It must be a revision of the same book.
+  //
+  //   Example: c7cfa2a8
+  string revision_id = 2;
+}
+```
+
+- The request message **must** include a `revision_id` field.
+  - The API **must** fail the request with `NOT_FOUND` if the revision does not
+    exist on that resource.
+
+**Note:** When rolling back, the API should return a _new_ revision of the
+resource with a _new_ revision ID, rather than reusing the original ID. This
+avoids problems with representing the same revision being active for multiple
+ranges of time.
+
+[aip-131]: ./0131.md
+[aip-132]: ./0132.md


### PR DESCRIPTION
Toward #144.

I have had several conversations with API teams about needing resources with a revision history, so I have drawn up an AIP for it based on some research and discussion.

This is _very_ much a draft and we need to discuss many aspects of this proposal. I expect some of it to change, but this will be a good test of "we discuss and debate in the open where possible".

I am also going to call out some aspects of this that I am not sure about / not convinced of.