### PR TITLE
Adds "get" guidance for soft-delete.

### DIFF
--- a/aip/0135.md
+++ b/aip/0135.md
@@ -96,7 +96,8 @@ resource (not `google.protobuf.Empty`), with its [state][aip-216] set to
 `DELETED`.
 
 Soft-deleted resources **should not** show up in [list][aip-132] requests by
-default (unless `bool show_deleted` is true).
+default (unless `bool show_deleted` is true). Soft-deleted resources **should**
+show up in [get][aip-131] requests by default.
 
 The undelete functionality **should** be implemented through an "undelete"
 [custom method][aip-136].
@@ -191,6 +192,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 [aip-121]: ./0121.md
 [aip-123]: ./0123.md
+[aip-131]: ./0131.md
 [aip-132]: ./0132.md
 [aip-136]: ./0136.md
 [aip-214]: ./0214.md
@@ -199,6 +201,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Changelog
 
+- **2020-06-08**: Added guidance for "get" of soft-deleted resources.
 - **2020-02-03**: Added guidance for error cases.
 - **2019-10-18**: Added guidance on annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -95,7 +95,7 @@ system. If the method behaves this way, it **should** return the updated
 resource (not `google.protobuf.Empty`), with its [state][aip-216] set to
 `DELETED`.
 
-Soft-deleted resources **should not** show up in [list][aip-132] requests by
+Soft-deleted resources **should not** show up in [`List`][aip-132] requests by
 default (unless `bool show_deleted` is true). Soft-deleted resources **should**
 show up in [get][aip-131] requests by default.
 

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -96,8 +96,9 @@ resource (not `google.protobuf.Empty`), with its [state][aip-216] set to
 `DELETED`.
 
 Soft-deleted resources **should not** show up in [`List`][aip-132] requests by
-default (unless `bool show_deleted` is true). Soft-deleted resources **should**
-show up in [get][aip-131] requests by default.
+default (unless `bool show_deleted` is true). [`Get`][aip-131] requests for
+soft-deleted resources **should** return the resource (rather than a
+`NOT_FOUND` error).
 
 The undelete functionality **should** be implemented through an "undelete"
 [custom method][aip-136].

--- a/aip/0135.md
+++ b/aip/0135.md
@@ -202,7 +202,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Changelog
 
-- **2020-06-08**: Added guidance for "get" of soft-deleted resources.
+- **2020-06-08**: Added guidance for `Get` of soft-deleted resources.
 - **2020-02-03**: Added guidance for error cases.
 - **2019-10-18**: Added guidance on annotations.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to


### PR DESCRIPTION
I'm assuming that the desired behavior is that a `get` should return a soft-deleted resource (with the appropriate state) but it's not clear from the AIP and it seems worth making explicit.