### PR TITLE
Add annotation guidance to the standard methods.

### DIFF
--- a/aip/0131.md
+++ b/aip/0131.md
@@ -32,6 +32,7 @@ rpc GetBook(GetBookRequest) returns (Book) {
   option (google.api.http) = {
     get: "/v1/{name=publishers/*/books/*}"
   };
+  option (google.api.method_signature) = "name";
 }
 ```
 
@@ -48,6 +49,8 @@ rpc GetBook(GetBookRequest) returns (Book) {
   - The `name` field **should** be the only variable in the URI path. All
     remaining parameters **should** map to URI query parameters.
 - There **must not** be a `body` key in the `google.api.http` annotation.
+- There **should** be exactly one `google.api.method_signature` annotation,
+  with a value of `"name"`.
 
 ### Request message
 
@@ -57,11 +60,18 @@ Get methods implement a common request message pattern:
 message GetBookRequest {
   // The name of the book to retrieve.
   // Format: publishers/{publisher}/books/{book}
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "library-example.googleapis.com/Book"
+    }];
 }
 ```
 
 - A resource name field **must** be included. It **should** be called `name`.
+  - The field **should** be annotated as required.
+  - The field **should** identify the [resource type][aip-123] that it
+    references.
 - The comment for the `name` field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in
@@ -73,6 +83,7 @@ field in the request to be populated based on the value in the URL when the
 REST/JSON interface is used.
 
 [aip-121]: ./0121.md
+[aip-123]: ./0123.md
 
 ### Errors
 
@@ -86,6 +97,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Changelog
 
+- **2019-10-18**: Added guidance on annotations.
 - **2019-08-12**: Added guidance for error cases.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.

--- a/aip/0132.md
+++ b/aip/0132.md
@@ -32,6 +32,7 @@ rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
   option (google.api.http) = {
     get: "/v1/{parent=publishers/*}/books"
   };
+  option (google.api.method_signature) = "parent";
 }
 ```
 
@@ -50,6 +51,8 @@ rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
 - The `body` key in the `google.api.http` annotation **must** be omitted.
 - The method **must** document the default ordering, if one exists, or **must**
   explicitly document that the ordering behavior is unspecified.
+- There **should** be exactly one `google.api.method_signature` annotation,
+  with a value of `"parent"`.
 
 ### Request message
 
@@ -59,7 +62,11 @@ List methods implement a common request message pattern:
 message ListBooksRequest {
   // The parent, which owns this collection of books.
   // Format: publishers/{publisher}
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "library-example.googleapis.com/Book"
+    }];
 
   // The maximum number of books to return. The service may return fewer than
   // this value.
@@ -78,6 +85,9 @@ message ListBooksRequest {
 
 - A `parent` field **must** be included unless the resource being listed is a
   top-level resource. It **should** be called `parent`.
+  - The field **should** be annotated as required.
+  - The field **should** identify the [resource type][aip-123] of the resource
+    being listed.
 - The `page_size` and `page_token` fields, which support pagination, **must**
   be specified on all list request messages. For more information, see
   [AIP-158][].
@@ -169,6 +179,7 @@ requests. APIs with soft deletion of a resource **should** include a
 soft-deleted resources to be included.
 
 [aip-121]: ./0121.md
+[aip-123]: ./0123.md
 [aip-158]: ./0158.md
 [soft delete]: ./0135.md#soft-delete
 
@@ -178,6 +189,7 @@ soft-deleted resources to be included.
 
 ## Changelog
 
+- **2019-10-18**: Added guidance on annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.
 - **2019-07-30**: Added guidance about documenting the ordering behavior.

--- a/aip/0133.md
+++ b/aip/0133.md
@@ -33,6 +33,7 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
     post: "/v1/{parent=publishers/*}/books"
     body: "book"
   };
+  option (google.api.method_signature) = "parent,book";
 }
 ```
 
@@ -54,6 +55,9 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
 - There **must** be a `body` key in the `google.api.http` annotation, and it
   **must** map to the resource field in the request message.
   - All remaining fields **should** map to URI query parameters.
