### PR TITLE
[AIP-3001]: Create AoG AIP block and AIP 3001.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,4 @@ aip/cloud/26*.md              @googleapis/aip-cloud-cli
 aip/apps/27*.md               @googleapis/aip-apps
 aip/client-libraries/42*.md   @googleapis/aip-client-libraries
 aip/geo/46*.md                @googleapis/aip-geo
+aip/aog/30*.md                @googleapis/aip-aog

--- a/aip/0002.md
+++ b/aip/0002.md
@@ -3,7 +3,7 @@ aip:
   id: 2
   state: approved
   created: 2018-08-23
-  updated: 2019-01-26
+  updated: 2019-10-03
 permalink: /2
 redirect_from:
   - /02
@@ -48,6 +48,7 @@ Currently recognized blocks of AIP numbers are:
 
 - **2700-2799:** Apps (GSuite)
 - **2500-2599:** Cloud
+- **3000-3099:** Actions on Google
 - **4600-4699:** Geo
 
 To request a block for a specific team that is publishing API guidance or
@@ -55,6 +56,7 @@ documentation germane to that specific team, reach out to api-editors@.
 
 ## Changelog
 
+- **2019-10-03:** The 3000-3099 block was assigned to Actions on Google.
 - **2019-01-26:** The general API design guidance block was expanded to include
   100-199.
 - **2018-10-24:** The 4600-4699 block was assigned to Google Geo.

--- a/aip/aog/3001.md
+++ b/aip/aog/3001.md
@@ -1,0 +1,123 @@
+---
+aip:
+  id: 3001
+  state: draft
+  created: 2019-10-03
+  updated: 2019-10-03
+  type: process
+js:
+  - /assets/js/graphviz/viz.js
+  - /assets/js/graphviz/lite.render.js
+  - /assets/js/aip/aip-graphviz.js
+permalink: /3001
+---
+
+# Actions on Google AIP Process
+
+This AIP extends [AIP-1][] with details specific to Actions on Google AIPs
+("AoG AIPs"). Any details of [AIP-1][] not modified or contradicted by this AIP
+also apply to AoG AIPs.
+
+## Stakeholders
+
+As with any process there are many different stakeholders when it comes to
+reviewing and working with AIPs. Below is a summary of the escalation path
+starting with the API producer.
+
+```graphviz
+digraph d_front_back {
+  rankdir=BT;
+  ranksep=0.3;
+  node [ style="filled,solid" shape=box fontname="Roboto" ];
+
+  producer [ label="API Producer" ];
+  editors [ label="AIP Editors" ];
+  aog_editors [ label="AoG AIP Editors" ];
+  tl_infra [ label="Infrastructure TL" ];
+  tl_design [ label="Design TL" ];
+  tl [ label="TL" ];
+
+  producer -> aog_editors;
+  aog_editors -> editors;
+  editors -> tl_infra -> tl;
+  editors -> tl_design -> tl;
+}
+```
+
+### Actions on Google Editors
+
+The Actions on Google editors are the set of people who make decisions on AoG
+AIPs before escalation to the general editors defined in [AIP-1][].
+
+The list of AoG AIP editors is currently:
+
+- Richard Frankel ([@rofrankel][])
+- Ali Ibrahim ([@aliibrahim][])
+- Silvano Luciani ([@silvano][])
+
+The AoG editors have the same responsibilities as the general editors. They
+also have the additional responsibility of establishing correctness of, and
+leadership support for, the contents of AoG AIPs.
+
+AoG AIP editorship is by invitation of the current AoG editors.
+
+## States
+
+AoG AIPs use the states defined in [AIP-1][], except that the "Reviewing" state
+is divided into two states, "AoG Reviewing" and "Reviewing":
+
+### AoG Reviewing
+
+Once discussion on an AoG AIP has generally concluded, but before it is
+formally accepted it moves to the “AoG Reviewing” state. This means that the
+authors have reached a general consensus on the proposal and the AoG editors
+are now involved. At this stage the AoG editors may request changes or suggest
+alternatives to the proposal before moving forward.
+
+**Note:** This state is effectively the same as the "Reviewing" state, except
+that it involves the AoG editors rather than the general editors.
+
+### Reviewing
+
+This state is very similar to the "Reviewing" state in AIP 1. The only
+difference is that AoG AIPs enter this state from the "AoG Reviewing" state,
+not the "Draft" state.
+
+## Workflow
+
+The following workflow describes the process for proposing an AoG AIP, and
+moving an AoG AIP from proposal to implementation to final acceptance.
+
+### Overview
+
+```graphviz
+digraph d_front_back {
+  rankdir=LR;
+  node [ style="filled,solid" shape=box fontname="Roboto" ];
+  draft [ label="Draft" fillcolor="orange" ];
+  aog_reviewing [ label="AoG Reviewing" fillcolor="lightskyblue" ];
+  reviewing [ label="Reviewing" fillcolor="lightskyblue" ];
+  approved [ label="Approved" fillcolor="palegreen" ];
+  withdrawn [ label="Withdrawn" fillcolor="mistyrose" ];
+  rejected [ label="Rejected" fillcolor="mistyrose" ];
+  deferred [ label="Deferred" fillcolor="lightsteelblue" ];
+  replaced [ label="Replaced" fillcolor="lightsteelblue" ];
+
+  draft -> aog_reviewing;
+  aog_reviewing -> reviewing;
+  draft -> withdrawn [ style=dashed, color=mistyrose3 ];
+  draft -> rejected [ style=dashed, color=mistyrose3 ];
+  reviewing -> approved;
+  aog_reviewing -> withdrawn [ style=dashed, color=mistyrose3 ];
+  reviewing -> withdrawn [ style=dashed, color=mistyrose3 ];
+  aog_reviewing -> rejected [ style=dashed, color=mistyrose3 ];
+  reviewing -> rejected [ style=dashed, color=mistyrose3 ];
+  draft -> deferred [ style=dashed, color=lightsteelblue3 ];
+  aog_reviewing -> deferred [ style=dashed, color=lightsteelblue3 ];
+  reviewing -> deferred [ style=dashed, color=lightsteelblue3 ];
+  approved -> replaced [ style=dashed, color=lightsteelblue3 ];
+  reviewing -> replaced [ style=dashed, color=lightsteelblue3 ];
+}
+```
+
+[aip-1]: ./0001.md

