### PR TITLE
[AIP-160] Filtering

### DIFF
--- a/aip/0160.md
+++ b/aip/0160.md
@@ -83,7 +83,7 @@ Filtering implementations **must** provide the binary comparison operators `=`,
 | `<=`     | `a <= "foo"` | True if `a` is "foo" or lexically before it.    |
 | `>=`     | `a >= 42`    | True if `a` is a numeric value of 42 or higher. |
 
-Because filters are accepted as querty strings, type conversion takes place to
+Because filters are accepted as query strings, type conversion takes place to
 translate the string to the appropriate strongly-typed value:
 
 - Enums expect the enum's string representation (case-sensitive).
@@ -130,7 +130,8 @@ element:
 | `r.foo:42` | True if `r` contains an element `e` such that `e.foo = 42`. |
 
 **Important:** Filters can not query a _specific_ element on a repeated field
-for a value. For example, `e.0.foo = 42` is **not** a valid filter.
+for a value. For example, `e.0.foo = 42` and `e[0].foo = 42` are **not** valid
+filters.
 
 Maps, structs, messages can query either for the presence of a field in the map
 or a specific value:

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -93,7 +93,7 @@ translate the string to the appropriate strongly-typed value:
 - [Durations][] expect a numeric representation followed by an `s` suffix (for
   seconds). Examples: `20s`, `1.2s`.
 - [Timestamps][] expect an [RFC-3339][] formatted string (e.g.
-  `2012-04-21T11:30:00-0400`). UTC offsets are supported.
+  `2012-04-21T11:30:00-04:00`). UTC offsets are supported.
 
 **Warning:** The identifiers `true`, `false`, and `null` only carry intrinsic
 meaning when used in the context of a typed field reference.

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -33,7 +33,7 @@ is formally defined in the [EBNF grammar][].
 
 **Note:** List Filters have fuzzy matching characteristics with support for
 result ranking and scoring. For developers interested in deterministic
-evaluation, see [CEL][].
+evaluation of list filters, see [CEL][].
 
 ### Literals
 

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -26,9 +26,10 @@ common patterns found in code.
 
 ## Guidance
 
-APIs **may** provide filtering to users on `List` methods. If they choose to do
-so, they **must** follow the common specification for filters discussed here.
-The syntax is formally defined in the [EBNF grammar][].
+APIs **may** provide filtering to users on `List` methods (or similar methods
+to query a collection, such as `Search`). If they choose to do so, they
+**must** follow the common specification for filters discussed here. The syntax
+is formally defined in the [EBNF grammar][].
 
 **Note:** Google provides implementations for the filtering language in both
 [C++][cel-cpp] and [Go][cel-go] as a discrete component of [CEL][]. The use of
@@ -111,7 +112,7 @@ traversal through a message, map, or struct.
 | `a.b > 42`      | True if `a` has a numeric `b` field that is above 42. |
 | `a.b.c = "foo"` | True if `a.b` has a string `c` field that is "foo".   |
 
