### PR TITLE
Correct markdown link format in AIP-155

### DIFF
--- a/aip/0155.md
+++ b/aip/0155.md
@@ -69,7 +69,7 @@ response with a similar response that reflects more current data.
 ## Further reading
 
 - For which codes to retry, see [AIP-194](https://aip.dev/194).
-- For how to retry errors in client libraries, see [AIP-4221][https://aip.dev/4221].
+- For how to retry errors in client libraries, see [AIP-4221](https://aip.dev/4221).
 
 ## Changelog
 


### PR DESCRIPTION
The link to AIP-4221 is incorrectly formatted under the "Further reading" section.