### PR TITLE
Fix reference to requests field

### DIFF
--- a/aip/0233.md
+++ b/aip/0233.md
@@ -82,8 +82,8 @@ message BatchCreateBooksRequest {
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
   or another AIP.
-- The comment above the names field **should** document the maximum number of
-  requests allowed.
+- The comment above the `requests` field **should** document the maximum number
+  of requests allowed.
 
 ### Response message
 


### PR DESCRIPTION
Best guess this came from Get Batch page where `names` was a field.