### PR TITLE
[AIP-8] Clarify how to use internal links correcly.

### DIFF
--- a/aip/0008.md
+++ b/aip/0008.md
@@ -174,8 +174,9 @@ the AIP if appropriate.
 
 **Important:** AIP links **must** use the relative path to the file in the
 repository (such as `./0008.md` for core AIPs, or `../0008.md` for AIPs in a
-subdirectory); this ensures that the link works both on the AIP site and when
-viewing the Markdown file on GitHub.
+subdirectory); this ensures that the link works both on the AIP site, when
+viewing the Markdown file on GitHub, using the local development server, or a
+branch.
 
 [aip-1]: ./0001.md
 [protocol buffers]: https://developers.google.com/protocol-buffers/

--- a/aip/0008.md
+++ b/aip/0008.md
@@ -172,6 +172,15 @@ When AIPs reference other AIPs, the prosaic text **must** use the format
 link to the relevant AIP. AIP links **may** point to a particular section of
 the AIP if appropriate.
 
+**Important:** AIP links **must** use the relative path to the file in the
+repository (such as `./0008.md` for core AIPs, or `../0008.md` for AIPs in a
+subdirectory); this ensures that the link works both on the AIP site and when
+viewing the Markdown file on GitHub.
+
 [aip-1]: ./0001.md
 [protocol buffers]: https://developers.google.com/protocol-buffers/
 [rfc 2119]: https://www.ietf.org/rfc/rfc2119.txt
+
+## Changelog
+
+- **2019-08-23**: Added guidance for internal AIP links.


### PR DESCRIPTION
Internal AIP links are shockingly easy to mess up -- there is only one way to do them that works on both the GitHub Pages site and when viewing the Markdown file on GitHub.

We should tell AIP authors what that is. :)