### PR TITLE
Fix comment in BatchGetBooksRequest

### DIFF
--- a/aip/0231.md
+++ b/aip/0231.md
@@ -51,8 +51,8 @@ pattern:
 message BatchGetBooksRequest {
   // The parent resource shared by all books being retrieved.
   // Format: publishers/{publisher}
-  // If this is set, the parent field in the GetBookRequest messages
-  // must either be empty or match this field.
+  // If this is set, the parent of all of the books specified in `names`
+  // must match this field.
   string parent = 1;
   // The names of the books to retrieve.
   // A maximum of 1000 books can be retrieved in a batch.


### PR DESCRIPTION
`BatchGetBooksRequest` does not specify any `GetBookRequest` messages.
Instead, this comment should refer to the `names` field.