### PR TITLE
[AIP-4232]: add restrictions on removal/alteration

### DIFF
--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -97,13 +97,16 @@ appear before any optional ones. Code generators implementing this feature
 field after an optional one, and **must** do so if the resulting client library
 would not be valid.
 
-Removing or altering an existing `google.api.method_signature` entry is a
-breaking change for client libraries. The associated generated method is either
-removed entirely or its signature is altered, both of which break user code. 
+### Compatibility
+
+Removing, reordering or altering an existing `google.api.method_signature` entry
+is a breaking change for client libraries. The associated generated method is
+either removed entirely or its signature is altered, both of which break user
+code. 
 
 ## Changelog
 
-- **2019-09-27**: Added annotation alteration and removal restrictions.
+- **2019-09-27**: Added a Compatibility section.
 
 <!-- prettier-ignore-start -->
 [aip-203]: ../0203.md

--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -4,7 +4,7 @@ aip:
   scope: client-libraries
   state: approved
   created: 2018-06-22
-  updated: 2019-05-09
+  updated: 2019-09-27
 permalink: /client-libraries/4232
 redirect_from:
   - /4232
@@ -96,6 +96,14 @@ appear before any optional ones. Code generators implementing this feature
 **should** error with a descriptive error message if encountering a required
 field after an optional one, and **must** do so if the resulting client library
 would not be valid.
+
+Removing or altering an existing `google.api.method_signature` entry is a
+breaking change for client libraries. The associated generated method is either
+removed entirely or its signature is altered, both of which break user code. 
+
+## Changelog
+
+- **2019-09-27**: Added annotation alteration and removal restrictions.
 
 <!-- prettier-ignore-start -->
 [aip-203]: ../0203.md


### PR DESCRIPTION
Add restrictions for alteration or removal of a method_signature annotation.

Fixes #313 