### PR TITLE
AIP-4232: Add caveat for supporting RPC types

### DIFF
--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -4,7 +4,7 @@ aip:
   scope: client-libraries
   state: approved
   created: 2018-06-22
-  updated: 2019-09-27
+  updated: 2020-07-14
 permalink: /client-libraries/4232
 redirect_from:
   - /4232
@@ -43,6 +43,14 @@ of the following strategies would be permissible:
 
 In all of these situations, the requirement that the request object is always
 accepted still applies.
+
+Furthermore, client library generators **may** also choose to support this
+functionality for a subset of RPC types, those being:
+
+- Unary
+- Server Streaming
+- Client Streaming
+- Bi-directional Streaming
 
 ### Method Signatures
 
@@ -106,6 +114,7 @@ code.
 
 ## Changelog
 
+- **2020-07-14**: Added caveat for supporting some RPC types
 - **2019-09-27**: Added a Compatibility section.
 
 <!-- prettier-ignore-start -->

--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -44,7 +44,7 @@ of the following strategies would be permissible:
 In all of these situations, the requirement that the request object is always
 accepted still applies.
 
-Furthermore, client library generators **may** also choose to support this
+Furthermore, client library generators **may** choose to support this
 functionality for a subset of RPC types, those being:
 
 - Unary


### PR DESCRIPTION
This adds a caveat that indicates generators may choose to support method_signatures for a subset of RPC types.