-**important:** The `.` operator **must not** be used to traverse through a
+**Important:** The `.` operator **must not** be used to traverse through a
 repeated field or list, except for specific use with the `:` operator.
 
 ### Has Operator

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -93,7 +93,7 @@ translate the string to the appropriate strongly-typed value:
 - [Durations][] expect a numeric representation followed by an `s` suffix (for
   seconds). Examples: `20s`, `1.2s`.
 - [Timestamps][] expect an [RFC-3339][] formatted string (e.g.
-  `2012-04-21T11:30:00-0400`). Timezones are supported.
+  `2012-04-21T11:30:00-0400`). UTC offsets are supported.
 
 **Warning:** The identifiers `true`, `false`, and `null` only carry intrinsic
 meaning when used in the context of a typed field reference.

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -1,0 +1,166 @@
+---
+aip:
+  id: 160
+  state: reviewing
+  created: 2020-02-24
+permalink: /160
+redirect_from:
+  - /0160
+---
+
+# Filtering
+
+Often, when listing resources (using a list method as defined in [AIP-132][] or
+something reasonably similar), it is desirable to filter over the collection
+and only return results that the user is interested in.
+
+It is tempting to define a structure to handle the precise filtering needs for
+each API. However, filtering requirements evolve frequently, and therefore it
+is prudent to use a string field with a structured syntax accessible to a
+non-technical audience. This allows updates to be able to be made
+transparently, without waiting for UI or client updates.
+
+**Note:** Because list filters are intended for a potentially non-technical
+audience, they sometimes borrow from patterns of colloquial speech rather than
+common patterns found in code.
+
+## Guidance
+
+APIs **may** provide filtering to users on `List` methods. If they choose to do
+so, they **must** follow the common specification for filters discussed here.
+The syntax is formally defined in the [EBNF grammar][].
+
+**Note:** Google provides implementations for the filtering language in both
+[C++][cel-cpp] and [Go][cel-go] as a discrete component of [CEL][]. The use of
+these implementations is encouraged.
+
+### Expressions
+
+Expressions are literal values in the filtering syntax ("42", "Victor Hugo").
+Expressions can be pieced together with operators to make other expressions.
+
+### Logical Operators
+
+Filtering implementations **must** provide the binary operators `AND` and `OR`,
+as well as a whitespace operator:
+
+| Operator | Example       | Meaning                                |
+| -------- | ------------- | -------------------------------------- |
+| `AND`    | `a AND b`     | True if `a` and `b` are true.          |
+| `OR`     | `a OR b OR c` | True if any of `a`, `b`, `c` are true. |
+
+The whitespace operator (example: `a b c`) represents a fuzzy variant of `AND`,
+which is suitable for result ranking and term rewrite.
+
+**Note:** To match common patterns of speech, the `OR` operator has higher
+precedence than `AND`, unlike what is found in most programming languages. The
+expression `a AND b OR c` evaluates: `a AND (b OR c)`. API documentation and
+examples **should** encourage the use of explicit parentheses to avoid
+confusion.
+
+### Negation Operators
+
+Filtering implementations **must** provide the unary operators `NOT` and `-`.
+These are used interchangeably.
+
+| Operator | Example | Meaning                  |
+| -------- | ------- | ------------------------ |
+| `NOT`    | `NOT a` | True if `a` is not true. |
+| `-`      | `-a`    | True if `a` is not true. |
+
+### Comparison Operators
+
+Filtering implementations **must** provide the binary comparison operators `=`,
+`!=`, `<`, `>`, `<=`, and `>=`.
+
+| Operator | Example      | Meaning                                         |
+| -------- | ------------ | ----------------------------------------------- |
+| `=`      | `a = true`   | True if `a` is true.                            |
+| `!=`     | `a != 42`    | True unless `a` equals 42.                      |
+| `<`      | `a < 42`     | True if `a` is a numeric value below 42.        |
+| `>`      | `a > "foo"`  | True if `a` is lexically ordered after "foo".   |
+| `<=`     | `a <= "foo"` | True if `a` is "foo" or lexically before it.    |
+| `>=`     | `a >= 42`    | True if `a` is a numeric value of 42 or higher. |
+
+Because filters are accepted as querty strings, type conversion takes place to
+translate the string to the appropriate strongly-typed value:
+
+- Enums expect the enum's string representation (case-sensitive).
+- Booleans expect `true` and `false` literal values.
+- Numbers expect the standard integer or float representations. For floats,
+  exponents are supported (e.g. `2.997e9`).
+- [Durations][] expect a numeric representation followed by an `s` suffix (for
+  seconds). Examples: `20s`, `1.2s`.
+- [Timestamps][] expect an [RFC-3339][] formatted string (e.g.
+  `2012-04-21T11:30:00-0400`). Timezones are supported.
+
+**Warning:** The identifiers `true`, `false`, and `null` only carry intrinsic
+meaning when used in the context of a typed field reference.
+
+Additionally, when comparing strings for equality, the `*` character denotes
+wildcard syntax; for example, `a = "*.foo"` is true if `a` _ends with_ ".foo".
+
+### Traversal operator
+
+Filtering implementations **must** provide the `.` operator, which indicates
+traversal through a message, map, or struct.
+
+| Example         | Meaning                                               |
+| --------------- | ----------------------------------------------------- |
+| `a.b = true`    | True if `a` has a boolean `b` field that is true.     |
+| `a.b > 42`      | True if `a` has a numeric `b` field that is above 42. |
+| `a.b.c = "foo"` | True if `a.b` has a string `c` field that is "foo".   |
+
+**important:** The `.` operator **must not** be used to traverse through a
+repeated field or list, except for specific use with the `:` operator.
+
+### Has Operator
+
+Filtering implementations **must** provide the `:` operator, which means "has".
+It is usable with collections (repeated fields or maps) as well as messages,
+and behaves slightly differently in each case.
+
+Repeated fields query to see if the repeated structure contains a matching
+element:
+
+| Example    | Meaning                                                     |
+| ---------- | ----------------------------------------------------------- |
+| `r:42`     | True if `r` contains 42.                                    |
+| `r.foo:42` | True if `r` contains an element `e` such that `e.foo = 42`. |
+
+**Important:** Filters can not query a _specific_ element on a repeated field
+for a value. For example, `e.0.foo = 42` is **not** a valid filter.
+
+Maps, structs, messages can query either for the presence of a field in the map
+or a specific value:
+
+| Example    | Meaning                             |
+| ---------- | ----------------------------------- |
+| `m:foo`    | True if `m` contains the key "foo". |
+| `m.foo:*`  | True if `m` contains the key "foo". |
+| `m.foo:42` | True if `m.foo` is 42.              |
+
+There are two slight distinctions when parsing messages:
+
+- When traversing messages, a field is only considered to be present if it has
+  a non-default value.
+- When traversing messages, field names transparently convert between camel
+  case and snake case.
+
+### Functions
+
+The filtering language supports a function call syntax in order to support
+API-specific extensions. An API **may** define a function using the
+`call(arg...)` syntax, and **must** document any specific functions it
+supports.
+
+<!-- prettier-ignore-start -->
+[aip-132]: ./0132.md
+[cel]: https://github.com/google/cel-spec
+[cel-cpp]: https://github.com/google/cel-cpp
+[cel-go]: https://github.com/google/cel-go
+[durations]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto
+[ebnf grammar]: ../assets/misc/ebnf-filtering.txt
+[rfc-3339]: https://tools.ietf.org/html/rfc3339
+[timestamps]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
+<!-- prettier-ignore-end -->

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -151,7 +151,8 @@ There are two slight distinctions when parsing messages:
 
 - When traversing messages, a field is only considered to be present if it has
   a non-default value.
