### PR TITLE
[fix] Linkify RPCs

### DIFF
--- a/aip/0127.md
+++ b/aip/0127.md
@@ -11,7 +11,7 @@ redirect_from:
 # HTTP and gRPC Transcoding
 
 APIs that follow [resource-oriented design][aip-121] are defined using
-[RPCs][], but the resource-oriented design framework allows them to also be
+[RPCs][rpc], but the resource-oriented design framework allows them to also be
 presented as APIs that largely follow REST/JSON conventions. This is important
 in order to help developers use their existing knowledge: over 80% of the
 public APIs available follow most REST conventions, and developers are


### PR DESCRIPTION
The Markdown link for RPCs wasn't connected.