### PR TITLE
[AIP-192] Require absolute URLs for external links

### DIFF
--- a/aip/0192.md
+++ b/aip/0192.md
@@ -95,8 +95,9 @@ Markdown reference link. For example: `[Book][google.example.v1.Book]`
 
 Comments **may** link to external pages to provide background information
 beyond what is described in the public comments themselves. External links
-**must** use absolute (rather than relative) URLs, including the protocol (usually `https`), and **should not** assume the
-documentation is located on any particular host. For example:
+**must** use absolute (rather than relative) URLs, including the protocol
+(usually `https`), and **should not** assume the documentation is located on
+any particular host. For example:
 `[Spanner Documentation](https://cloud.google.com/spanner/docs)`
 
 ### Trademarked names

--- a/aip/0192.md
+++ b/aip/0192.md
@@ -95,7 +95,7 @@ Markdown reference link. For example: `[Book][google.example.v1.Book]`
 
 Comments **may** link to external pages to provide background information
 beyond what is described in the public comments themselves. External links
-**must** use absolute (rather than relative) URLs, and should not assume the
+**must** use absolute (rather than relative) URLs, including the protocol (usually `https`), and **should not** assume the
 documentation is located on any particular host. For example:
 `[Spanner Documentation](https://cloud.google.com/spanner/docs)`
 

--- a/aip/0192.md
+++ b/aip/0192.md
@@ -91,6 +91,14 @@ Comments **may** "link" to another component (service, method, message, field,
 enum, or enum value) by using the fully-qualified name of the element as a
 Markdown reference link. For example: `[Book][google.example.v1.Book]`
 
+### External links
+
+Comments **may** link to external pages to provide background information
+beyond what is described in the public comments themselves. External links
+**must** use absolute (rather than relative) URLs, and should not assume the
+documentation is located on any particular host. For example:
+`[Spanner Documentation](https://cloud.google.com/spanner/docs)`
+
 ### Trademarked names
 
 When referring to the proper, trademarked names of companies or products in
@@ -121,6 +129,7 @@ of inadvertent omissions of the internal content annotation.
 
 ## Changelog
 
+- **2020-04-01**: Added guidance requiring absolute URLs for external links.
 - **2020-02-14**: Added guidance around the use of trademarked names.
 - **2019-09-23**: Added guidance about not using both leading and trailing
   comments.


### PR DESCRIPTION
Relative links in documentation cause problems because the rendered documentation may be hosted on a different site. Adding this section because I've seen a large number of relative links in existing documentation, and it is not even consistent what host they assume (some assume cloud.google.com while others assume developers.google.com).

Fixes #443.