-- When traversing messages, field names transparently convert between camel
+- When traversing messages, field names are snake case, although
+  implementations **may** choose to support automatic conversion between camel
   case and snake case.
 
 ### Functions

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -31,9 +31,9 @@ to query a collection, such as `Search`). If they choose to do so, they
 **must** follow the common specification for filters discussed here. The syntax
 is formally defined in the [EBNF grammar][].
 
-**Note:** Google provides implementations for the filtering language in both
-[C++][cel-cpp] and [Go][cel-go] as a discrete component of [CEL][]. The use of
-these implementations is encouraged.
+**Note:** List Filters have fuzzy matching characteristics with support for
+result ranking and scoring. For developers interested in deterministic
+evaluation, see [CEL][].
 
 ### Literals
 

--- a/aip/0160.md
+++ b/aip/0160.md
@@ -35,23 +35,24 @@ is formally defined in the [EBNF grammar][].
 [C++][cel-cpp] and [Go][cel-go] as a discrete component of [CEL][]. The use of
 these implementations is encouraged.
 
-### Expressions
+### Literals
 
-Expressions are literal values in the filtering syntax ("42", "Victor Hugo").
-Expressions can be pieced together with operators to make other expressions.
+A bare literal value (examples: "42", "Hugo") is a value to be matched against.
+Literals appearing alone are matched anywhere it may appear in an object's
+field values.
+
+**Note:** Literals separated by whitespace are considered to have a fuzzy
+variant of `AND`. Therefore, `Victor Hugo` is roughly equivalent to
+`Victor AND Hugo`.
 
 ### Logical Operators
 
