### PR TITLE
[AIP-4110] Initial AIP for google auth libraries.

### DIFF
--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -1,0 +1,153 @@
+---
+aip:
+  id: 4110
+  scope: auth
+  state: approved
+  created: 2018-06-24
+  updated: 2019-06-24
+permalink: /auth/4110
+redirect_from:
+  - /4110
+---
+
+# Application Default Credentials
+
+Google auth libraries use a strategy called _Application Default Credentials
+(ADC)_ to detect and select credentials based on environment or context. With 
+ADC, developers should be able to run the code in different environments and the
+supporting systems fetch the appropriate credentials based on each environment
+in an effortless manner.
+
+Auth libraries following the standards in these AIPs are known as _"Google
+Unified Auth Clients"_, or _GUAC_ for short. The resulting libraries are
+colloquially called _GUACs_.
+
+**Note:** Because this AIP describes guidance and requirements in a
+language-neutral way, it uses generic terminology which may be imprecise or
+inappropriate in certain languages or environments.
+
+## Guidance
+
+### Credential Types
+
+This section outlines the supported credential types of the ADC.
+
+#### GCloud CLI Credential
+
+A credential provided by the [GCloud CLI][0] that identifies a human user that
+needs to authenticate to access Google APIs. The auth libraries **must** support
+this credential type.
+
+#### Service Account Key
+
+A credential that identifies a non-human user that needs to authenticate to
+aceess Google APIs. The auth libraries **must** support this
+credential type.
+
+#### OAuth Client ID
+
+A credential that identifies the client application which allows human users to
+sign-in through [3-legged OAuth flow][1], which grants the permissions to the
+application to access Google APIs on behave of the human user. The auth
+libraries **may** support this credential type.
+
+### Environment Variables
+
+The auth libraries **must** support the following environment variables to allow
+developers to provide authentication configuration for their application:
+
+#### GOOGLE\_APPLICATION\_CREDENTIALS
+
+The specified value will be used as the full path for ADC to locate the
+credentials file. The credentials file **should** be one of the following types:
+
+- Service account key
+- GCloud CLI credentials
+
+The credentials __may__ be the OAuth Client ID if it is supported by the auth
+library.
+
+This value __must__ be overridden by any user specified credentials at the
+programming level (e.g. through clien-level options)
+
+#### GOOGLE\_API\_KEY
+
+[API keys][2] are a simple encrypted string that identifies an application,
+which are useful for accessing public data anonymously. The specified value of
+this environment variable **should** be used as the API key for the API
+requests.
+
+This value **must** be overridden by any user specified credentials at the
+programming level (e.g. through client options)
+
+**Note:** This value **must** be ignored if GOOGLE\_APPLICATION\_CREDENTIALS is
+specified.
+
+#### GOOGLE\_API\_USE\_CLIENT\_CERTIFICATE
+
+The specified value **must** be either true or false. The client certificate
+**must** be ignored if this variable is set to false.
+
+### Inputs & Outputs
+
+From the input/output perspective, the inputs of _ADC_ __should__ be the
+credentials as well as the underlying environment that provides these
+credentials. 
+
+For example, the _GOOGLE_APPLICATION_CREDENTIALS_ environment variable can provide the
+default credential JSON as the input here, or the well-known path that gCloud
+uses to store the default user credential JSON. The output is the access token
+that application can use to access the Google APIs. This access token __may__ be
+a bearer token, a certificate bound token or STS depending on the chosen
+authentication flow.
+
+## Expected Behavior
+
+This section outlines the expected behavior of the ADC. Auth libraries **must**
+implement these concepts in order to be considered complete.
+
+1. **Check environment variables**
+    1. Check GOOGLE\_APPLICATION\_CREDENTIALS
+        1. If set, go to step (2.2)
+    2. Check GOOGLE\_API\_KEY
+        1. If set, use the provided API key _[END]_
+    3. If neither of above is set, go to step (2)
+2. **Load credentials**
+    1. Check gCloud default credentials through its default path
+        1. If found go to step (2.2)
+        2. Otherwise go to step (3)
+    2. Check the provided credential type
+        1. If the credential is gCloud CLI credentials, go to step (4)
+        2. If the credential is a service account key JSON, go to step (4)
+        3. If the credential is unknown type, go to step (2.4)
+    3. Credentials not found _[END]_
+3. **Check VM environment**
+    1. If true, use the VM metadata service flow to get an access token
+    associated with the current VM _[END]_
+    2. If false, go to step (2.3)
+4. **Determine auth flows**
+    1. If the credential is gCloud CLI credential go to step (5.3)
+    2. If scope is provided by the developer go to step (5.1)
+    3. Otherwise, go to step (5.2)
+5. **Execute auth flows**
+    1. Use 2LO flow to exchange for an access token
+        1. If client certificate is presented, the exchanged token will be a
+        certificate bind token and then go to step (6)
+    2. Use self-signed JWT flow to create an access token locally.
+        1. If certificate is presented, embed the certificate into the JWT and
+        then go to step (6). 
+        2. Otherwise, use the regular self-signed JWT flow and then go to step
+        (6)
+    3. Use user identity flow to exchange for an access token and then go to
+    step (6)
+6. **Check if STS is needed**
+    1. If the given TLD is not a googleapis.com domain and extra system
+    parameters are provided (e.g. quota project override), call STS to exchange
+    for a STS token. (a.k.a. UAT). _[END]_
+    2. Otherwise, use the access token directly. _[END]_
+
+<!-- prettier-ignore-start -->
+[0]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
+[1]: https://developers.google.com/identity/protocols/oauth2/native-app
+[2]: https://cloud.google.com/docs/authentication/api-keys
+<!-- prettier-ignore-end -->

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -90,7 +90,7 @@ or metadata service that provides these credentials.
 For example, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable can provide
 the default credential JSON as the input here, or the well-known path that
 gCloud uses to store the default user credential JSON. The output is the access
