### PR TITLE
Fix typo in AIP-162

### DIFF
--- a/aip/0162.md
+++ b/aip/0162.md
@@ -78,7 +78,7 @@ not already used elsewhere.
 
 APIs **should** generally accept a resource reference at a particular revision
 in any place where they ordinarily accept the resource name. However, they
-**must not** accept a resource in situations that mutate the resource, and
+**must not** accept a revision in situations that mutate the resource, and
 should error with `INVALID_ARGUMENT` if one is given.
 
 **Important:** APIs **must not** require a revision ID, and **must** default to


### PR DESCRIPTION
Requirement refers to 'resource' when 'revision' is clearly intended.