-Filtering implementations **must** provide the binary operators `AND` and `OR`,
-as well as a whitespace operator:
+Filtering implementations **must** provide the binary operators:
 
 | Operator | Example       | Meaning                                |
 | -------- | ------------- | -------------------------------------- |
 | `AND`    | `a AND b`     | True if `a` and `b` are true.          |
 | `OR`     | `a OR b OR c` | True if any of `a`, `b`, `c` are true. |
-
-The whitespace operator (example: `a b c`) represents a fuzzy variant of `AND`,
-which is suitable for result ranking and term rewrite.
 
 **Note:** To match common patterns of speech, the `OR` operator has higher
 precedence than `AND`, unlike what is found in most programming languages. The
@@ -82,6 +83,10 @@ Filtering implementations **must** provide the binary comparison operators `=`,
 | `>`      | `a > "foo"`  | True if `a` is lexically ordered after "foo".   |
 | `<=`     | `a <= "foo"` | True if `a` is "foo" or lexically before it.    |
 | `>=`     | `a >= 42`    | True if `a` is a numeric value of 42 or higher. |
+
+**Note:** Unlike in most programming languages, field names **must** appear on
+the left-hand side of a comparison operator; the right-hand side only accepts
+literals and logical operators.
 
 Because filters are accepted as query strings, type conversion takes place to
 translate the string to the appropriate strongly-typed value:

