### PR TITLE
[AIP-4222] Add additional_bindings request param source

### DIFF
--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -45,7 +45,8 @@ md := metadata.Pairs("x-goog-request-params",
 ```
 
 Much like URL parameters, if there is more than one key-value pair, the `&`
-character is used as the separator.
+character is used as the separator. If a named parameter is unset on the request
+message, it *should not* be included.
 
 If the [`google.api.http`][http] annotation contains `additional_bindings`,
 these patterns **should** be parsed for additional request parameters. Fields

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -46,7 +46,7 @@ md := metadata.Pairs("x-goog-request-params",
 
 Much like URL parameters, if there is more than one key-value pair, the `&`
 character is used as the separator. If a named parameter is unset on the request
-message, it **shsould not** be included.
+message, it **should not** be included.
 
 If the [`google.api.http`][http] annotation contains `additional_bindings`,
 these patterns **should** be parsed for additional request parameters. Fields

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -4,7 +4,7 @@ aip:
   scope: client-libraries
   state: approved
   created: 2018-06-22
-  updated: 2019-06-26
+  updated: 2019-11-27
 permalink: /client-libraries/4222
 redirect_from:
   - /4222
@@ -47,6 +47,11 @@ md := metadata.Pairs("x-goog-request-params",
 Much like URL parameters, if there is more than one key-value pair, the `&`
 character is used as the separator.
 
+If the [`google.api.http`][http] annotation contains `additional_bindings`,
+these patterns **should** be parsed for additional request parameters. Fields
+not duplicated in the top-level (or `additional_bindings`) pattern **should** be
+included in request parameters, encoded in the same way.
+
 **Note:** There is no additional annotation used for this; the presence of the
 key in any of the standard fields (`get`, `post`, `put`, `patch`, `delete`) on
 the [`google.api.http`][http] annotation is sufficient.
@@ -58,4 +63,5 @@ the [`google.api.http`][http] annotation is sufficient.
 ## Changelog
 
 - **2019-06-20**: Specify encoding of header parameters.
-- **2019-06-26**: Fix wording and example of key-value pair encoding
+- **2019-06-26**: Fix wording and example of key-value pair encoding.
+- **2019-11-27**: Include `additional_bindings` as a request parameter source.

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -45,8 +45,8 @@ md := metadata.Pairs("x-goog-request-params",
 ```
 
 Much like URL parameters, if there is more than one key-value pair, the `&`
-character is used as the separator. If a named parameter is unset on the request
-message, it **should not** be included.
+character is used as the separator. At runtime, if a named parameter is unset on
+the request message, it **should not** be included in the headers.
 
 If the [`google.api.http`][http] annotation contains `additional_bindings`,
 these patterns **should** be parsed for additional request parameters. Fields

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -46,7 +46,7 @@ md := metadata.Pairs("x-goog-request-params",
 
 Much like URL parameters, if there is more than one key-value pair, the `&`
 character is used as the separator. If a named parameter is unset on the request
-message, it *should not* be included.
+message, it **shsould not** be included.
 
 If the [`google.api.http`][http] annotation contains `additional_bindings`,
 these patterns **should** be parsed for additional request parameters. Fields

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -62,6 +62,6 @@ the [`google.api.http`][http] annotation is sufficient.
 
 ## Changelog
 
-- **2019-06-20**: Specify encoding of header parameters.
-- **2019-06-26**: Fix wording and example of key-value pair encoding.
 - **2019-11-27**: Include `additional_bindings` as a request parameter source.
+- **2019-06-26**: Fix wording and example of key-value pair encoding.
+- **2019-06-20**: Specify encoding of header parameters.


### PR DESCRIPTION
Adds guidance on incorporating the `additional_bindings` field of the `google.api.http` annotation as a source of other request parameter pairs.