### PR TITLE
feat: Add August Newsletter

### DIFF
--- a/config/hero.yaml
+++ b/config/hero.yaml
@@ -34,5 +34,5 @@ shortcuts:
       questions</a>. If you don't find an answer there, file an issue on our
       GitHub repository.
     button:
-      href: https://github.com/aip-dev/aip.dev/issues
+      href: https://github.com/aip-dev/google.aip.dev/issues
       text: Ask us on GitHub

--- a/pages/news/2020-03.md
+++ b/pages/news/2020-03.md
@@ -44,10 +44,10 @@ have a specified place for per-source and per-destination configuration,
 distinct from configuration for the data itself.
 
 We are aiming to approve AIP-153 on March 27. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/422).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/422).
 
-[aip-151]: ../aip/0151.md
-[aip-153]: ../aip/0153.md
+[aip-151]: ../151
+[aip-153]: ../153
 
 ### AIP-162: Resource revisions
 
@@ -70,9 +70,9 @@ method structures for most common operations (listing revisions, rollback,
 etc.). It also proposes a tagging mechanism for user-friendly revision names.
 
 We are aiming to approve AIP-162 on March 27. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/436).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/436).
 
-[aip-162]: ../aip/0162.md
+[aip-162]: ../162
 
 ### AIP-163: Change validation
 
@@ -95,9 +95,9 @@ over time.
 situations around permissions and incomplete output.
 
 We are aiming to approve AIP-163 on March 27. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/437).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/437).
 
-[aip-163]: ../aip/0163.md
+[aip-163]: ../163
 
 ### AIP-165: Criteria-based delete
 
@@ -120,10 +120,10 @@ common name (`Purge`) and structure, and mandates a dry-run by default with a
 `force` flag to actually perform the purge.
 
 We are aiming to approve AIP-165 on March 27. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/438).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/438).
 
-[aip-165]: ../aip/0165.md
-[aip-235]: ../aip/0235.md
+[aip-165]: ../165
+[aip-235]: ../235
 
 ### AIP-194: Retries for gRPC clients
 
@@ -144,23 +144,25 @@ an API are safe to retry. It recommends usually retrying `UNAVAILABLE` and
 nothing else.
 
 We are aiming to approve AIP-194 on March 27. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/439).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/439).
+
+[aip-194]: ../194
 
 ## Recent updates
 
 In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
