### PR TITLE
Clarify that paged and LRO responses must not use `stream`.

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -40,6 +40,7 @@ rpc WriteBook(WriteBookRequest) returns (google.longrunning.Operation) {
 
 - The response type **must** be `google.longrunning.Operation`. The `Operation`
   proto definition **must not** be copied into individual APIs.
+  - The response **must not** be a streaming response.
 - The method **must** include a `google.longrunning.operation_info` annotation,
   which **must** define both response and metadata types.
   - The response and metadata types **must** be defined in the file where the
@@ -119,6 +120,7 @@ metadata message. The errors themselves **must** still be represented with a
 
 ## Changelog
 
+- **2020-08-24**: Clarified that responses are not streaming responses.
 - **2020-06-24**: Added guidance for parallel operations.
 - **2020-03-20**: Clarified that both `response_type` and `metadata_type` are
   required.

--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -71,6 +71,7 @@ message ListBooksResponse {
   - The user is expected to keep all other arguments to the RPC the same; if
     any arguments are different, the API **should** send an `INVALID_ARGUMENT`
     error.
+- The response **must not** be a streaming response.
 - Response messages for collections **should** define a
   `string next_page_token` field, providing the user with a page token that may
   be used to retrieve the next page.
@@ -104,9 +105,10 @@ internal protocol buffer message with any data needed, and send the serialized
 proto, base-64 encoded.
 
 Page tokens **must** be limited to providing an indication of where to continue
-the pagination process only. They **must not** provide any form of authorization
-to the underlying resources, and authorization **must** be performed on the request
-as with any other regardless of the presence of a page token.
+the pagination process only. They **must not** provide any form of
+authorization to the underlying resources, and authorization **must** be
+performed on the request as with any other regardless of the presence of a page
+token.
 
 ### Expiring page tokens
 
@@ -144,6 +146,7 @@ paginate) is reasonable for initially-small collections.
 
 ## Changelog
 
+- **2020-08-24**: Clarified that responses are not streaming responses.
 - **2020-06-24**: Clarified that page size is always optional for users.
 - **2019-02-12**: Added guidance on the field being paginated over.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to


### PR DESCRIPTION
That would just be silly, and nobody has ever tried, but if anyone
ever does try, lots of infrastructure teams will have a really bad
week.