### PR TITLE
feat: Genericize AIP-131.

### DIFF
--- a/aip/general/0131.md
+++ b/aip/general/0131.md
@@ -62,7 +62,7 @@ Permission **must** be checked prior to checking if the resource exists.
 If the user does have proper permission, but the requested resource does not
 exist, the service **must** reply with an HTTP 404 error.
 
-## Examples
+## Interface Definitions
 
 <!-- prettier-ignore-start -->
 === "Protocol buffers"

--- a/aip/general/0131.md
+++ b/aip/general/0131.md
@@ -7,94 +7,156 @@ placement:
   order: 10
 ---
 
-# Standard methods: Get
+# GET for individual resources
 
 In REST APIs, it is customary to make a `GET` request to a resource's URI (for
 example, `/v1/publishers/{publisher}/books/{book}`) in order to retrieve that
 resource.
 
-Resource-oriented design ([AIP-121][]) honors this pattern through the `Get`
-method. These RPCs accept the URI representing that resource and return the
-resource.
+Our APIs honor this pattern by allowing `GET` requests to be sent to the
+resource URI, which returns the resource itself.
 
 ## Guidance
 
-APIs **should** generally provide a get method for resources unless it is not
-valuable for users to do so. The purpose of the get method is to return data
-from a single resource.
+APIs **should** generally provide a `GET` method for resources unless it is not
+valuable for users to do so. The purpose of this method is to return data for a
+single resource.
 
-Get methods are specified using the following pattern:
+### Requests
 
-```proto
-rpc GetBook(GetBookRequest) returns (Book) {
-  option (google.api.http) = {
-    get: "/v1/{name=publishers/*/books/*}"
-  };
-  option (google.api.method_signature) = "name";
-}
+Single-resource `GET` methods **must** be made be sending a `GET` request to
+the resource's path:
+
+```http
+GET /v1/publishers/{publisher}/books/{book} HTTP/2
+Host: library.googleapis.com
+Accept: application/json
 ```
 
-- The RPC's name **must** begin with the word `Get`. The remainder of the RPC
-  name **should** be the singular form of the resource's message name.
-- The request message **must** match the RPC name, with a `-Request` suffix.
-- The response message **must** be the resource itself. (There is no
-  `GetBookResponse`.)
-  - The response **should** usually include the fully-populated resource unless
-    there is a reason to return a partial response (see [AIP-157][]).
 - The HTTP verb **must** be `GET`.
-- The URI **should** contain a single variable field corresponding to the
-  resource name.
-  - This field **should** be called `name`.
-  - The URI **should** have a variable corresponding to this field.
-  - The `name` field **should** be the only variable in the URI path. All
-    remaining parameters **should** map to URI query parameters.
-- There **must not** be a `body` key in the `google.api.http` annotation.
-- There **should** be exactly one `google.api.method_signature` annotation,
-  with a value of `"name"`.
+  - The request **must** be safe and **must not** have side effects.
+- There **must not** be a request body.
+  - If a `GET` request contains a body, the body **must** be ignored, and
+    **must not** cause an error.
 
-### Request message
+### Responses
 
-Get methods implement a common request message pattern:
+Single-resource `GET` methods **must** return the resource itself, without any
+additional wrapping:
 
-```proto
-message GetBookRequest {
-  // The name of the book to retrieve.
-  // Format: publishers/{publisher}/books/{book}
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type: "library-example.googleapis.com/Book"
-    }];
+```json
+{
+  "name": "publishers/lacroix/books/les-mis",
+  "title": "Les Misérables",
+  "authors": ["Victor Hugo"],
+  "rating": 9.6
 }
 ```
-
-- A resource name field **must** be included. It **should** be called `name`.
-  - The field **should** be annotated as required.
-  - The field **should** identify the [resource type][aip-123] that it
-    references.
-- The comment for the `name` field **should** document the resource pattern.
-- The request message **must not** contain any other required fields, and
-  **should not** contain other optional fields except those described in
-  another AIP.
-
-**Note:** The `name` field in the request object corresponds to the `name`
-variable in the `google.api.http` annotation on the RPC. This causes the `name`
-field in the request to be populated based on the value in the URL when the
-REST/JSON interface is used.
-
-[aip-121]: ./0121.md
-[aip-123]: ./0123.md
-[aip-157]: ./0157.md
 
 ### Errors
 
 If the user does not have permission to access the resource, regardless of
