### PR TITLE
Update 0200.md; Fixes #547

### DIFF
--- a/aip/0200.md
+++ b/aip/0200.md
@@ -93,7 +93,7 @@ message Author {
 }
 ```
 
-### Grandfathered functionality
+### Previously approved functionality
 
 Standards violations are sometimes overlooked before launching, resulting in
 APIs that become stable and therefore can not easily be modified. Additionally,

--- a/aip/0200.md
+++ b/aip/0200.md
@@ -93,7 +93,7 @@ message Author {
 }
 ```
 
-### Previously approved functionality
+### Pre-existing functionality
 
 Standards violations are sometimes overlooked before launching, resulting in
 APIs that become stable and therefore can not easily be modified. Additionally,


### PR DESCRIPTION
Remove 'Grandfathered' and replace with 'Previously approved'. This removes an American idiom to enhance clarity. It also removes a potentially sensitive term.

Fixes #547.