### PR TITLE
[AIP-122] Tighten the restriction on resource name characters.

### DIFF
--- a/aip/0122.md
+++ b/aip/0122.md
@@ -37,10 +37,13 @@ the leading slash:
     character.
   - The terminal segment of a resource name **should not** contain a `/`
     character.
-- Resource names **should** only use ASCII characters that do not require
-  URL-escaping when possible.
-  - If Unicode characters must be used, resource names **must** be stored in
-    Normalization Form C (see [AIP-210][]).
+- Resource names **should** only use characters available in DNS names, as
+  defined by [RFC-1123](https://tools.ietf.org/html/rfc1123).
+  - Additionally, resource names **should not** use upper-case letters.
+  - If additional characters are necessary, resource names **should not** use
+    characters that require URL-escaping, or characters outside of ASCII.
+  - If Unicode characters can not be avoided, resource names **must** be stored
+    in Normalization Form C (see [AIP-210][]).
 
 **Note:** Resource names as described here are used within the scope of a
 single API (or else in situations where the owning API is clear from the
@@ -297,6 +300,7 @@ strictly necessary, use an `_id` suffix (e.g. `shelf_id`).
 
 ## Changelog
 
+- **2020-04-27**: Tighten the restriction on valid characters.
 - **2019-12-05**: Added guidance for resource annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership. Also changed the final


### PR DESCRIPTION
This remains at "should" level, but it tightens the guidance on
characters to use in resource names, effectively to lower-case
letters, numbers, and hyphen.

This is intended to help teams avoid common traps, including
case issues, URL-escaping, etc.