### PR TITLE
Configuring urls to be aip.dev agnostic

### DIFF
--- a/_includes/aip-breadcrumb.html
+++ b/_includes/aip-breadcrumb.html
@@ -4,7 +4,7 @@
 >
   <ol class="h-c-breadcrumbs__list aip-breadcrumbs">
     <li class="h-c-breadcrumbs__item" aria-level="1">
-      <a class="h-c-breadcrumbs__link" href="/">
+      <a class="h-c-breadcrumbs__link" href="{{ relative_url}}">
         API Improvement Proposals
       </a>
     </li>
@@ -12,7 +12,7 @@
     <li class="h-c-breadcrumbs__item" aria-level="2">
       <!-- prettier-ignore -->
       <a class="h-c-breadcrumbs__link"
-         href="/{{ page.aip.scope | default: '#aip-listing' }}">
+         href="/{{ page.aip.scope | default: '#aip-listing' | relative_url }}">
         {% if page.aip.scope %}{{ page.areas[page.aip.scope] }}
         {% else %}General{% endif %} AIPs
       </a>

--- a/_includes/aip-listing.html
+++ b/_includes/aip-listing.html
@@ -16,7 +16,7 @@ inclusive. {% endcomment -%}
     <tr>
       <td style="text-align: right;">{{ p.aip.id }}</td>
       <td>
-        <a href="{{ p.url }}">{{ p.title }}</a>
+        <a href="{{ p.url | relative_url }}">{{ p.title }}</a>
         {% if p.aip.state != 'approved' -%}
         <span class="aip-state aip-state-{{ p.aip.state }}">
           {{ p.aip.state | capitalize }}

--- a/_includes/aip-nav-mobile.html
+++ b/_includes/aip-nav-mobile.html
@@ -5,7 +5,7 @@
     </li>
     {% for p in page.overview %}
     <li class="h-c-header__drawer-nav-li" aria-level="1">
-      <a href="{{ p.uri }}" class="h-c-header__drawer-nav-li-link">
+      <a href="{{ p.uri | relative_url}}" class="h-c-header__drawer-nav-li-link">
         {{ p.title }}
       </a>
     </li>
@@ -15,13 +15,13 @@
       <div class="drawer-heading-text">AIPs</div>
     </li>
     <li class="h-c-header__drawer-nav-li" aria-level="1">
-      <a href="/general" class="h-c-header__drawer-nav-li-link">
+      <a href="{{ '/general' | relative_url }}" class="h-c-header__drawer-nav-li-link">
         General
       </a>
     </li>
     {% for area in page.areas %}
     <li class="h-c-header__drawer-nav-li" aria-level="1">
-      <a href="/{{ area[0] }}" class="h-c-header__drawer-nav-li-link">
+      <a href="{{ area[0] | relative_url }}" class="h-c-header__drawer-nav-li-link">
         {{ area[1] }}
       </a>
     </li>

--- a/_includes/aip-nav.html
+++ b/_includes/aip-nav.html
@@ -4,20 +4,20 @@
     <li class="nav-item nav-item-header">Overview</li>
     {% for p in page.overview %}
     <li class="nav-item{% if page.url == p.uri %} nav-item-active{% endif %}">
-      <a href="{{ p.uri }}">{{ p.title }}</a>
+      <a href="{{ p.uri | relative_url }}">{{ p.title }}</a>
     </li>
     {% endfor %}
 
     <li class="nav-item nav-item-header">AIPs by category</li>
     <li class="nav-item{% if page.url == '/general' %} nav-item-active{% endif %}">
-      <a href="/general">General</a>
+      <a href="{{ '/general' | relative_url }}">General</a>
     </li>
     {% for area in page.areas %}
     {% if page.aip_index.scope == area[0] %}
       {% assign scope = area[0] %}
     {% endif %}
     <li class="nav-item{% if page.aip_index.scope == area[0] %} nav-item-active{% endif %}">
-      <a href="/{{ area[0] }}">{{ area[1] }}</a>
+      <a href="{{ area[0] | relative_url }}">{{ area[1] }}</a>
     </li>
     {% endfor %}
 
@@ -40,7 +40,7 @@
     </li>
     {% for p in site.pages %}{% if p.aip and p.aip.scope == scope -%}
     <li class="nav-item{% if p.url == page.url %} nav-item-active{% endif %}">
