### PR TITLE
0133: fix copy-paste nit

### DIFF
--- a/aip/0133.md
+++ b/aip/0133.md
@@ -78,11 +78,11 @@ message CreateBookRequest {
 }
 ```
 
-- A `parent` field **must** be included unless the resource being listed is a
+- A `parent` field **must** be included unless the resource being created is a
   top-level resource. It **should** be called `parent`.
   - The field **should** be annotated as required.
   - The field **should** identify the [resource type][aip-123] of the resource
-    being listed.
+    being created.
 - The resource field **must** be included and **must** map to the POST body.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this


### PR DESCRIPTION
Fix copy-paste issue referring to "listing" resources in a create-focussed AIP doc.