### PR TITLE
Fixed broken links in AIP-193

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -16,10 +16,10 @@ than being expected to constantly add verbose error handling everywhere.
 
 ## Guidance
 
-Services **must** return a [`google.rpc.Status`][] message when an API error
-occurs, and **must** use the canonical error codes defined in
-[`google.rpc.Code`][]. More information about the particular codes is available
-in the [gRPC status code documentation][].
+Services **must** return a [`google.rpc.Status`][Status] message when an API
+error occurs, and **must** use the canonical error codes defined in
+[`google.rpc.Code`][Code]. More information about the particular codes is
+available in the [gRPC status code documentation][].
 
 Error messages **should** help a reasonably technical user _understand_ and
 _resolve_ the issue, and **should not** assume that the user is an expert in
@@ -43,7 +43,7 @@ strings **may** change over time; however, if an error message does not have a
 machine-readable identifier _in addition to_ the `code` field, changing the
 error message **must** be considered a backwards-incompatible change.
 
-**Note:** The [`ErrorInfo`][] message is the recommended way to send a
+**Note:** The [`ErrorInfo`][ErrorInfo] message is the recommended way to send a
 machine-readable identifier.
 
 ### Localization
@@ -66,7 +66,7 @@ because of a problem with a single entry.
 Methods that require partial errors **should** use [long-running operations][],
 and the method **should** put partial failure information in the metadata
 message. The errors themselves **must** still be represented with a
-[`google.rpc.Status`][] object.
+[`google.rpc.Status`][Status] object.
 
 ## Further reading
 
@@ -75,7 +75,7 @@ message. The errors themselves **must** still be represented with a
 
 ## Changelog
 
-- **2020-01-22**: Added a reference to the [`ErrorInfo`][] message.
+- **2020-01-22**: Added a reference to the [`ErrorInfo`][ErrorInfo] message.
 - **2019-10-14**: Added guidance restricting error message mutability to if
   there is a machine-readable identifier present.
 - **2019-09-23**: Added guidance about error message strings being able to
@@ -84,9 +84,9 @@ message. The errors themselves **must** still be represented with a
 <!-- prettier-ignore-start -->
 [aip-4221]: ./client-libraries/4221.md
 [details]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/error_details.proto
-[`ErrorInfo`]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/error_details.proto#L111
+[ErrorInfo]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/error_details.proto#L111
 [grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
-[`google.rpc.Code`]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/code.proto
-[`google.rpc.Status`]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/status.proto
+[Code]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/code.proto
+[Status]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/status.proto
 [long-running operations]: ./0151.md
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
Github's markdown supports link identifiers that contain backticks but whatever
engine renders https://google.aip.dev/193 does not.