### PR TITLE
Add PERMISSION_DENIED error requirements to List and Update.

### DIFF
--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -202,6 +202,7 @@ not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Changelog
 
+- **2020-08-14**: Added error guidance for permission denied cases.
 - **2020-06-08**: Added guidance on returning the full resource.
 - **2020-05-19**: Removed requirement to document ordering behavior.
 - **2020-04-15**: Added guidance on List permissions.

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -185,6 +185,16 @@ soft-deleted resources to be included.
 [aip-158]: ./0158.md
 [soft delete]: ./0135.md#soft-delete
 
+### Errors
+
+If the user does not have permission to access the parent resource, regardless
+of whether or not it exists, the service **must** error with `PERMISSION_DENIED`
+(HTTP 403). Permission **must** be checked prior to checking if the parent
+resource exists.
+
+If the user does have proper permission, but the requested parent resource does
+not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
+
 ## Further reading
 
 - For details on pagination, see [AIP-158](./0158.md).

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -165,7 +165,8 @@ message CreateBookRequest {
 - If a user tries to create a resource with an ID that would result in a
   duplicate resource name, the service **must** error with `ALREADY_EXISTS`.
   - However, if the user making the call does not have permission to see the
-    duplicate resource, the service **must** error with `FORBIDDEN` instead.
+    duplicate resource, the service **must** error with `PERMISSION_DENIED`
+    instead.
 
 ## Further reading
 

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -182,6 +182,8 @@ message CreateBookRequest {
 
 ## Changelog
 
+- **2020-08-14**: Updated error guidance to use permission denied over
+  forbidden.
 - **2020-06-08**: Added guidance on returning the full resource.
 - **2019-11-22**: Added clarification on what error to use if a duplicate name
   is sent.

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -242,6 +242,7 @@ exists.
 
 ## Changelog
 
+- **2020-08-14**: Added error guidance for permission denied cases.
 - **2020-06-08**: Added guidance on returning the full resource.
 - **2019-10-18**: Added guidance on annotations.
 - **2019-09-10**: Added a link to the long-running operations AIP

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -233,6 +233,13 @@ so.
 [required]: ./0203.md#required
 [optional]: ./0203.md#optional
 
+### Errors
+
+If the user does not have permission to access the resource, regardless of
+whether or not it exists, the service **must** error with `PERMISSION_DENIED`
+(HTTP 403). Permission **must** be checked prior to checking if the resource
+exists.
+
 ## Changelog
 
 - **2020-06-08**: Added guidance on returning the full resource.


### PR DESCRIPTION
Add PERMISSION_DENIED error requirements to List and Update. This description already exists in Get, Create, and Delete, but should also apply to List and Update. Also updated FORBIDDEN error name in the Create error description to PERMISSION_DENIED to make it match other usages.