### PR TITLE
[AIP-159] Explicitly use the words hyphen and dash.

### DIFF
--- a/aip/0159.md
+++ b/aip/0159.md
@@ -17,8 +17,8 @@ what collection it is in.
 ## Guidance
 
 APIs **may** support reading resources across multiple collections by allowing
-users to specify a `-` as a wildcard character in a standard [`List`][aip-132]
-method:
+users to specify a `-` (the hyphen or dash character) as a wildcard character
+in a standard [`List`][aip-132] method:
 
 ```
 GET /v1/publishers/-/books?filter=...
@@ -50,8 +50,8 @@ Sometimes, a resource within a sub-collection has an identifier that is unique
 across parent collections. In this case, it may be useful to allow a
 [`Get`][aip-131] method to retrieve that resource without knowing which parent
 collection contains it. In such cases, APIs **may** allow users to specify the
-wildcard collection ID `-` for all parent collections within which the resource
-is unique:
+wildcard collection ID `-` (the hyphen or dash character) to represent any
+parent collection:
 
 ```
 GET https://example.googleapis.com/v1/publishers/-/books/{book}
@@ -65,6 +65,7 @@ GET https://example.googleapis.com/v1/publishers/-/books/{book}
   resource, with actual parent collection identifiers (instead of `-`). For
   example, the request above returns a resource with a name like
   `publishers/123/books/456`, _not_ `publishers/-/books/456`.
+- The resource ID **must** be unique within parent collections.
 
 ## Further reading
 


### PR DESCRIPTION
This makes a search for "hyphen" or "dash" make the AIP show up.