### PR TITLE
fix: disallow simultaneous use of type and child_type

### DIFF
--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -160,7 +160,9 @@ message ListLogEntriesRequest {
 ```
 
 In this situation, client library generators implementing this feature **must**
-derive the set of parent resources from the child type.
+derive the set of parent resources from the child type. Client library
+generators **must** fail with an error if both `type` and `child_type` are
+provided.
 
 ### Referencing an arbitrary resource
 
@@ -180,7 +182,7 @@ provide a generic utility class or function to address that resource name.
 
 ### Complex resource ID path segments
 
-**Warning**: Complex resource ID path segments **should not** generally be used
+**Warning:** Complex resource ID path segments **should not** generally be used
 in new APIs. [AIP-124][] contains advice on handling many-to-many associations.
 
 Resource patterns **may** contain resource ID path segments which contain
@@ -234,6 +236,7 @@ deprecated, and must not be used.
 
 ## Changelog
 
+- **2020-09-14**: Disallow simultaneous use of both `type` and `child_type`.
 - **2020-05-14**: Added complex resource ID path segments.
 - **2020-05-07**: Updated backwards compatibility guidance.
 - **2019-09-16**: Added guidance for resources without messages.


### PR DESCRIPTION
In AIP-4231, explicitly state that simultaneous use of `type` and `child_type` should produce a generator error. Also fixes `Warning` syntax in complex resource ID section.