+- There **should** be exactly one `google.api.method_signature` annotation,
+  with a value of `"parent,{resource}"` (unless the method supports
+  [user-specified IDs](#user-specified-ids)).
 
 ### Request message
 
@@ -63,15 +67,22 @@ Create methods implement a common request message pattern:
 message CreateBookRequest {
   // The parent resource where this book will be created.
   // Format: publishers/{publisher}
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "library-example.googleapis.com/Book"
+    }];
 
   // The book to create.
-  Book book = 2;
+  Book book = 2 [(google.api.field_behavior) = REQUIRED];
 }
 ```
 
 - A `parent` field **must** be included unless the resource being listed is a
   top-level resource. It **should** be called `parent`.
+  - The field **should** be annotated as required.
+  - The field **should** identify the [resource type][aip-123] of the resource
+    being listed.
 - The resource field **must** be included and **must** map to the POST body.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
@@ -122,10 +133,14 @@ field on the request message:
 message CreateBookRequest {
   // The parent resource where this book will be created.
   // Format: publishers/{publisher}
-  string parent = 1;
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      child_type: "library-example.googleapis.com/Book"
+    }];
 
   // The book to create.
-  Book book = 2;
+  Book book = 2 [(google.api.field_behavior) = REQUIRED];
 
   // The ID to use for the book, which will become the final component of
   // the book's resource name.
@@ -138,7 +153,11 @@ message CreateBookRequest {
 
 - The `{resource}_id` field **must** exist on the request message, not the
   resource itself.
+  - The field **may** be required or optional. If it is required, it **should**
+    include the corresponding annotation.
 - The `name` field on the resource **must** be ignored.
+- There **should** be exactly one `google.api.method_signature` annotation on
+  the RPC, with a value of `"parent,{resource},{resource}_id"`.
 - The documentation **should** explain what the acceptable format is, and the
   format **should** follow the guidance for resource name formatting in
   [AIP-122][].
@@ -150,11 +169,13 @@ message CreateBookRequest {
 
 [aip-121]: ./0121.md
 [aip-122]: ./0122.md
+[aip-123]: ./0123.md
 [aip-155]: ./0155.md
 [aip-210]: ./0210.md
 
 ## Changelog
 
+- **2019-10-18**: Added guidance on annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.
 - **2019-06-10**: Added guidance for long-running create.

--- a/aip/0134.md
+++ b/aip/0134.md
@@ -33,6 +33,7 @@ rpc UpdateBook(UpdateBookRequest) returns (Book) {
     patch: "/v1/{book.name=publishers/*/books/*}"
     body: "book"
   };
+  option (google.api.method_signature) = "book,update_mask";
 }
 ```
 
@@ -55,6 +56,8 @@ rpc UpdateBook(UpdateBookRequest) returns (Book) {
 - There **must** be a `body` key in the `google.api.http` annotation, and it
   **must** map to the resource field in the request message.
   - All remaining fields **should** map to URI query parameters.
+- There **should** be exactly one `google.api.method_signature` annotation,
+  with a value of `"{resource},update_mask"`.
 
 **Note:** Unlike the other four standard methods, the URI path here references
 a nested field (`book.name`) in the example. If the resource field has a word
@@ -70,21 +73,24 @@ message UpdateBookRequest {
   //
   // The book's `name` field is used to identify the book to be updated.
   // Format: publishers/{publisher}/books/{book}
-  Book book = 1;
+  Book book = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The list of fields to be updated.
   google.protobuf.FieldMask update_mask = 2;
 }
 ```
 
-- A `name` field **must** be included in the resource message. It **should** be
-  called `name`.
-- The comment for the field **should** document the resource pattern.
+- The request message **must** contain a field for the resource.
+  - The field **should** be annotated as required.
+  - A `name` field **must** be included in the resource message. It **should**
+    be called `name`.
 - A field mask **should** be included in order to support partial update. It
   **must** be of type `google.protobuf.FieldMask`, and it **should** be called
   `update_mask`.
   - The fields used in the field mask correspond to the resource being updated
     (not the request message).
+  - The field **may** be required or optional. If it is required, it **should**
+    include the corresponding annotation.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
   or another AIP.
@@ -226,6 +232,7 @@ so.
 
 ## Changelog
 
+- **2019-10-18**: Added guidance on annotations.
 - **2019-09-10**: Added a link to the long-running operations AIP
   ([AIP-151][]).
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -31,6 +31,7 @@ rpc DeleteBook(DeleteBookRequest) returns (google.protobuf.Empty) {
   option (google.api.http) = {
     delete: "/v1/{name=publishers/*/books/*}"
   };
+  option (google.api.method_signature) = "name";
 }
 ```
 
@@ -50,6 +51,9 @@ rpc DeleteBook(DeleteBookRequest) returns (google.protobuf.Empty) {
   - The `name` field **should** be the only variable in the URI path. All
     remaining parameters **should** map to URI query parameters.
 - There **must not** be a `body` key in the `google.api.http` annotation.
+- There **should** be exactly one `google.api.method_signature` annotation,
+  with a value of `"name"`. If an etag or force field are used, they **may** be
+  included in the signature.
 
 The Delete method **should** succeed if and only if a resource was present and
 was successfully deleted. If the resource did not exist, the method **should**
@@ -63,11 +67,18 @@ Delete methods implement a common request message pattern:
 message DeleteBookRequest {
   // The name of the book to delete.
   // Format: publishers/{publisher}/books/{book}
-  string name = 1;
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "library-example.googleapis.com/Book"
+    }];
 }
 ```
 
 - A `name` field **must** be included. It **should** be called `name`.
+  - The field **should** be annotated as required.
+  - The field **should** identify the [resource type][aip-123] that it
+    references.
 - The comment for the field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
@@ -169,6 +180,7 @@ If the etag is provided and does not match the server-computed etag, the
 request **must** fail with a `FAILED_PRECONDITION` error code.
 
 [aip-121]: ./0121.md
+[aip-123]: ./0123.md
 [aip-131]: ./0131.md
 [aip-136]: ./0136.md
 [aip-214]: ./0214.md
@@ -177,6 +189,7 @@ request **must** fail with a `FAILED_PRECONDITION` error code.
 
 ## Changelog
 
+- **2019-10-18**: Added guidance on annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.
 - **2019-06-10**: Added guidance for long-running delete.


### PR DESCRIPTION
We need this in the AIPs before I can lint for them. :-)