--- a/assets/misc/ebnf-filtering.txt
+++ b/assets/misc/ebnf-filtering.txt
@@ -1,0 +1,184 @@
+# Filter, possibly empty
+filter
+    : [expression]
+    ;
+
+
+# Expressions may either be a conjunction (AND) of sequences or a simple
+# sequence.
+#
+# Note, the AND is case-sensitive.
+#
+# Example: `a b AND c AND d`
+#
+# The expression `(a b) AND c AND d` is equivalent to the example.
+expression
+    : sequence {WS AND WS sequence}
+    ;
+
+# Sequence is composed of one or more whitespace (WS) separated factors.
+#
+# A sequence expresses a logical relationship between 'factors' where
+# the ranking of a filter result may be scored according to the number
+# factors that match and other such criteria as the proximity of factors
+# to each other within a document.
+#
+# When filters are used with exact match semantics rather than fuzzy
+# match semantics, a sequence is equivalent to AND.
+#
+# Example: `New York Giants OR Yankees`
+#
+# The expression `New York (Giants OR Yankees)` is equivalent to the
+# example.
+sequence
+    : factor {WS factor}
+    ;
+
+
+# Factors may either be a disjunction (OR) of terms or a simple term.
+#
+# Note, the OR is case-sensitive.
+#
+# Example: `a < 10 OR a >= 100`
+factor
+    : term {WS OR WS term}
+    ;
+
+# Terms may either be unary or simple expressions.
+#
+# Unary expressions negate the simple expression, either mathematically `-`
+# or logically `NOT`. The negation styles may be used interchangeably.
+#
+# Note, the `NOT` is case-sensitive and must be followed by at least one
+# whitespace (WS).
+#
+# Examples:
+# * logical not     : `NOT (a OR b)`
+# * alternative not : `-file:".java"`
+# * negation        : `-30`
+term
+    : [(NOT WS | MINUS)] simple
+    ;
+
+# Simple expressions may either be a restriction or a nested (composite)
+# expression.
+simple
+    : restriction
+    | composite
+    ;
+
+# Restrictions express a relationship between a comparable value and a
+# single argument. When the restriction only specifies a comparable
+# without an operator, this is a global restriction.
+#
+# Note, restrictions are not whitespace sensitive.
+#
+# Examples:
+# * equality         : `package=com.google`
+# * inequality       : `msg != 'hello'`
+# * greater than     : `1 > 0`
+# * greater or equal : `2.5 >= 2.4`
+# * less than        : `yesterday < request.time`
+# * less or equal    : `experiment.rollout <= cohort(request.user)`
+# * has              : `map:key`
+# * global           : `prod`
+#
+# In addition to the global, equality, and ordering operators, filters
+# also support the has (`:`) operator. The has operator is unique in
+# that it can test for presence or value based on the proto3 type of
+# the `comparable` value. The has operator is useful for validating the
+# structure and contents of complex values.
+restriction
+    : comparable [comparator arg]
+    ;
+
+# Comparable may either be a member or function.
+comparable
+    : member
+    | function
+    ;
+
+# Member expressions are either value or DOT qualified field references.
+#
+# Example: expr.type_map.1.type
+member
+    : value {DOT field}
+    ;
+
+# Function calls may use simple or qualified names with zero or more
+# arguments.
+#
+# All functions declared within the list filter, apart from the special
+# `arguments` function must be provided by the host service.
+#
+# Examples:
+# * regex(m.key, '^.*prod.*$')
+# * math.mem('30mb')
+#
+# Antipattern: simple and qualified function names may include keywords:
+# NOT, AND, OR. It is not recommended that any of these names be used
+# within functions exposed by a service that supports list filters.
+function
+    : name {DOT name} LPAREN [argList] RPAREN
+    ;
+
+# Comparators supported by list filters.
+comparator
+    : LESS_EQUALS      # <=
+    | LESS_THAN        # <
+    | GREATER_EQUALS   # >=
+    | GREATER_THAN     # >
+    | NOT_EQUALS       # !=
+    | EQUALS           # =
+    | HAS              # :
+    ;
+
+# Composite is a parenthesized expression, commonly used to group
+# terms or clarify operator precedence.
+#
+# Example: `(msg.endsWith('world') AND retries < 10)`
+composite
+    : LPAREN expression RPAREN
+    ;
+
+# Value may either be a TEXT or STRING.
+#
+# TEXT is a free-form set of characters without whitespace (WS)
+# or . (DOT) within it. The text may represent a variable, string,
+# number, boolean, or alternative literal value and must be handled
+# in a manner consistent with the service's intention.
+#
+# STRING is a quoted string which may or may not contain a special
+# wildcard `*` character at the beginning or end of the string to
+# indicate a prefix or suffix-based search within a restriction.
+value
+    : TEXT
+    | STRING
+    ;
+
+# Fields may be either a value or a keyword.
+field
+    : value
+    | keyword
+    ;
+
+# Names may either be TEXT or a keyword.
+name
+    : TEXT
+    | keyword
+    ;
+
+argList
+    : arg { COMMA arg}
+    ;
+
+arg
+    : comparable
+    | composite
+    ;
+
+keyword
+    : NOT
+    | AND
+    | OR
+    ;


### PR DESCRIPTION
It is here. Fixes #85.

This is my pass at a filtering AIP that addresses our utter lack of public documentation about this. As such, a bunch of notes about this:

- This is (heavily) adapted from @TristonianJones' internal doc to serve a different audience. With apologies to non-Googlers, [here is the link](https://docs.google.com/document/d/1fdHqUomhzBXlHWe0hYu3rIjsIRLJkabo1Xug9Gm-0ZI/edit#).
- While most AIPs are focused on producers, a large part of the goal for this one is to function as a consumer-facing document as well. The voice and such should still be the same, but this is example heavy so we can point a user at it.
- I worked very hard to keep this AIP short (it is at 167 lines at the moment), but that may have some at the cost of being too terse in a couple of spots, and it might make sense to expand the sections on comparison and `:`.

Some other notes inline.

**Note:** In addition to the normal review requirements, formal assent from @TristonianJones is required to merge this.