-      <a href="{{ p.url }}">
+      <a href="{{ p.url | relative_url }}">
         <span class="aip-number">{{ p.aip.id }}</span> {{ p.title }}
       </a>
     </li>

--- a/_includes/aip-state-banner.html
+++ b/_includes/aip-state-banner.html
@@ -23,7 +23,7 @@
   This AIP is currently deferred. This means that discussion on the AIP has
   dropped off and it is in an indeterminate state. If you are interested in
   championing this AIP, please
-  <a href="https://github.com/googleapis/aip/issues/">open an issue</a>.
+  <a href="{{ site.github.repository_url }}/issues">open an issue</a>.
 </p>
 {%- elsif page.aip.state == 'rejected' -%}
 <p id="aip-state-banner" class="callout important">
@@ -37,7 +37,7 @@
 <p id="aip-state-banner" class="callout important">
   This AIP is no longer the best current practice.<br />
   It has been replaced by
-  <a href="/{{ page.aip.replacement }}">AIP-{{ page.aip.replacement }}</a
+  <a href="{{ page.aip.replacement | relative_url}}">AIP-{{ page.aip.replacement }}</a
   >.
 </p>
 {% endif -%}

--- a/_includes/aip-summary.html
+++ b/_includes/aip-summary.html
@@ -10,8 +10,8 @@
   <tr>
     <td>Permalink</td>
     <td>
-      <a href="https://aip.dev/{{ page.aip.id }}">
-        aip.dev/{{ page.aip.id }}
+      <a href="{{ page.aip.id | absolute_url }}">
+        {{ page.aip.id | absolute_url }}
       </a>
     </td>
   </tr>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="//www.gstatic.com/glue/v19_0/glue.min.css">
     <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     {% for stylesheet in page.css -%}
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ stylesheet }}?v={{ site.github.build_revision }}">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ stylesheet | relative_url }}?v={{ site.github.build_revision }}">
     {% endfor -%}
     <link rel="stylesheet" type="text/css" media="print" href="{{ '/assets/css/print.css?v=' | append: site.github.build_revision | relative_url }}">
     <script type="text/javascript" src="//code.jquery.com/jquery-3.4.0.min.js"></script>
@@ -22,7 +22,7 @@
     </script>
     <script type="text/javascript" src="{{ '/assets/js/global.js?v=' | append: site.github.build_revision | relative_url }}"></script>
     {% for js_script in page.js -%}
