### PR TITLE
Update aip/181 to not use the term "whitelist"

### DIFF
--- a/aip/general/0181.md
+++ b/aip/general/0181.md
@@ -22,7 +22,7 @@ here.
 
 An _alpha_ component undergoes rapid iteration with a known set of users who
 **must** be tolerant of change. The number of users **should** be a
-whitelisted, manageable set, such that it is feasible to communicate with all
+curated, manageable set, such that it is feasible to communicate with all
 of them individually.
 
 Breaking changes **must** be both allowed and expected in alpha components, and
@@ -33,7 +33,7 @@ users **must** have no expectation of stability.
 A _beta_ component **must** be considered complete and ready to be declared
 stable, subject to public testing. Beta components **should** be exposed to an
 unknown and potentially large set of users. In other words, beta components
-**should not** be behind a whitelist; instead, they **should** be available to
+**should not** be behind an allowlist; instead, they **should** be available to
 the public.
 
 Because users of beta components tend to have a lower tolerance of change, beta


### PR DESCRIPTION
This file contained 2 occurrence of the term "whitelist"; I have replaced them with "curated" and "allowlist" which seemed appropriate in the context of usage.