-whether or not it exists, the service **must** error with `PERMISSION_DENIED`
-(HTTP 403). Permission **must** be checked prior to checking if the resource
-exists.
+whether or not it exists, the service **must** reply with an HTTP 403 error.
+Permission **must** be checked prior to checking if the resource exists.
 
 If the user does have proper permission, but the requested resource does not
-exist, the service **must** error with `NOT_FOUND` (HTTP 404).
+exist, the service **must** reply with an HTTP 404 error.
+
+## Examples
+
+<!-- prettier-ignore-start -->
+=== "Protocol buffers"
+
+  Get methods are specified using the following pattern:
+
+  ```proto
+  // Get a single book.
+  rpc GetBook(GetBookRequest) returns (Book) {
+    option (google.api.http) = {
+      get: "/v1/{name=publishers/*/books/*}"
+    };
+    option (google.api.method_signature) = "name";
+  }
+  ```
+
+  - The RPC's name **must** begin with the word `Get`. The remainder of the RPC
+    name **should** be the singular form of the resource's message name.
+  - The request message **must** match the RPC name, with a `-Request` suffix.
+  - The response message **must** be the resource itself. (There is no
+    `GetBookResponse`.)
+    - The response **should** usually include the fully-populated resource unless
+      there is a reason to return a partial response (see AIP-157).
+  - The HTTP verb **must** be `GET`.
+  - The URI **should** contain a single variable field corresponding to the
+    resource name.
+    - This field **should** be called `name`.
+    - The URI **should** have a variable corresponding to this field.
+    - The `name` field **should** be the only variable in the URI path. All
+      remaining parameters **should** map to URI query parameters.
+  - There **must not** be a `body` key in the `google.api.http` annotation.
+  - There **should** be exactly one `google.api.method_signature` annotation,
+    with a value of `"name"`.
+
+  Get methods also implement a common request message pattern:
+
+  ```proto
+  message GetBookRequest {
+    // The name of the book to retrieve.
+    // Format: publishers/{publisher}/books/{book}
+    string name = 1 [
+      (google.api.field_behavior) = REQUIRED,
+      (google.api.resource_reference) = {
+        type: "library-example.googleapis.com/Book"
+      }];
+  }
+  ```
+
+  - A resource name field **must** be included. It **should** be called `name`.
+    - The field **should** be annotated as required.
+    - The field **should** identify the [resource type][aip-123] that it
+      references.
+  - The comment for the `name` field **should** document the resource pattern.
+  - The request message **must not** contain any other required fields, and
+    **should not** contain other optional fields except those described in
+    another AIP.
+
+  **Note:** The `name` field in the request object corresponds to the `name`
+  variable in the `google.api.http` annotation on the RPC. This causes the `name`
+  field in the request to be populated based on the value in the URL when the
+  REST/JSON interface is used.
+
+=== "OpenAPI 3.0"
+
+  Single-resource `GET` methods **must** be specified with consistent OpenAPI
+  metadata:
+
+  ```yaml
+  paths:
+    /publishers/{publisherId}/books/{id}:
+      get:
+        operationId: getBook
+        description: Get a single book.
+        responses:
+          200:
+            description: OK
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Book'
+  ```
+
+  - The `operationId` **must** begin with the word `get`. The remainder of the
+    `operationId` **should** be the singular form of the resource type's name.
+  - The response content **must** be the resource itself. For example:
+    `#/components/schemas/Book`
+    - The response **should** usually include the fully-populated resource
+      unless there is a reason to return a partial response (see AIP-157).
+  - The URI **should** contain a variable for each individual ID in the resource
+    hierarchy.
+    - The variable for the resource ID **must** be named `id`. Variables
+      representing the ID of parent resources **must** end with `Id`.
+
+<!-- prettier-ignore-end -->
 
 ## Changelog
 


### PR DESCRIPTION
This is a generic AIP-131. We should discuss some aspects of this, but my ultimate goal is that this gets merged.

Stuff I like:

- Having a "Guidance" and "Examples" section works pretty well, I think.
  - I like the "HTTP first" approach to the writing. We might want gRPC examples but I am not convinced we actually care.
- The tabs look nice (note that they require aip-dev/site-generator#6, which is not merged yet).

Stuff I do not like:

- "Examples" does not quite feel like the right term.
- We need to decide "discrete IDs" vs. "resource names" for the generic stuff. I think I prefer discrete IDs but I want to take a census first.
- I want to consider splitting off the examples into separate files (which we could then ensure compile in protobuf's case), similar to how our developer relations folks incorporate samples for client libraries.
  - Doing this also might really help forks -- e.g. you configure which specification languages you want to show (and we can be smart enough not to show tabs if you only show one).