-- [AIP-8](../aip/0008.md): AIPs have reverse-chronological changelogs
-  ([#425](https://github.com/googleapis/aip/pull/425))
-- [AIP-135](../aip/0135.md): Delete methods send 403 errors if the user lacks
-  access ([#409](https://github.com/googleapis/aip/pull/409))
-- [AIP-140](../aip/0140.md): `display_name` and `title` standard fields
-  ([#405](https://github.com/googleapis/aip/pull/405))
-- [AIP-158](../aip/0158.md): Field order for pagination response messages
-  ([#419](https://github.com/googleapis/aip/pull/419))
-- [AIP-193](../aip/0193.md): Added reference to new `ErrorInfo` message
-  ([#396](https://github.com/googleapis/aip/pull/396))
+- [AIP-8](../8): AIPs have reverse-chronological changelogs
+  ([#425](https://github.com/aip-dev/aip.dev/pull/425))
+- [AIP-135](../135): Delete methods send 403 errors if the user lacks access
+  ([#409](https://github.com/aip-dev/aip.dev/pull/409))
+- [AIP-140](../140): `display_name` and `title` standard fields
+  ([#405](https://github.com/aip-dev/aip.dev/pull/405))
+- [AIP-158](../158): Field order for pagination response messages
+  ([#419](https://github.com/aip-dev/aip.dev/pull/419))
+- [AIP-193](../193): Added reference to new `ErrorInfo` message
+  ([#396](https://github.com/aip-dev/aip.dev/pull/396))
 
 ## What is coming?
 
@@ -172,5 +174,3 @@ exploring the possibility of bringing AIPs to even more API producers across
 multiple companies, so that others can publish their standards under a common
 information architecture. This effort is still nascent, but we are excited and
 hopeful. Stay tuned!
-
-[aip-194]: ../aip/0194.md

--- a/pages/news/2020-03.md
+++ b/pages/news/2020-03.md
@@ -44,7 +44,7 @@ have a specified place for per-source and per-destination configuration,
 distinct from configuration for the data itself.
 
 We are aiming to approve AIP-153 on March 27. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/422).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/422).
 
 [aip-151]: ../151
 [aip-153]: ../153
@@ -70,7 +70,7 @@ method structures for most common operations (listing revisions, rollback,
 etc.). It also proposes a tagging mechanism for user-friendly revision names.
 
 We are aiming to approve AIP-162 on March 27. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/436).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/436).
 
 [aip-162]: ../162
 
@@ -95,7 +95,7 @@ over time.
 situations around permissions and incomplete output.
 
 We are aiming to approve AIP-163 on March 27. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/437).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/437).
 
 [aip-163]: ../163
 
@@ -120,7 +120,7 @@ common name (`Purge`) and structure, and mandates a dry-run by default with a
 `force` flag to actually perform the purge.
 
 We are aiming to approve AIP-165 on March 27. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/438).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/438).
 
 [aip-165]: ../165
 [aip-235]: ../235
@@ -144,7 +144,7 @@ an API are safe to retry. It recommends usually retrying `UNAVAILABLE` and
 nothing else.
 
 We are aiming to approve AIP-194 on March 27. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/439).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/439).
 
 [aip-194]: ../194
 
@@ -154,15 +154,15 @@ In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
 - [AIP-8](../8): AIPs have reverse-chronological changelogs
-  ([#425](https://github.com/aip-dev/aip.dev/pull/425))
+  ([#425](https://github.com/aip-dev/google.aip.dev/pull/425))
 - [AIP-135](../135): Delete methods send 403 errors if the user lacks access
-  ([#409](https://github.com/aip-dev/aip.dev/pull/409))
+  ([#409](https://github.com/aip-dev/google.aip.dev/pull/409))
 - [AIP-140](../140): `display_name` and `title` standard fields
-  ([#405](https://github.com/aip-dev/aip.dev/pull/405))
+  ([#405](https://github.com/aip-dev/google.aip.dev/pull/405))
 - [AIP-158](../158): Field order for pagination response messages
-  ([#419](https://github.com/aip-dev/aip.dev/pull/419))
+  ([#419](https://github.com/aip-dev/google.aip.dev/pull/419))
 - [AIP-193](../193): Added reference to new `ErrorInfo` message
-  ([#396](https://github.com/aip-dev/aip.dev/pull/396))
+  ([#396](https://github.com/aip-dev/google.aip.dev/pull/396))
 
 ## What is coming?
 

--- a/pages/news/2020-04.md
+++ b/pages/news/2020-04.md
@@ -35,7 +35,7 @@ associations: a resource with multiple different one-to-many relationships, and
 a resource with a many-to-many association with another resource.
 
 We are aiming to approve AIP-124 on April 24. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/475).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/475).
 
 [aip-124]: ../124
 
@@ -58,7 +58,7 @@ the two update strategies.
 distinct strategies for updating repeated fields.
 
 We are aiming to approve AIP-144 on April 24. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/476).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/476).
 
 [aip-144]: ../144
 
@@ -80,7 +80,7 @@ if not for the efforts of [Tristan Swadell][]; we are grateful for his efforts.
 and how to provide filtering results in list and search methods.
 
 We are aiming to approve AIP-160 on April 24. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/473).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/473).
 
 [aip-160]: ../160
 [tristan swadell]: https://github.com/tristonianjones
@@ -91,10 +91,10 @@ In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
 - [AIP-133](../133): Clarify which fields can be required
-  ([#460](https://github.com/aip-dev/aip.dev/pull/460))
+  ([#460](https://github.com/aip-dev/google.aip.dev/pull/460))
 - [AIP-140](../140): Add guidance about message and field name conflicts
-  ([#470](https://github.com/aip-dev/aip.dev/pull/470))
+  ([#470](https://github.com/aip-dev/google.aip.dev/pull/470))
 - [AIP-151](../151): Clarify that both `response_type` and `metadata_type` are
-  expected ([#469](https://github.com/aip-dev/aip.dev/pull/469))
+  expected ([#469](https://github.com/aip-dev/google.aip.dev/pull/469))
 - [AIP-231](../231): Clarify Batch Get behavior if no resource names are sent
-  ([#474](https://github.com/aip-dev/aip.dev/pull/474))
+  ([#474](https://github.com/aip-dev/google.aip.dev/pull/474))

--- a/pages/news/2020-04.md
+++ b/pages/news/2020-04.md
@@ -35,9 +35,9 @@ associations: a resource with multiple different one-to-many relationships, and
 a resource with a many-to-many association with another resource.
 
 We are aiming to approve AIP-124 on April 24. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/475).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/475).
 
-[aip-124]: ../aip/0124.md
+[aip-124]: ../124
 
 ### AIP-144: Repeated fields
 
@@ -58,9 +58,9 @@ the two update strategies.
 distinct strategies for updating repeated fields.
 
 We are aiming to approve AIP-144 on April 24. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/476).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/476).
 
-[aip-144]: ../aip/0144.md
+[aip-144]: ../144
 
 ### AIP-160: Filtering
 
@@ -80,9 +80,9 @@ if not for the efforts of [Tristan Swadell][]; we are grateful for his efforts.
 and how to provide filtering results in list and search methods.
 
 We are aiming to approve AIP-160 on April 24. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/473).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/473).
 
-[aip-160]: ../aip/0160.md
+[aip-160]: ../160
 [tristan swadell]: https://github.com/tristonianjones
 
 ## Recent updates
@@ -90,12 +90,11 @@ We are aiming to approve AIP-160 on April 24. If you have feedback, please
 In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
-- [AIP-133](../aip/0133.md): Clarify which fields can be required
-  ([#460](https://github.com/googleapis/aip/pull/460))
-- [AIP-140](../aip/0140.md): Add guidance about message and field name
-  conflicts ([#470](https://github.com/googleapis/aip/pull/470))
-- [AIP-151](../aip/0151.md): Clarify that both `response_type` and
-  `metadata_type` are expected
-  ([#469](https://github.com/googleapis/aip/pull/469))
-- [AIP-231](../aip/0231.md): Clarify Batch Get behavior if no resource names
-  are sent ([#474](https://github.com/googleapis/aip/pull/474))
+- [AIP-133](../133): Clarify which fields can be required
+  ([#460](https://github.com/aip-dev/aip.dev/pull/460))
+- [AIP-140](../140): Add guidance about message and field name conflicts
+  ([#470](https://github.com/aip-dev/aip.dev/pull/470))
+- [AIP-151](../151): Clarify that both `response_type` and `metadata_type` are
+  expected ([#469](https://github.com/aip-dev/aip.dev/pull/469))
+- [AIP-231](../231): Clarify Batch Get behavior if no resource names are sent
+  ([#474](https://github.com/aip-dev/aip.dev/pull/474))

--- a/pages/news/2020-05.md
+++ b/pages/news/2020-05.md
@@ -37,9 +37,9 @@ represent tasks that are run repeatedly, whether by a user or by the system on
 a schedule.
 
 We are aiming to approve AIP-152 on May 29. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/504).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/504).
 
-[aip-152]: ../aip/0152.md
+[aip-152]: ../152
 
 ### AIP-160: Filtering
 
@@ -61,15 +61,15 @@ and how to provide filtering results in list and search methods.
 We are aiming to approve AIP-160 on May 29. If you have feedback, please [leave
 a comment][#473].
 
-[#473]: https://github.com/googleapis/aip/pull/473
-[aip-160]: ../aip/0160.md
+[#473]: https://github.com/aip-dev/aip.dev/pull/473
+[aip-160]: ../160
 
 ## Recent updates
 
 In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
-- [AIP-122](../aip/0122.md): Tighten restrictions on resource names
-  ([#496](https://github.com/googleapis/aip/pull/496))
-- [AIP-192](../aip/0192.md): Mandate use of absolute links in comments
-  ([#480](https://github.com/googleapis/aip/pull/480))
+- [AIP-122](../122): Tighten restrictions on resource names
+  ([#496](https://github.com/aip-dev/aip.dev/pull/496))
+- [AIP-192](../192): Mandate use of absolute links in comments
+  ([#480](https://github.com/aip-dev/aip.dev/pull/480))

--- a/pages/news/2020-05.md
+++ b/pages/news/2020-05.md
@@ -37,7 +37,7 @@ represent tasks that are run repeatedly, whether by a user or by the system on
 a schedule.
 
 We are aiming to approve AIP-152 on May 29. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/504).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/504).
 
 [aip-152]: ../152
 
@@ -61,7 +61,7 @@ and how to provide filtering results in list and search methods.
 We are aiming to approve AIP-160 on May 29. If you have feedback, please [leave
 a comment][#473].
 
-[#473]: https://github.com/aip-dev/aip.dev/pull/473
+[#473]: https://github.com/aip-dev/google.aip.dev/pull/473
 [aip-160]: ../160
 
 ## Recent updates
@@ -70,6 +70,6 @@ In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
 - [AIP-122](../122): Tighten restrictions on resource names
-  ([#496](https://github.com/aip-dev/aip.dev/pull/496))
+  ([#496](https://github.com/aip-dev/google.aip.dev/pull/496))
 - [AIP-192](../192): Mandate use of absolute links in comments
-  ([#480](https://github.com/aip-dev/aip.dev/pull/480))
+  ([#480](https://github.com/aip-dev/google.aip.dev/pull/480))

--- a/pages/news/2020-06.md
+++ b/pages/news/2020-06.md
@@ -35,7 +35,7 @@ this using the idea of "colloquial precedent".
 that represent a start and end value.
 
 We are aiming to approve AIP-145 on June 26. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/523).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/523).
 
 [aip-145]: ../145
 
@@ -54,7 +54,7 @@ tradeoffs.
 the tradeoffs of each.
 
 We are aiming to approve AIP-146 on June 26. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/524).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/524).
 
 [aip-146]: ../146
 
@@ -64,12 +64,12 @@ In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
 - [AIP-122](../122): Corrected a mistaken piece of guidance about
-  capitalization ([#513](https://github.com/aip-dev/aip.dev/pull/513))
+  capitalization ([#513](https://github.com/aip-dev/google.aip.dev/pull/513))
 - [AIP-132](../132): Removed mandate to document default ordering
-  ([#512](https://github.com/aip-dev/aip.dev/pull/512))
+  ([#512](https://github.com/aip-dev/google.aip.dev/pull/512))
 - [AIP-140](../140): Add guidance for URI fields
-  ([#519](https://github.com/aip-dev/aip.dev/pull/519))
+  ([#519](https://github.com/aip-dev/google.aip.dev/pull/519))
 - [AIP-143](../143): Change guidance for countries to `region_code`
-  ([#507](https://github.com/aip-dev/aip.dev/pull/507))
+  ([#507](https://github.com/aip-dev/google.aip.dev/pull/507))
 - [AIP-203](../203): Clarified behavior for updating immutable fields
-  ([#516](https://github.com/aip-dev/aip.dev/pull/516))
+  ([#516](https://github.com/aip-dev/google.aip.dev/pull/516))

--- a/pages/news/2020-06.md
+++ b/pages/news/2020-06.md
@@ -35,9 +35,9 @@ this using the idea of "colloquial precedent".
 that represent a start and end value.
 
 We are aiming to approve AIP-145 on June 26. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/523).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/523).
 
-[aip-145]: ../aip/0145.md
+[aip-145]: ../145
 
 ### AIP-146: Generic fields
 
@@ -54,22 +54,22 @@ tradeoffs.
 the tradeoffs of each.
 
 We are aiming to approve AIP-146 on June 26. If you have feedback, please
-[leave a comment](https://github.com/googleapis/aip/pull/524).
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/524).
 
-[aip-146]: ../aip/0146.md
+[aip-146]: ../146
 
 ## Recent updates
 
 In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
-- [AIP-122](../aip/0122.md): Corrected a mistaken piece of guidance about
-  capitalization ([#513](https://github.com/googleapis/aip/pull/513))
-- [AIP-132](../aip/0132.md): Removed mandate to document default ordering
-  ([#512](https://github.com/googleapis/aip/pull/512))
-- [AIP-140](../aip/0140.md): Add guidance for URI fields
-  ([#519](https://github.com/googleapis/aip/pull/519))
-- [AIP-143](../aip/0143.md): Change guidance for countries to `region_code`
-  ([#507](https://github.com/googleapis/aip/pull/507))
-- [AIP-203](../aip/0203.md): Clarified behavior for updating immutable fields
-  ([#516](https://github.com/googleapis/aip/pull/516))
+- [AIP-122](../122): Corrected a mistaken piece of guidance about
+  capitalization ([#513](https://github.com/aip-dev/aip.dev/pull/513))
+- [AIP-132](../132): Removed mandate to document default ordering
+  ([#512](https://github.com/aip-dev/aip.dev/pull/512))
+- [AIP-140](../140): Add guidance for URI fields
+  ([#519](https://github.com/aip-dev/aip.dev/pull/519))
+- [AIP-143](../143): Change guidance for countries to `region_code`
+  ([#507](https://github.com/aip-dev/aip.dev/pull/507))
+- [AIP-203](../203): Clarified behavior for updating immutable fields
+  ([#516](https://github.com/aip-dev/aip.dev/pull/516))

--- a/pages/news/2020-08.md
+++ b/pages/news/2020-08.md
@@ -1,0 +1,55 @@
+# Field patterns, redux
+
+Welcome to the fifth edition of the **AIP newsletter**, which is designed to
+keep you up to date about the AIP program, and particular proposals making
+their way through the system. (Our apologies for not publishing a newsletter in
+July.)
+
+We have one new AIP this month, on sensitive fields. As always, the AIP
+newsletter kicks off what is effectively a "public comment" period: the AIP
+editors are happy with this proposal, but we want to ensure that you are too.
+Assuming feedback is sufficiently positive, we intend to formally approve these
+proposals on Friday, August 28, 2020.
+
+## AIPs under review
+
+### AIP-147: Sensitive fields
+
+> Sometimes APIs need to collect sensitive information such as private
+> encryption keys meant to be _stored_ by the underlying service but not
+> intended to be _read_ after writing due to the sensitive nature of the data.
+
+[Sensitive fields][aip-147] are fields that are stored by a service but, once
+set, not retrievable by the user, such as passwords or private keys. These are
+not particularly common in APIs, and often it is sufficient to set them as
+`INPUT_ONLY` (as described in AIP-203).
+
+However, there is a challenge in situations where the service needs to provide
+some kind of indication that a value has been provided, or provide an
+obfuscated value that the original user ought to recognize. This AIP provides a
+standard for each of those situations.
+
+A special thanks to [Michael Bleigh][] for writing this AIP.
+
+**Summary:** [AIP-147][] provides patterns for indicators around sensitive
+fields.
+
+We are aiming to approve AIP-147 on August 28. If you have feedback, please
+[leave a comment](https://github.com/aip-dev/aip.dev/pull/XYZ).
+
+[michael bleigh]: https://github.com/mbleigh
+[aip-147]: ../147
+
+## Recent updates
+
+In addition to the new AIPs under review, we have added the following guidance
+to existing AIPs:
+
+- [AIP-135](../135): Add "get" guidance for soft delete.
+  ([#526](https://github.com/aip-dev/aip.dev/pull/526))
+- [AIP-140](../140): Word segments in field names must not begin with a number.
+  ([#528](https://github.com/aip-dev/aip.dev/pull/528))
+- [AIP-151](../151): Add guidance for parallel operations.
+  ([#535](https://github.com/aip-dev/aip.dev/pull/535))
+- [AIP-158](../158): Clarify that `page_size` is always an opitonal field.
+  ([#537](https://github.com/aip-dev/aip.dev/pull/537))

--- a/pages/news/2020-08.md
+++ b/pages/news/2020-08.md
@@ -35,7 +35,7 @@ A special thanks to [Michael Bleigh][] for writing this AIP.
 fields.
 
 We are aiming to approve AIP-147 on August 28. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/XYZ).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/583).
 
 [michael bleigh]: https://github.com/mbleigh
 [aip-147]: ../147

--- a/pages/news/2020-08.md
+++ b/pages/news/2020-08.md
@@ -35,7 +35,7 @@ A special thanks to [Michael Bleigh][] for writing this AIP.
 fields.
 
 We are aiming to approve AIP-147 on August 28. If you have feedback, please
-[leave a comment](https://github.com/aip-dev/aip.dev/pull/XYZ).
+[leave a comment](https://github.com/aip-dev/google.aip.dev/pull/XYZ).
 
 [michael bleigh]: https://github.com/mbleigh
 [aip-147]: ../147
@@ -46,10 +46,10 @@ In addition to the new AIPs under review, we have added the following guidance
 to existing AIPs:
 
 - [AIP-135](../135): Add "get" guidance for soft delete.
-  ([#526](https://github.com/aip-dev/aip.dev/pull/526))
+  ([#526](https://github.com/aip-dev/google.aip.dev/pull/526))
 - [AIP-140](../140): Word segments in field names must not begin with a number.
-  ([#528](https://github.com/aip-dev/aip.dev/pull/528))
+  ([#528](https://github.com/aip-dev/google.aip.dev/pull/528))
 - [AIP-151](../151): Add guidance for parallel operations.
-  ([#535](https://github.com/aip-dev/aip.dev/pull/535))
+  ([#535](https://github.com/aip-dev/google.aip.dev/pull/535))
 - [AIP-158](../158): Clarify that `page_size` is always an opitonal field.
-  ([#537](https://github.com/aip-dev/aip.dev/pull/537))
+  ([#537](https://github.com/aip-dev/google.aip.dev/pull/537))

--- a/pages/news/2020-08.yaml
+++ b/pages/news/2020-08.yaml
@@ -1,0 +1,7 @@
+---
+news:
+  year: 2020
+  month: August
+  description: Patterns around sensitive fields.
+  aips:
+    reviewing: [147]


### PR DESCRIPTION
Also fix links in the March to June ones.
(The cleanup the generator does only applies to actual AIPs.)
