### PR TITLE
[AIP-158] Add guidance for the paginated response field.

### DIFF
--- a/aip/0158.md
+++ b/aip/0158.md
@@ -75,7 +75,8 @@ message ListBooksResponse {
   `string next_page_token` field, providing the user with a page token that may
   be used to retrieve the next page.
   - The field being paginated over **should** be the first field in the message
-    and have a field number of `1`. It **should not** be a primitive field.
+    and have a field number of `1`. It **should** be a repeated field
+    containing a list of resources constituting a single page of results.
   - If the end of the collection has been reached, the `next_page_token` field
     **must** be empty. This is the _only_ way to communicate
     "end-of-collection" to users.

--- a/aip/0158.md
+++ b/aip/0158.md
@@ -74,10 +74,9 @@ message ListBooksResponse {
 - Response messages for collections **should** define a
   `string next_page_token` field, providing the user with a page token that may
   be used to retrieve the next page.
-  - The field containing pagination results **should** be the first field in the
-    message
-    and have a field number of `1`. It **should** be a repeated field
-    containing a list of resources constituting a single page of results.
+  - The field containing pagination results **should** be the first field in
+    the message and have a field number of `1`. It **should** be a repeated
+    field containing a list of resources constituting a single page of results.
   - If the end of the collection has been reached, the `next_page_token` field
     **must** be empty. This is the _only_ way to communicate
     "end-of-collection" to users.

--- a/aip/0158.md
+++ b/aip/0158.md
@@ -74,6 +74,8 @@ message ListBooksResponse {
 - Response messages for collections **should** define a
   `string next_page_token` field, providing the user with a page token that may
   be used to retrieve the next page.
+  - The field being paginated over **should** be the first field in the message
+    and have a field number of `1`. It **should not** be a primitive field.
   - If the end of the collection has been reached, the `next_page_token` field
     **must** be empty. This is the _only_ way to communicate
     "end-of-collection" to users.
@@ -136,6 +138,7 @@ paginate) is reasonable for initially-small collections.
 
 ## Changelog
 
+- **2019-02-12**: Added guidance on the field being paginated over.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.
 - **2019-07-19**: Update the opacity requirement from "should" to "must".

--- a/aip/0158.md
+++ b/aip/0158.md
@@ -74,7 +74,8 @@ message ListBooksResponse {
 - Response messages for collections **should** define a
   `string next_page_token` field, providing the user with a page token that may
   be used to retrieve the next page.
-  - The field being paginated over **should** be the first field in the message
+  - The field containing pagination results **should** be the first field in the
+    message
     and have a field number of `1`. It **should** be a repeated field
     containing a list of resources constituting a single page of results.
   - If the end of the collection has been reached, the `next_page_token` field


### PR DESCRIPTION
This mirrors the code generation guidance in [AIP-4233](https://aip.dev/4233) and also permits adding [lint rules](https://github.com/googleapis/api-linter/issues/490) to that effect.