### PR TITLE
Shrink AIP header slightly.

### DIFF
--- a/_sass/headings.scss
+++ b/_sass/headings.scss
@@ -34,7 +34,7 @@
     @extend .glue-has-bottom-margin;
   }
   h4 {
-    @extend .glue-headline--headline-4;
+    @extend .glue-headline--headline-5;
 
     &.aip-number {
       line-height: 1em;


### PR DESCRIPTION
I think the current AIP number header over the AIP title is a bit too big. I am not sure if I made a small mistake in migrating or if it was always like that, but let's make it a touch smaller.

<img width="1415" alt="Screen Shot 2020-02-19 at 3 39 47 PM" src="https://user-images.githubusercontent.com/4346/74886875-2e620c00-532e-11ea-82b2-81432d677218.png">