--- a/aip/aog/3001.md
+++ b/aip/aog/3001.md
@@ -52,8 +52,8 @@ AIPs before escalation to the general editors defined in [AIP-1][].
 The list of AoG AIP editors is currently:
 
 - Richard Frankel ([@rofrankel][])
-- Ali Ibrahim ([@aliibrahim][])
-- Silvano Luciani ([@silvano][])
+- Ali Ibrahim
+- Silvano Luciani ([@silvolu][])
 
 The AoG editors have the same responsibilities as the general editors. They
 also have the additional responsibility of establishing correctness of, and
@@ -122,5 +122,4 @@ digraph d_front_back {
 
 [aip-1]: ../0001.md
 [@rofrankel]: https://github.com/rofrankel
-[@aliibrahim]: https://google.com
-[@silvano]: https://github.com/silvolu
+[@silvolu]: https://github.com/silvolu

--- a/aip/aog/3001.md
+++ b/aip/aog/3001.md
@@ -116,6 +116,7 @@ digraph d_front_back {
   aog_reviewing -> deferred [ style=dashed, color=lightsteelblue3 ];
   reviewing -> deferred [ style=dashed, color=lightsteelblue3 ];
   approved -> replaced [ style=dashed, color=lightsteelblue3 ];
+  aog_reviewing -> replaced [ style=dashed, color=lightsteelblue3 ];
   reviewing -> replaced [ style=dashed, color=lightsteelblue3 ];
 }
 ```

--- a/aip/aog/3001.md
+++ b/aip/aog/3001.md
@@ -120,4 +120,7 @@ digraph d_front_back {
 }
 ```
 
-[aip-1]: ./0001.md
+[aip-1]: ../0001.md
+[@rofrankel]: https://github.com/rofrankel
+[@aliibrahim]: https://google.com
+[@silvano]: https://github.com/silvolu

--- a/aip/aog/3001.md
+++ b/aip/aog/3001.md
@@ -51,8 +51,8 @@ AIPs before escalation to the general editors defined in [AIP-1][].
 
 The list of AoG AIP editors is currently:
 
+- Ali Ibrahim ([@ahahibrahim][])
 - Richard Frankel ([@rofrankel][])
-- Ali Ibrahim
 - Silvano Luciani ([@silvolu][])
 
 The AoG editors have the same responsibilities as the general editors. They
@@ -122,5 +122,6 @@ digraph d_front_back {
 ```
 
 [aip-1]: ../0001.md
+[@ahahibrahim]: https://github.com/ahahibrahim
 [@rofrankel]: https://github.com/rofrankel
 [@silvolu]: https://github.com/silvolu


### PR DESCRIPTION
This PR creates an AoG block, as discussed with @jgeewax.  He gave the 3000 block as an example, so I went with that, but please let me know if another block would be preferable.

I also took a stab at the actual contents of an AoG-specific override of AIP 1 (as AIP 3001), also at JJ's suggestion.  It probably isn't perfect; I wanted to get some initial feedback before putting too much time into polishing it.

@silvolu @ahahibrahim FYI