### PR TITLE
[AIP 3001] Remove references to "AoG".

### DIFF
--- a/aip/aog/3001.md
+++ b/aip/aog/3001.md
@@ -15,9 +15,9 @@ permalink: /3001
 
 # Actions on Google AIP Process
 
-This AIP extends [AIP-1][] with details specific to Actions on Google AIPs
-("AoG AIPs"). Any details of [AIP-1][] not modified or contradicted by this AIP
-also apply to AoG AIPs.
+This AIP extends [AIP-1][] with details specific to Actions on Google AIPs. Any
+details of [AIP-1][] not modified or contradicted by this AIP also apply to
+Actions on Google AIPs.
 
 ## Stakeholders
 
@@ -33,7 +33,7 @@ digraph d_front_back {
 
   producer [ label="API Producer" ];
   editors [ label="AIP Editors" ];
-  aog_editors [ label="AoG AIP Editors" ];
+  aog_editors [ label="Actions on Google AIP Editors" ];
   tl_infra [ label="Infrastructure TL" ];
   tl_design [ label="Design TL" ];
   tl [ label="TL" ];
@@ -47,20 +47,23 @@ digraph d_front_back {
 
 ### Actions on Google Editors
 
-The Actions on Google editors are the set of people who make decisions on AoG
-AIPs before escalation to the general editors defined in [AIP-1][].
+The Actions on Google editors are the set of people who make decisions on
+Actions on Google AIPs before escalation to the general editors defined in
+[AIP-1][].
 
-The list of AoG AIP editors is currently:
+The list of Actions on Google AIP editors is currently:
 
 - Ali Ibrahim ([@ahahibrahim][])
 - Richard Frankel ([@rofrankel][])
 - Silvano Luciani ([@silvolu][])
 
-The AoG editors have the same responsibilities as the general editors. They
-also have the additional responsibility of establishing correctness of, and
-leadership support for, the contents of AoG AIPs.
+The Actions on Google editors have the same responsibilities as the general
+editors. They also have the additional responsibility of establishing
+correctness of, and leadership support for, the contents of Actions on Google
+AIPs.
 
-AoG AIP editorship is by invitation of the current AoG editors.
+Actions on Google AIP editorship is by invitation of the current Actions on
+Google editors.
 
 ## States
 

--- a/aip/aog/3001.md
+++ b/aip/aog/3001.md
@@ -67,30 +67,33 @@ Google editors.
 
 ## States
 
-AoG AIPs use the states defined in [AIP-1][], except that the "Reviewing" state
-is divided into two states, "AoG Reviewing" and "Reviewing":
+Actions on Google AIPs use the states defined in [AIP-1][], except that the
+"Reviewing" state is divided into two states, "Actions on Google Reviewing" and
+"Reviewing":
 
-### AoG Reviewing
+### Actions on Google Reviewing
 
-Once discussion on an AoG AIP has generally concluded, but before it is
-formally accepted it moves to the “AoG Reviewing” state. This means that the
-authors have reached a general consensus on the proposal and the AoG editors
-are now involved. At this stage the AoG editors may request changes or suggest
-alternatives to the proposal before moving forward.
+Once discussion on an Actions on Google AIP has generally concluded, but before
+it is formally accepted it moves to the “Actions on Google Reviewing” state.
+This means that the authors have reached a general consensus on the proposal
+and the Actions on Google editors are now involved. At this stage the Actions
+on Google editors may request changes or suggest alternatives to the proposal
+before moving forward.
 
 **Note:** This state is effectively the same as the "Reviewing" state, except
-that it involves the AoG editors rather than the general editors.
+that it involves the Actions on Google editors rather than the general editors.
 
 ### Reviewing
 
 This state is very similar to the "Reviewing" state in AIP 1. The only
-difference is that AoG AIPs enter this state from the "AoG Reviewing" state,
-not the "Draft" state.
+difference is that Actions on Google AIPs enter this state from the "Actions on
+Google Reviewing" state, not the "Draft" state.
 
 ## Workflow
 
-The following workflow describes the process for proposing an AoG AIP, and
-moving an AoG AIP from proposal to implementation to final acceptance.
+The following workflow describes the process for proposing an Actions on Google
+AIP, and moving an Actions on Google AIP from proposal to implementation to
+final acceptance.
 
 ### Overview
 
@@ -99,7 +102,7 @@ digraph d_front_back {
   rankdir=LR;
   node [ style="filled,solid" shape=box fontname="Roboto" ];
   draft [ label="Draft" fillcolor="orange" ];
-  aog_reviewing [ label="AoG Reviewing" fillcolor="lightskyblue" ];
+  aog_reviewing [ label="Actions on Google Reviewing" fillcolor="lightskyblue" ];
   reviewing [ label="Reviewing" fillcolor="lightskyblue" ];
   approved [ label="Approved" fillcolor="palegreen" ];
   withdrawn [ label="Withdrawn" fillcolor="mistyrose" ];


### PR DESCRIPTION
We don't use this acronym externally.  All instances have been replaced with "Actions on Google".

Note that this depends on #361; AFAICT GitHub doesn't support dependent/child PRs.