-tokem that application can use to access the Google APIs. This access token
+token that application can use to access the Google APIs. This access token
 __may__ be a bearer token, a certificate bound token or STS depending on the
 chosen authentication flow.
 

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -36,7 +36,7 @@ inappropriate in certain languages or environments.
 
 This section outlines the supported credential types of the ADC.
 
-- **Gcloud CLI Credential**: A credential provided by the [Gcloud CLI][0] that
+- **Gcloud Credential**: A credential provided by the [Gcloud tool][0] that
 identifies a human user that needs to authenticate to access Google APIs. The
 auth libraries **must** support this credential type.
 
@@ -59,7 +59,7 @@ full path for ADC to locate the credentials file. The credentials file
 **should** be one of the following types:
 
     - Service account key
-    - Gcloud CLI credentials
+    - Gcloud credentials
 
     The credentials **may** be the OAuth Client ID if it is supported by the
     auth library. This value **must** be overridden by any user specified
@@ -129,7 +129,7 @@ digraph d_front_back {
         1. If found go to step (2.2)
         2. Otherwise go to step (3)
     2. Check the provided credential type
-        1. If the credential is gcloud CLI credentials, go to step (4)
+        1. If the credential is gcloud credentials, go to step (4)
         2. If the credential is a service account key JSON, go to step (4)
         3. If the credential is unknown type, return an error saying that _[END]_
     3. Credentials not found _[END]_
@@ -138,7 +138,7 @@ digraph d_front_back {
     associated with the current environment _[END]_
     2. If false, go to step (2.3)
 4. **Determine auth flows**
-    1. If the credential is gcloud CLI credential go to step (5.3)
+    1. If the credential is gcloud credential go to step (5.3)
     2. If scope is provided by the developer go to step (5.1)
     3. Otherwise, go to step (5.2)
 5. **Execute auth flows**

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -2,9 +2,13 @@
 aip:
   id: 4110
   scope: auth
-  state: approved
+  state: reviewing
   created: 2018-06-24
   updated: 2019-06-24
+js:
+  - /assets/js/graphviz/viz.js
+  - /assets/js/graphviz/lite.render.js
+  - /assets/js/aip/aip-graphviz.js
 permalink: /auth/4110
 redirect_from:
   - /4110
@@ -32,61 +36,46 @@ inappropriate in certain languages or environments.
 
 This section outlines the supported credential types of the ADC.
 
-#### GCloud CLI Credential
+- **GCloud CLI Credential**: A credential provided by the [GCloud CLI][0] that
+identifies a human user that needs to authenticate to access Google APIs. The
+auth libraries **must** support this credential type.
 
-A credential provided by the [GCloud CLI][0] that identifies a human user that
-needs to authenticate to access Google APIs. The auth libraries **must** support
+- **Service Account Key**: A credential that identifies a non-human user that
+needs to authenticate to aceess Google APIs. The auth libraries **must** support
 this credential type.
 
-#### Service Account Key
-
-A credential that identifies a non-human user that needs to authenticate to
-aceess Google APIs. The auth libraries **must** support this
-credential type.
-
-#### OAuth Client ID
-
-A credential that identifies the client application which allows human users to
-sign-in through [3-legged OAuth flow][1], which grants the permissions to the
-application to access Google APIs on behave of the human user. The auth
-libraries **may** support this credential type.
+- **OAuth Client ID**: A credential that identifies the client application which
+allows human users to sign-in through [3-legged OAuth flow][1], which grants the
+permissions to the application to access Google APIs on behave of the human
+user. The auth libraries **may** support this credential type.
 
 ### Environment Variables
 
 The auth libraries **must** support the following environment variables to allow
 developers to provide authentication configuration for their application:
 
-#### GOOGLE\_APPLICATION\_CREDENTIALS
+- **GOOGLE_APPLICATION_CREDENTIALS**: The specified value will be used as the
+full path for ADC to locate the credentials file. The credentials file
+**should** be one of the following types:
 
-The specified value will be used as the full path for ADC to locate the
-credentials file. The credentials file **should** be one of the following types:
+    - Service account key
+    - GCloud CLI credentials
 
-- Service account key
-- GCloud CLI credentials
+    The credentials **may** be the OAuth Client ID if it is supported by the
+    auth library. This value __must__ be overridden by any user specified
+    credentials at the programming level (e.g. through clien-level options)
 
-The credentials __may__ be the OAuth Client ID if it is supported by the auth
-library.
-
-This value __must__ be overridden by any user specified credentials at the
-programming level (e.g. through clien-level options)
-
-#### GOOGLE\_API\_KEY
-
-[API keys][2] are a simple encrypted string that identifies an application,
-which are useful for accessing public data anonymously. The specified value of
-this environment variable **should** be used as the API key for the API
-requests.
-
-This value **must** be overridden by any user specified credentials at the
-programming level (e.g. through client options)
-
-**Note:** This value **must** be ignored if GOOGLE\_APPLICATION\_CREDENTIALS is
+- **GOOGLE_API_KEY**: [API keys][2] are a simple encrypted string that
+identifies an application, which are useful for accessing public data
+anonymously. The specified value of this environment variable **should** be used
+as the API key for the API requests. This value **must** be overridden by any
+user specified credentials at the programming level (e.g. through client
+options). And it **must** be ignored if GOOGLE_APPLICATION_CREDENTIALS is
 specified.
 
-#### GOOGLE\_API\_USE\_CLIENT\_CERTIFICATE
-
-The specified value **must** be either true or false. The client certificate
-**must** be ignored if this variable is set to false.
+- **GOOGLE_API_USE_CLIENT_CERTIFICATE:** The specified value **must** be
+either true or false. The client certificate **must** be ignored if this
+variable is set to false.
 
 ### Inputs & Outputs
 
@@ -94,22 +83,41 @@ From the input/output perspective, the inputs of _ADC_ __should__ be the
 credentials as well as the underlying environment that provides these
 credentials. 
 
-For example, the _GOOGLE_APPLICATION_CREDENTIALS_ environment variable can provide the
-default credential JSON as the input here, or the well-known path that gCloud
-uses to store the default user credential JSON. The output is the access token
-that application can use to access the Google APIs. This access token __may__ be
-a bearer token, a certificate bound token or STS depending on the chosen
-authentication flow.
+For example, the _GOOGLE_APPLICATION_CREDENTIALS_ environment variable can provide
+the default credential JSON as the input here, or the well-known path that
+gCloud uses to store the default user credential JSON. The output is the access
+tokem that application can use to access the Google APIs. This access token
+__may__ be a bearer token, a certificate bound token or STS depending on the
+chosen authentication flow.
 
 ## Expected Behavior
 
 This section outlines the expected behavior of the ADC. Auth libraries **must**
 implement these concepts in order to be considered complete.
 
+```graphviz
+digraph d_front_back {
+  rankdir=TB;
+  ranksep=0.3;
+  node [ style="filled,solid" shape=box fontname="Roboto" ];
+
+  check_env_var [ label="1. Check Environment Variables" ];
+  load_credentials [ label="2. Load Credentials" ];
+  check_vm_env [ label="3. Check VM Default Credentials" ];
+  auth_flows [ label="4. Determine Auth Flows" ];
+  execute [ label="5. Execute Auth Flows" ];
+  sts [ label="6. Apply STS" ];
+
+  check_env_var -> load_credentials -> check_vm_env ->auth_flows -> execute ->
+  sts;
+  load_credentials -> auth_flows;
+}
+```
+
 1. **Check environment variables**
-    1. Check GOOGLE\_APPLICATION\_CREDENTIALS
+    1. Check GOOGLE_APPLICATION_CREDENTIALS
         1. If set, go to step (2.2)
-    2. Check GOOGLE\_API\_KEY
+    2. Check GOOGLE_API_KEY
         1. If set, use the provided API key _[END]_
     3. If neither of above is set, go to step (2)
 2. **Load credentials**
@@ -121,7 +129,7 @@ implement these concepts in order to be considered complete.
         2. If the credential is a service account key JSON, go to step (4)
         3. If the credential is unknown type, go to step (2.4)
     3. Credentials not found _[END]_
-3. **Check VM environment**
+3. **Check VM default credentials**
     1. If true, use the VM metadata service flow to get an access token
     associated with the current VM _[END]_
     2. If false, go to step (2.3)

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -74,8 +74,12 @@ options). And it **must** be ignored if GOOGLE_APPLICATION_CREDENTIALS is
 specified.
 
 - **GOOGLE_API_USE_CLIENT_CERTIFICATE:** The specified value **must** be
-either 0 or 1. The client certificate **must** be ignored if this variable is
-set to 0.
+either true or false. The client certificate **must** be ignored if this
+variable is set to false. The default is true if the value is unset.
+
+```
+GOOGLE_API_USE_CLIENT_CERTIFICATE=[true|false]
+```
 
 ### Inputs & Outputs
 

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -75,7 +75,7 @@ specified.
 
 - **GOOGLE_API_USE_CLIENT_CERTIFICATE:** The specified value **must** be
 either true or false. The client certificate **must** be ignored if this
-variable is set to false. The default is true if the value is unset.
+variable is set to false. The default value is false if the value is unset.
 
 ```
 GOOGLE_API_USE_CLIENT_CERTIFICATE=[true|false]

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -61,9 +61,9 @@ full path for ADC to locate the credentials file. The credentials file
     - Service account key
     - Gcloud CLI credentials
 
-The credentials **may** be the OAuth Client ID if it is supported by the auth
-library. This value **must** be overridden by any user specified credentials at
-the programming level (e.g. through client-level options)
+    The credentials **may** be the OAuth Client ID if it is supported by the
+    auth library. This value **must** be overridden by any user specified
+    credentials at the programming level (e.g. through client-level options)
 
 - **GOOGLE_API_KEY**: [API keys][2] are a simple encrypted string that
 identifies an application, which are useful for accessing public data

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -61,9 +61,9 @@ full path for ADC to locate the credentials file. The credentials file
     - Service account key
     - Gcloud CLI credentials
 
-    The credentials **may** be the OAuth Client ID if it is supported by the
-    auth library. This value **must** be overridden by any user specified
-    credentials at the programming level (e.g. through clien-level options)
+The credentials **may** be the OAuth Client ID if it is supported by the auth
+library. This value **must** be overridden by any user specified credentials at
+the programming level (e.g. through client-level options)
 
 - **GOOGLE_API_KEY**: [API keys][2] are a simple encrypted string that
 identifies an application, which are useful for accessing public data

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -41,12 +41,12 @@ identifies a human user that needs to authenticate to access Google APIs. The
 auth libraries **must** support this credential type.
 
 - **Service Account Key**: A credential that identifies a non-human user that
-needs to authenticate to aceess Google APIs. The auth libraries **must** support
+needs to authenticate to access Google APIs. The auth libraries **must** support
 this credential type.
 
 - **OAuth Client ID**: A credential that identifies the client application which
 allows human users to sign-in through [3-legged OAuth flow][1], which grants the
-permissions to the application to access Google APIs on behave of the human
+permissions to the application to access Google APIs on behalf of the human
 user. The auth libraries **may** support this credential type.
 
 ### Environment Variables
@@ -58,12 +58,13 @@ developers to provide authentication configuration for their application:
 full path for ADC to locate the credentials file. The credentials file
 **should** be one of the following types:
 
-    - Service account key
     - Gcloud credentials
+    - Service account key
 
     The credentials **may** be the OAuth Client ID if it is supported by the
-    auth library. This value **must** be overridden by any user specified
-    credentials at the programming level (e.g. through client-level options)
+    auth library. Credentials file path specified at the program level (e.g. via
+    client options) **must** have priority over the value of this environment
+    variable.
 
 - **GOOGLE_API_KEY**: [API keys][2] are a simple encrypted string that
 identifies an application, which are useful for accessing public data

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -84,8 +84,8 @@ GOOGLE_API_USE_CLIENT_CERTIFICATE=[true|false]
 ### Inputs & Outputs
 
 From the input/output perspective, the inputs of _ADC_ **should** be the
-credentials as well as the underlying environment that provides these
-credentials. 
+credentials as well as the underlying environment such as environment variables
+or metadata service that provides these credentials. 
 
 For example, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable can provide
 the default credential JSON as the input here, or the well-known path that

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -36,7 +36,7 @@ inappropriate in certain languages or environments.
 
 This section outlines the supported credential types of the ADC.
 
-- **GCloud CLI Credential**: A credential provided by the [GCloud CLI][0] that
+- **Gcloud CLI Credential**: A credential provided by the [Gcloud CLI][0] that
 identifies a human user that needs to authenticate to access Google APIs. The
 auth libraries **must** support this credential type.
 
@@ -59,10 +59,10 @@ full path for ADC to locate the credentials file. The credentials file
 **should** be one of the following types:
 
     - Service account key
-    - GCloud CLI credentials
+    - Gcloud CLI credentials
 
     The credentials **may** be the OAuth Client ID if it is supported by the
-    auth library. This value __must__ be overridden by any user specified
+    auth library. This value **must** be overridden by any user specified
     credentials at the programming level (e.g. through clien-level options)
 
 - **GOOGLE_API_KEY**: [API keys][2] are a simple encrypted string that
@@ -79,11 +79,11 @@ variable is set to false.
 
 ### Inputs & Outputs
 
-From the input/output perspective, the inputs of _ADC_ __should__ be the
+From the input/output perspective, the inputs of _ADC_ **should** be the
 credentials as well as the underlying environment that provides these
 credentials. 
 
-For example, the _GOOGLE_APPLICATION_CREDENTIALS_ environment variable can provide
+For example, the `GOOGLE_APPLICATION_CREDENTIALS` environment variable can provide
 the default credential JSON as the input here, or the well-known path that
 gCloud uses to store the default user credential JSON. The output is the access
 tokem that application can use to access the Google APIs. This access token
@@ -103,12 +103,12 @@ digraph d_front_back {
 
   check_env_var [ label="1. Check Environment Variables" ];
   load_credentials [ label="2. Load Credentials" ];
-  check_vm_env [ label="3. Check VM Default Credentials" ];
+  check_metadata [ label="3. Check Metadata Service Credentials" ];
   auth_flows [ label="4. Determine Auth Flows" ];
   execute [ label="5. Execute Auth Flows" ];
   sts [ label="6. Apply STS" ];
 
-  check_env_var -> load_credentials -> check_vm_env ->auth_flows -> execute ->
+  check_env_var -> load_credentials -> check_metadata ->auth_flows -> execute ->
   sts;
   load_credentials -> auth_flows;
 }
@@ -121,20 +121,20 @@ digraph d_front_back {
         1. If set, use the provided API key _[END]_
     3. If neither of above is set, go to step (2)
 2. **Load credentials**
-    1. Check gCloud default credentials through its default path
+    1. Check gcloud default credentials through its default path
         1. If found go to step (2.2)
         2. Otherwise go to step (3)
     2. Check the provided credential type
-        1. If the credential is gCloud CLI credentials, go to step (4)
+        1. If the credential is gcloud CLI credentials, go to step (4)
         2. If the credential is a service account key JSON, go to step (4)
-        3. If the credential is unknown type, go to step (2.4)
+        3. If the credential is unknown type, return an error saying that _[END]_
     3. Credentials not found _[END]_
-3. **Check VM default credentials**
-    1. If true, use the VM metadata service flow to get an access token
-    associated with the current VM _[END]_
+3. **Check Metadata Service Credentials**
+    1. If true, use the metadata service flow to get an access token
+    associated with the current environment _[END]_
     2. If false, go to step (2.3)
 4. **Determine auth flows**
-    1. If the credential is gCloud CLI credential go to step (5.3)
+    1. If the credential is gcloud CLI credential go to step (5.3)
     2. If scope is provided by the developer go to step (5.1)
     3. Otherwise, go to step (5.2)
 5. **Execute auth flows**

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -74,8 +74,8 @@ options). And it **must** be ignored if GOOGLE_APPLICATION_CREDENTIALS is
 specified.
 
 - **GOOGLE_API_USE_CLIENT_CERTIFICATE:** The specified value **must** be
-either true or false. The client certificate **must** be ignored if this
-variable is set to false.
+either 0 or 1. The client certificate **must** be ignored if this variable is
+set to 0.
 
 ### Inputs & Outputs
 


### PR DESCRIPTION
Added initial AIP for google auth libraries, which is the overview AIP for application default credentials (ADC).

Follow up AIPs will be added in later PRs.

cc: @andyrzhao @yaoliugg