### PR TITLE
[AIP-132] Remove requirement to document ordering.

### DIFF
--- a/aip/0132.md
+++ b/aip/0132.md
@@ -49,8 +49,6 @@ rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
   - The collection identifier (`books` in the above example) **must** be a
     literal string.
 - The `body` key in the `google.api.http` annotation **must** be omitted.
-- The method **must** document the default ordering, if one exists, or **must**
-  explicitly document that the ordering behavior is unspecified.
 - There **should** be exactly one `google.api.method_signature` annotation,
   with a value of `"parent"`.
 

--- a/aip/0132.md
+++ b/aip/0132.md
@@ -188,6 +188,7 @@ soft-deleted resources to be included.
 
 ## Changelog
 
+- **2020-05-19**: Removed requirement to document ordering behavior.
 - **2019-10-18**: Added guidance on annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.


### PR DESCRIPTION
I originally planned to add an example as the person who posted #506 suggested, but it turns out that _literally nobody_ documents this. As best as I can tell, this has never been a problem for anyone, and therefore I believe we should just remove the requirement.

Fixes #506.