### PR TITLE
adding RAML

### DIFF
--- a/aip/0131.md
+++ b/aip/0131.md
@@ -85,6 +85,36 @@ paths:
   - The variable for the resource ID **must** be named `id`. Variables
     representing the ID of parent resources **must** end with `Id`.
 
+#### RAML
+
+Single-resource `GET` methods **must** be specified in accordance with the
+following RAML spec.
+
+```yaml
+/publishers/{publisherId}/books/{bookId}:
+  uriParameters:
+    publisherId:
+      description: |
+        The unique identifier provided by the system for this publisher.
+    bookId:
+      description: |
+        The unique identifier provided by the system for this book.
+  get:
+    displayName: getBook
+    description: Get a single book.
+    responses:
+      200:
+        description: OK
+        body:
+          application/json:
+            type: Book
+```
+
+- The `displayName` **must** begin with the word `get` followed by the singular
+  form of the resource type's name.
+- The response content **must** be the resource itself.
+- The URI **must** contain a variable for each ID in the resource hierarchy.
+
 #### Protocol buffers
 
 Single-resource `GET` methods **must** be specified using the following


### PR DESCRIPTION
Really simple RAML example.

I think the value of RAML will actually become more apparent if there are RAML fragments created to support the AIPs. Then instead of providing examples written in RAML, the examples would show how to use existing RAML fragments to create a complete example or request.

Below is an example using book but based on an actual endpoint from my day job:

```
/{bookId}:
    uriParameters:
      assetId:
        required: true
        displayName: bookId
        description: The id of the book
        type: string
        example: "les-miserables"
    get:
      displayName: getBook
      description: Retrive book with given ID.
      is:
        - ApiStandards.RateLimited4:
            responseStatus: 200
            responseStatus2: 500   
            responseStatus3: 404   
            responseStatus4: 401   
        - AssetManagementTraits.InternalServerError 
        - AssetManagementTraits.UnAuthorized
      securedBy:
        - ApiStandards.BearerToken
        - ApiStandards.AmOAuth2
      responses:
        200:
          description: OK
          headers:
            Content-Type:
              default: application/json
              displayName: Content-Type
              type: string
          body:
            application/json:
              displayName: response
              description: OK
              type: book
```

Unfortunately, I am still more familiar with OAS than I am with RAML. However, I believe this example could be be further broken down with reusable headers, and responses, etc.