### PR TITLE
[AIP-200] Improve not-precedent "consistency" case

### DIFF
--- a/aip/0200.md
+++ b/aip/0200.md
@@ -86,9 +86,9 @@ message Book {
 
 // ...
 message Author {
-  // (-- aip.dev/not-precedent: This field was present before there was a
-  //     standard field.
-  //     Ordinarily, it should be spelled `create_time`. --)
+  // (-- aip.dev/not-precedent: `Book` had `creation_time` before there was
+  //     a standard field, so we match that here for consistency. Ordinarily,
+  //     this would be spelled `create_time`. --)
   google.protobuf.Timestamp creation_time = 1;
 }
 ```


### PR DESCRIPTION
Book.creation_time and Author.creation_time currently have identical
messages "This field was present before there was a standard field".
That's certainly not "wrong", but it's preferable to explain
"I'm doing this again to be *consistent* with <X>".

I chose to place a "This doesn't follow the standard because
Book.creation_time didn't" on Author. I figured it's more likely
someone would have perhaps ignored create_time for an Author but would
have used one for Books (as if it were a published date).