-    <script type="text/javascript" src="{{ js_script }}?v={{ site.github.build_revision }}"></script>
+    <script type="text/javascript" src="{{ js_script | relative_url}}?v={{ site.github.build_revision }}"></script>
     {% endfor -%}
     {% seo %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -60,7 +60,7 @@
         </div>
         <div class="h-c-header__lockup">
           <div class="h-c-header__company-logo">
-            <a href="/" class="h-c-header__company-logo-link title="Google">
+            <a href="{{ '/' | relative_url }}" class="h-c-header__company-logo-link title="Google">
               <svg role="img" aria-label="Google" class="h-c-header__company-logo-img
                   h-c-header__company-logo-img--standard">
                 <use xlink:href="#h-color-google-logo"></use>
@@ -72,11 +72,11 @@
             </a>
           </div>
           <div class="h-c-header__product-logo">
-            <a href="/" class="h-c-header__product-logo-link">
+            <a href="{{ '/' | relative_url }}" class="h-c-header__product-logo-link">
               <span class="h-c-header__product-logo-text">AIPs</span>
             </a>
           </div>
-          <a href="#jump-content" class="h-c-header__jump-to-content"
+          <a href=" {{ '#jump-content' | relative_url }}" class="h-c-header__jump-to-content"
               data-glue-jump-link>
             <span class="h-c-header__jump-to-content-text">Skip to content</span>
           </a>
@@ -131,9 +131,9 @@
               </form>
             </li>
             <li class="h-c-header__cta-li h-c-header__cta-li--primary">
-              <a href="https://github.com/googleapis/aip" class="h-c-header__cta-li-link
+              <a href={{ site.github.repository_url }} class="h-c-header__cta-li-link
                   h-c-header__cta-li-link--primary">
-                <img src="/assets/images/github.png" class="github-logo">
+                <img src={{ '/assets/images/github.png' | relative_url}} class="github-logo">
                 View on GitHub
               </a>
             </li>
@@ -165,15 +165,15 @@
         <div class="h-c-header__drawer-cta">
           <ul class="h-c-header__drawer-cta-list">
             <li class="h-c-header__drawer-cta-li h-c-header__drawer-cta-li--secondary">
-              <a href="https://github.com/googleapis/aip/issues" class="h-c-header__drawer-cta-li-link
+              <a href="{{ site.github.repository_url }}/issues" class="h-c-header__drawer-cta-li-link
                   h-c-header__drawer-cta-li-link--secondary">
                 File an Issue
               </a>
             </li>
             <li class="h-c-header__drawer-cta-li h-c-header__drawer-cta-li--primary">
-              <a href="https://github.com/googleapis/aip" class="h-c-header__drawer-cta-li-link
+              <a href={{ site.github.repository_url }} "https://github.com/googleapis/aip" class="h-c-header__drawer-cta-li-link
                   h-c-header__drawer-cta-li-link--primary">
-                <img src="/assets/images/github.png" class="github-logo">
+                <img src="{{ '/assets/images/github.png' | relative_url }}" class="github-logo">
                 View on GitHub
               </a>
             </li>
@@ -199,17 +199,17 @@
           <section class="docs-component-sidebar-actions">
             <ul>
               <li>
-                <a href="https://github.com/googleapis/aip/issues/">
+                <a href="{{ site.github.repository_url }}/issues/">
                   File Bug
                 </a>
               </li>
               <li>
-                <a href="https://github.com/googleapis/aip/blob/master/{{ page.path }}">
+                <a href="{{ site.github.repository_url }}/blob/master/{{ page.path }}">
                   View source
                 </a>
               </li>
               <li>
-                <a href="https://github.com/googleapis/aip/edit/master/{{ page.path }}">
+                <a href="{{ site.github.repository_url }}/edit/master/{{ page.path }}">
                   Edit this page
                 </a>
               </li>
@@ -233,7 +233,7 @@
             <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons
             Attribution 4.0 License</a>, and code samples are licensed under the
             <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 License</a>.
-            <span class="no-print">For details, see <a href="/licensing">content licensing</a>.</span>
+            <span class="no-print">For details, see <a href="{{ '/licensing' | relative_url }}">content licensing</a>.</span>
             {% endif %}
           </footer>
         </section>

--- a/_layouts/hero.html
+++ b/_layouts/hero.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="//www.gstatic.com/glue/v19_0/glue.min.css">
     <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     {% for stylesheet in page.css -%}
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ stylesheet }}?v={{ site.github.build_revision }}">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ stylesheet | relative_url }}?v={{ site.github.build_revision }}">
     {% endfor -%}
     <link rel="stylesheet" type="text/css" media="print" href="{{ '/assets/css/print.css?v=' | append: site.github.build_revision | relative_url }}">
     <script type="text/javascript" src="//code.jquery.com/jquery-3.4.0.min.js"></script>
@@ -22,7 +22,7 @@
     </script>
     <script type="text/javascript" src="{{ '/assets/js/global.js?v=' | append: site.github.build_revision | relative_url }}"></script>
     {% for js_script in page.js -%}
