### PR TITLE
Add missing markdown for "should" for input fields

### DIFF
--- a/aip/0203.md
+++ b/aip/0203.md
@@ -95,8 +95,8 @@ are:
 The use of `INPUT_ONLY` indicates that the field is provided in requests and
 that the corresponding field will not be included in output.
 
-Additionally, a field should only be described as input only if it is a field
-in a resource message or a field of a message included within a resource
+Additionally, a field **should** only be described as input only if it is a
+field in a resource message or a field of a message included within a resource
 message. Notably, fields in request messages (a message which only ever acts as
 an argument to an RPC, with a name usually ending in `Request`) **should not**
 be described as input only because this is already implied.


### PR DESCRIPTION
Fix the markdown for "should" in input fields section.