### PR TITLE
Clarify required fields on Create requests.

### DIFF
--- a/aip/0133.md
+++ b/aip/0133.md
@@ -84,9 +84,9 @@ message CreateBookRequest {
   - The field **should** identify the [resource type][aip-123] of the resource
     being created.
 - The resource field **must** be included and **must** map to the POST body.
-- The request message **must not** contain any other required fields except
-  as allowed in other sections of this AIP , and **should not** contain other
-  optional fields except those described in this or another AIP.
+- The request message **must not** contain any other required fields and
+  **should not** contain other optional fields except those described in this
+  or another AIP.
 
 ### Long-running create
 

--- a/aip/0133.md
+++ b/aip/0133.md
@@ -84,9 +84,9 @@ message CreateBookRequest {
   - The field **should** identify the [resource type][aip-123] of the resource
     being created.
 - The resource field **must** be included and **must** map to the POST body.
-- The request message **must not** contain any other required fields, and
-  **should not** contain other optional fields except those described in this
-  or another AIP.
+- The request message **must not** contain any other required fields except
+  as allowed in other sections of this AIP , and **should not** contain other
+  optional fields except those described in this or another AIP.
 
 ### Long-running create
 


### PR DESCRIPTION
Below in the user-specified ID section, it says that the user-specified ID **MAY** be required. This contradicts the language above which stated that fields outside the body **MUST NOT** be required.

It turns out this can be fixed by removing a comma 😄 