### PR TITLE
nit: Add INPUT_ONLY Field Behavior documentation to ttl field

### DIFF
--- a/aip/0214.md
+++ b/aip/0214.md
@@ -51,7 +51,7 @@ message ExpiringResource {
     google.protobuf.Timestamp expire_time = 2;
 
     // Input only. The TTL for this resource.
-    google.protobuf.Duration ttl = 3;
+    google.protobuf.Duration ttl = 3 [(google.api.field_behavior) = INPUT_ONLY];
   }
 }
 ```


### PR DESCRIPTION
https://aip.dev/214 has an example that contains a `ttl` field which is stated in the comment to be Input only. As such, I believe it is appropriate to add the `INPUT_ONLY` Field behavior documentation specified in https://aip.dev/203#input-only