### PR TITLE
fix: use absolute paths for docker bind mounts

### DIFF
--- a/aip/client-libraries/4290.md
+++ b/aip/client-libraries/4290.md
@@ -36,8 +36,8 @@ the proto import root, on a POSIX machine):
 
 ```bash
 $ docker run --rm --user $UID \
-  --mount type=bind,source=a/b/c/v1/,destination=/in/a/b/c/v1/,readonly \
-  --mount type=bind,source=dest/,destination=/out/ \
+  --mount type=bind,source=`pwd`/a/b/c/v1/,destination=/in/a/b/c/v1/,readonly \
+  --mount type=bind,source=/path/to/dest/,destination=/out/ \
   gcr.io/gapic-images/{GENERATOR} \
   [-- additional options...]
 ```


### PR DESCRIPTION
`docker` bind mounts require absolute paths (at least on OS X).

```
$ docker run --mount type=bind,source=test,destination=/test ubuntu
docker: Error response from daemon: invalid mount config for type "bind": invalid mount path: 'test' mount path must be absolute.
See 'docker run --help'.
```

Updating the command example to use absolute paths for both input and output directories.

