### PR TITLE
[fix] Remove /home from the user click flow.

### DIFF
--- a/_includes/aip-breadcrumb.html
+++ b/_includes/aip-breadcrumb.html
@@ -4,7 +4,7 @@
 >
   <ol class="h-c-breadcrumbs__list aip-breadcrumbs">
     <li class="h-c-breadcrumbs__item" aria-level="1">
-      <a class="h-c-breadcrumbs__link" href="/home">
+      <a class="h-c-breadcrumbs__link" href="/">
         API Improvement Proposals
       </a>
     </li>

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ hero:
   subtitle: Designs for API development
   buttons:
     - text: Explore the AIPs
-      href: /home
+      href: /general
     - text: Learn how it works
       href: /1
 shortcuts:
@@ -35,8 +35,9 @@ shortcuts:
       text: Learn more
   - title: Still have questions?
     description: |
-      Free free to take a look at the frequently asked questions. If you don't
-      find an answer there, file an issue on our GitHub repository.
+      Free free to take a look at the <a href="/faq">frequently asked
+      questions</a>. If you don't find an answer there, file an issue on our
+      GitHub repository.
     button:
       href: https://github.com/googleapis/aip/issues
       text: Ask us on GitHub


### PR DESCRIPTION
Landing on aip.dev, you see a big blue button that says "Explore
the AIPs", but it actually takes you to a page that largely
regurgitates the same information as the home page, with what you
expect -- the list of AIPs -- on the left sidebar.

This short-circuits that: the "explore" button goes directly to
the general AIP listing.