-    <script type="text/javascript" src="{{ js_script }}?v={{ site.github.build_revision }}"></script>
+    <script type="text/javascript" src="{{ js_script | relative_url }}?v={{ site.github.build_revision }}"></script>
     {% endfor -%}
     {% seo %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -60,7 +60,7 @@
         </div>
         <div class="h-c-header__lockup">
           <div class="h-c-header__company-logo">
-            <a href="/" class="h-c-header__company-logo-link title="Google">
+            <a href="{{ '/' | relative_url }}" class="h-c-header__company-logo-link title="Google">
               <svg role="img" aria-label="Google" class="h-c-header__company-logo-img
                   h-c-header__company-logo-img--standard">
                 <use xlink:href="#h-color-google-logo"></use>
@@ -72,11 +72,11 @@
             </a>
           </div>
           <div class="h-c-header__product-logo">
-            <a href="/" class="h-c-header__product-logo-link">
+            <a href="{{ '/' | relative_url }}" class="h-c-header__product-logo-link">
               <span class="h-c-header__product-logo-text">AIPs</span>
             </a>
           </div>
-          <a href="#jump-content" class="h-c-header__jump-to-content"
+          <a href="{{ '#jump-content' | relative_url }}" class="h-c-header__jump-to-content"
               data-glue-jump-link>
             <span class="h-c-header__jump-to-content-text">Skip to content</span>
           </a>
@@ -100,7 +100,7 @@
           </div>
         </div>
         <div class="h-c-header__initiative-logo">
-          <a href="#"
+          <a href="{{ '#' | relative_url }}"
               class="h-c-header__initiative-logo-link">
             <span class="h-c-header__initiative-logo-text">Initiative</span>
           </a>
@@ -131,9 +131,9 @@
               </form>
             </li>
             <li class="h-c-header__cta-li h-c-header__cta-li--primary">
-              <a href="https://github.com/googleapis/aip" class="h-c-header__cta-li-link
+              <a href="{{ site.github.repository_url }}" class="h-c-header__cta-li-link
                   h-c-header__cta-li-link--primary">
-                <img src="/assets/images/github.png" class="github-logo">
+                <img src="{{ '/assets/images/github.png' | relative_url }}" class="github-logo">
                 View on GitHub
               </a>
             </li>
@@ -165,15 +165,15 @@
         <div class="h-c-header__drawer-cta">
           <ul class="h-c-header__drawer-cta-list">
             <li class="h-c-header__drawer-cta-li h-c-header__drawer-cta-li--secondary">
-              <a href="https://github.com/googleapis/aip/issues" class="h-c-header__drawer-cta-li-link
+              <a href="{{ site.github.repository_url }}/issues" class="h-c-header__drawer-cta-li-link
                   h-c-header__drawer-cta-li-link--secondary">
                 File an Issue
               </a>
             </li>
             <li class="h-c-header__drawer-cta-li h-c-header__drawer-cta-li--primary">
-              <a href="https://github.com/googleapis/aip" class="h-c-header__drawer-cta-li-link
+              <a href="{{ site.github.repository_url }}" class="h-c-header__drawer-cta-li-link
                   h-c-header__drawer-cta-li-link--primary">
-                <img src="/assets/images/github.png" class="github-logo">
+                <img src="{{ '/assets/images/github.png' | relative_url }}" class="github-logo">
                 View on GitHub
               </a>
             </li>
@@ -197,7 +197,7 @@
           </div>
           <div class="aip-buttons">
             {% for button in page.hero.buttons %}
-            <a href="{{ button.href }}" class="h-c-button h-c-button--primary"
+            <a href="{{ button.href | relative_url }}" class="h-c-button h-c-button--primary"
               >{{ button.text }}</a>
             {% endfor %}
           </div>
@@ -212,7 +212,7 @@
             <div class="aip-shortcut h-c-grid__col h-c-grid__col--6">
               <h1>{{ shortcut.title }}</h1>
               <div>{{ shortcut.description }}</div>
-              <a href="{{ shortcut.button.href }}"
+              <a href="{{ shortcut.button.href | relative_url }}"
                 class="h-c-button h-c-button--secondary">
                 {{ shortcut.button.text }}
                 &raquo;
@@ -228,7 +228,7 @@
             <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons
             Attribution 4.0 License</a>, and code samples are licensed under the
             <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 License</a>.
-            <span class="no-print">For details, see <a href="/licensing">content licensing</a>.</span>
+            <span class="no-print">For details, see <a href="{{ '/licensing' | relative_url }}">content licensing</a>.</span>
           {% endif %}
         </footer>
       </section>

--- a/assets/css/search.scss
+++ b/assets/css/search.scss
@@ -48,7 +48,7 @@ permalink: /assets/css/search.css
     a {
       color: $h-google-green-400;
       &:before {
-        content: 'aip.dev';
+        content: '{{ site.url }}';
       }
     }
   }


### PR DESCRIPTION
Updated URLs in the _layouts and _includes to utilize Jekyll functionality for relative and absolute urls.

Removed hardcoded references to `aip.dev` in urls and text.

Removed hardcoded references to `aip.dev` repo in place of `site.github.repository_url`.

I've tested this on [my fork](https://rhamiltonsf.github.io/aip/). Although I am not certain how to ensure a holistic test, and am submitting this PR in part to seek your guidance.