### PR TITLE
[AIP-191] Add guidance around package directives.

### DIFF
--- a/aip/0191.md
+++ b/aip/0191.md
@@ -104,6 +104,11 @@ When defining APIs, the following rules apply:
     in every file in the proto package, or none of them. If they are set, the
     values **must** be identical in every file.
 
+**Important:** While other languages have sensible defaults, be aware that
+_adding_ this annotation (with a value not equivalent to the default)
+constitutes a breaking change in that language. When releasing protos, be sure
+that omissions are intentional.
+
 ## Changelog
 
 - **2019-11-18**: Added guidance on the packaging annotations.

--- a/aip/0191.md
+++ b/aip/0191.md
@@ -96,9 +96,9 @@ When defining APIs, the following rules apply:
     the proto package with the appropriate TLD prefixed. Example:
     `com.google.example.v1`.
   - The `java_multiple_files` annotation **must** be set to `true`.
-  - The `java_outer_classname` annotation **must** be set to the name of the
-    proto filename, in `PascalCase`, with `Proto` appended. Example:
-    `LibraryProto`.
+  - The `java_outer_classname` annotation **must** be set, and **should** be
+    set to the name of the proto filename, in `PascalCase`, with `Proto`
+    appended. Example: `LibraryProto`.
 - Other languages
   - Package or namespace directives for other languages **must** be set either
     in every file in the proto package, or none of them. If they are set, the

--- a/aip/0191.md
+++ b/aip/0191.md
@@ -81,3 +81,29 @@ these **should** be separated by a blank line:
   corresponding response message (if any).
 - Any remaining `message` definitions.
 - Any top-level `enum` definitions.
+
+### Packaging annotations
+
+Protocol buffers ships with annotations to declare the package or namespace
+(depending on the vocabulary of the target language) of the generated files.
+For example, setting `go_package` or `csharp_namespace` will override the
+inferred package name.
+
+When defining APIs, the following rules apply:
+
+- Java
+  - The `java_package` annotation **must** be set. The correct value is usually
+    the proto package with the appropriate TLD prefixed. Example:
+    `com.google.example.v1`.
+  - The `java_multiple_files` annotation **must** be set to `true`.
+  - The `java_outer_classname` annotation **must** be set to the name of the
+    proto filename, in `PascalCase`, with `Proto` appended. Example:
+    `LibraryProto`.
+- Other languages
+  - Package or namespace directives for other languages **must** be set either
+    in every file in the proto package, or none of them. If they are set, the
+    values **must** be identical in every file.
+
+## Changelog
+
+- **2019-11-18**: Added guidance on the packaging annotations.


### PR DESCRIPTION
We have a lot of API producers that define these inconsistently.
We should document the rules and lint for them.