### PR TITLE
[AIP-200] Refactor AIP for style.

### DIFF
--- a/aip/0200.md
+++ b/aip/0200.md
@@ -140,7 +140,7 @@ makes it difficult to follow AIP guidelines.
 ## Changelog
 
 - **2020-03-27**: Reworded much of this AIP to follow [AIP-8][], and remove
-  first and second person.
+  first and second person. No semantic changes.
 - **2019-05-04**: Changed to a public link ([aip.dev/not-precedent]()), and
   changed references to "the style guide" to use the more generic term
   "standards" (to account for a general shift to AIPs).

--- a/aip/0200.md
+++ b/aip/0200.md
@@ -10,7 +10,7 @@ redirect_from:
   - /0200
 ---
 
-# Bad API precedent
+# Precedent
 
 Many times, APIs are written in ways that do not match new guidance that is
 added to these standards after those APIs have already been released.
@@ -21,7 +21,7 @@ concerns. Finally, as carefully as everyone reviews APIs before they are
 released, sometimes mistakes can slip through.
 
 Since it often is not feasible to fix past mistakes or make the standards serve
-every use case, we may be stuck with these exceptions for quite some time.
+every use case, APIs may be stuck with these exceptions for quite some time.
 Further, since new APIs often base their designs (names, types, structures,
 etc) on existing APIs, it is possible that a standards violation in one API
 could spill over into other APIs, even if original reason for the exception is
@@ -58,25 +58,22 @@ message DailyMaintenanceWindow {
 }
 ```
 
-## Additional Guidance
-
-APIs should only be considered to be precedent-setting if they are in beta or
-GA.
-
-## Possible reasons for violating standards
+**Important:** APIs should only be considered to be precedent-setting if they
+are in beta or GA.
 
 ### Local consistency
 
-If your API violates a standard throughout, it would be jarring and frustrating
+If an API violates a standard throughout, it would be jarring and frustrating
 to users to break the existing pattern only for the sake of adhering to the
 global standard.
 
-For example, if all of your resources use `creation_time` (instead of the
-standard field `create_time`), a new resource in your API should continue to
-follow the pattern.
+For example, if all of an API's resources use `creation_time` (instead of the
+standard field `create_time` described in [AIP-142][]), a new resource in that
+API should continue to follow the local pattern.
 
-However, others who might copy your API should be made aware that this is
-contra-standard and not something to cite as precedent when launching new APIs.
+However, others who might otherwise copy that API should be made aware that
+this is contra-standard and not something to cite as precedent when launching
+new APIs.
 
 ```proto
 // ...
@@ -96,49 +93,57 @@ message Author {
 }
 ```
 
-### Already GA (Grandfathered)
+### Grandfathered functionality
 
 Standards violations are sometimes overlooked before launching, resulting in
-APIs that enter the GA stage and therefore can not easily be modified.
-Additionally, a stable API may pre-date a standards requirement. In these
-scenarios, we recognize the difficulty in fixing the problem; however, we want
-to avoid others' copying the mistake and citing the existing API as a reason
-why their design should be approved.
+APIs that become stable and therefore can not easily be modified. Additionally,
+a stable API may pre-date a standards requirement.
+
+In these scenarios, it is difficult to make the API fit the standard. However,
+the API should still cite that the functionality is contra-standard so that
+other APIs do not copy the mistake and cite the existing API as a reason why
+their design should be approved.
 
 ### Adherence to external spec
 
 Occasionally, APIs must violate standards because specific requests are
 implementations of an external specification (for example, OAuth), and their
-specification may be at odds with our style guide. In this case, it is likely
-to be appropriate to follow the external specification.
+specification may be at odds with AIP guidelines. In this case, it is likely to
+be appropriate to follow the external specification.
 
 ### Adherence to existing systems
 
 Similar to the example of an external specification above, it may be proper for
-an API to violate standards to fit in with an existing system in some way. This
-is a fundamentally similar case where it is wise to meet the customer where
-they are. A potential example of this might be integration with or similarity
-to a partner API.
+an API to violate AIP guidelines to fit in with an existing system in some way.
+This is a fundamentally similar case where it is wise to meet the customer
+where they are. A potential example of this might be integration with or
+similarity to a partner API.
 
 ### Expediency
 
-Sometimes we have users who need an API surface by a very hard deadline or
-money walks away. Since we are running a business here, there will be times
-when we recognize the API could be better but cannot get it that way and into
-users' hands before the deadline. In those cases, there are exceptions granted
-to ship APIs that violate standards due to time and business constraints.
+Sometimes there are users who need an API surface by a very hard deadline or
+money walks away. Since most APIs serve a business purpose, there will be times
+when an API could be better but cannot get it that way and into users' hands
+before the deadline. In those cases, API review councils **may** grant
+exceptions to ship APIs that violate guidelines due to time and business
+constraints.
 
 ### Technical concerns
 
-Sometimes our internal systems have very specific implementation needs (e.g.,
-they rely on operation transforms that speak UTF-16, not UTF-8) and adhering to
-standards would require extra work that does not add much value to API
+Internal systems sometimes have very specific implementation needs (e.g., they
+rely on operation transforms that speak UTF-16, not UTF-8) and adhering to AIP
+guidelines would require extra work that does not add significant value to API
 consumers. Future systems which are likely to expose an API at some point
 should bear this in mind to avoid building underlying infrastructure which
-makes it hard to follow standards.
+makes it difficult to follow AIP guidelines.
 
 ## Changelog
 
+- **2020-03-27**: Reworded much of this AIP to follow [AIP-8][], and remove
+  first and second person.
 - **2019-05-04**: Changed to a public link ([aip.dev/not-precedent]()), and
   changed references to "the style guide" to use the more generic term
   "standards" (to account for a general shift to AIPs).
+
+[aip-8]: ./0008.md
+[aip-142]: ./0142.md


### PR DESCRIPTION
Amusingly, our precedent AIP does not conform to AIP style. 😛

This PR removes first and second person language that was used throughout (which we generally do not use in AIPs) and refactors headings to conform to [AIP-8](https://aip.dev/8).

No actual guidance changes.