### PR TITLE
[AIP-135] Add guidance for error cases

### DIFF
--- a/aip/0135.md
+++ b/aip/0135.md
@@ -179,6 +179,16 @@ message DeleteBookRequest {
 If the etag is provided and does not match the server-computed etag, the
 request **must** fail with a `FAILED_PRECONDITION` error code.
 
+### Errors
+
+If the user does not have permission to access the resource, regardless of
+whether or not it exists, the service **must** error with `PERMISSION_DENIED`
+(HTTP 403). Permission **must** be checked prior to checking if the resource
+exists.
+
+If the user does have proper permission, but the requested resource does not
+exist, the service **must** error with `NOT_FOUND` (HTTP 404).
+
 [aip-121]: ./0121.md
 [aip-123]: ./0123.md
 [aip-132]: ./0132.md
@@ -189,6 +199,7 @@ request **must** fail with a `FAILED_PRECONDITION` error code.
 
 ## Changelog
 
+- **2020-02-03**: Added guidance for error cases.
 - **2019-10-18**: Added guidance on annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.


### PR DESCRIPTION
Explicitly call out the errors that should be returned based on permissions checks, similar to the change to [AIP-131](https://github.com/googleapis/aip/pull/240).