### PR TITLE
fix: Correct AIP-160 EBNF grammar link.

### DIFF
--- a/aip/general/0160.md
+++ b/aip/general/0160.md
@@ -200,7 +200,7 @@ query **must** error with `INVALID_ARGUMENT`.
 [cel-cpp]: https://github.com/google/cel-cpp
 [cel-go]: https://github.com/google/cel-go
 [durations]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto
-[ebnf grammar]: ../static/misc/ebnf-filtering.txt
+[ebnf grammar]: /assets/misc/ebnf-filtering.txt
 [rfc-3339]: https://tools.ietf.org/html/rfc3339
 [timestamps]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
I broke this by accident in #540.
This is still a bit broken (that file should not be in the site
generator; it should be here); will send a follow-up fix that is
more complete, but this addresses the immediate problem.

Fixes #559.