### PR TITLE
fix: one more place where we need an absolute path

### DIFF
--- a/aip/client-libraries/4290.md
+++ b/aip/client-libraries/4290.md
@@ -130,8 +130,8 @@ A resulting invocation of the Docker image would be as follows:
 
 ```bash
 $ docker run --rm --user $UID \
-      --mount type=bind,source=a/b/c/v1/,destination=/in/a/b/c/v1/,readonly \
-      --mount type=bind,source=dest/,destination=/out/ \
+      --mount type=bind,source=`pwd`/a/b/c/v1/,destination=/in/a/b/c/v1/,readonly \
+      --mount type=bind,source=/path/to/dest/,destination=/out/ \
       gcr.io/gapic-images/{GENERATOR} \
       --go-gapic-package GO_PACKAGE_VALUE
 ```


### PR DESCRIPTION
One more place where an absolute path is required. The actual script is fixed in https://github.com/googleapis/gapic-generator-python/pull/226.