### PR TITLE
Add AIP guidance for a short_name field

### DIFF
--- a/aip/general/0250.md
+++ b/aip/general/0250.md
@@ -71,10 +71,13 @@ what is on sale. Tooling can choose to support `short_name` as follows:
       price: $25.99
 ```
 
-Now the configuration is much more understandable to humans. The tooling can
-convert "1235/mary-poppins" to the resource name "publishers/1235/books/6789" by
-using the list method of the Books API (eg,.
-`ListBooks(parent="publishers/2345", filter="short_name:mary-poppins")`).
+Now the configuration is much more understandable to humans.
+
+The tooling knows that "1235/mary-poppins" is a reference to a book which will
+be formatted as `<publisher_id>/<book.short_name>`. Using the list method of the
+Books API
+(`ListBooks(parent="publishers/2345", filter="short_name:mary-poppins")`), the
+reference can be resolved to "publishers/1235/books/6789".
 
 Use of the `short_name` may also be appropriate in reporting scenarios, where
 tooling can find strings like "publishers/1235/books/6789" and replace them

--- a/aip/general/0250.md
+++ b/aip/general/0250.md
@@ -13,7 +13,7 @@ use.
 
 ## Guidance
 
-Resources with system-generated identifiers may choose to support a field
+Resources with system-generated identifiers **may** support a field
 `short_name` of type string, which **must** refer to a terse, human-friendly
 value which uniquely identifies a resource of a specific type within a
 namespace.

--- a/aip/general/0250.md
+++ b/aip/general/0250.md
@@ -99,7 +99,7 @@ project could be referenced as `projects/123/databases/456/table/789` or
 
 ### Use in API calls
 
-Some APIs may choose to allow `short_name` to be used in place of the
+Services **should not** allow `short_name` to be used in place of the
 system-generated identifier in API calls. This practice is discouraged as it
 creates confusion about which is the canonical name for a resource. Such
 confusion hampers interoperability between systems which are unable to reliably

--- a/aip/general/0250.md
+++ b/aip/general/0250.md
@@ -1,0 +1,107 @@
+---
+id: 250
+state: draft
+created: 2020-09-17
+placement:
+  category: fields
+---
+
+# Short names
+
+System-generated identifiers have many benefits, but are not easy for humans
+use.
+
+## Guidance
+
+Resources with system-generated identifiers may choose to support a field
+`short_name` of type string, which **must** refer to a terse, human-friendly
+value which uniquely identifies a resource of a specific type within a
+namespace.
+
+* `short_name` **must** have clear documentation for its namespace.
+
+* `short_name` **must** support at least the character set of
+  `/^[a-z][a-z0-9.-]+[a-z0-9]$/` (lowercase
+  [RFC-1034](https://tools.ietf.org/html/rfc1034)).
+
+* `short_name` **must** have a maximum length of no less than 30 characters.
+
+* `short_name` **should** be immutable, which is safer for references in
+  configuration files.
+
+### Usage
+
+To illustrate this concept, let us imagine a bookstore that uses a
+config-as-code system to manage which books are to be on sale each week.
+
+```proto
+message Book {
+  // The resource name of the book.
+  // Example: publishers/1235/books/6789
+  string name = 1;
+
+  // A short identifier for human use in the namespace of the publisher.
+  // Example: mary-poppins
+  string short_name = 2;
+
+  // The title of the book.
+  // Example: "Mary Poppins"
+  sting title = 3;
+}
+```
+
+```yaml
+- week_start: 2020-09-13
+  books_on_sale:
+    - book: publishers/1235/books/6789
+      price: $5.99
+    - book: publishers/2342/books/9827
+      price: $25.99
+```
+
+While this configuration is clear to machines, the human reader is at a loss for
+what is on sale. Tooling can choose to support `short_name` as follows:
+
+```yaml
+- week_start: 2020-09-13
+  books_on_sale:
+    - book: 1235/mary-poppins
+      price: $5.99
+    - book: 2342/thing-explainer
+      price: $25.99
+```
+
+Now the configuration is much more understandable to humans. The tooling can
+convert "1235/mary-poppins" to the resource name "publishers/1235/books/6789" by
+using the list method of the Books API (eg,.
+`ListBooks(parent="publishers/2345", filter="short_name:mary-poppins")`).
+
+Use of the `short_name` may also be appropriate in reporting scenarios, where
+tooling can find strings like "publishers/1235/books/6789" and replace them
+with "1235/mary-poppins" in contexts where a human is reading the output.
+
+### Context & Namespace
+
+`short_name` requires tools understand the context of the reference and the
+namespace in which the `short_name` is unique. The namespace **should** be based
+on an immutable property of the resource (eg,. its parent or an unchangeable
+portion of its ancestry).
+
+In the example above, the context is a reference to a Book, and the namespace
+is the publisher identifier.
+
+The namespace itself may utilize short names. For example, a database table in a
+project could be referenced as `projects/123/databases/456/table/789` or
+`123/wholesaler-db/books`.
+
+### Use in API calls
+
+Some APIs may choose to allow `short_name` to be used in place of the
+system-generated identifier in API calls. This practice is discouraged as it
+creates confusion about which is the canonical name for a resource. Such
+confusion hampers interoperability between systems which are unable to reliably
+join data on a resource name.
+
+## Changelog
+
+* **2020-09-17**: Initial draft guidance for the `short_name` field.


### PR DESCRIPTION
I propose a new standard field, short_name.

NOTE: I picked a random AIP number that I hoped wouldn't conflict with any in-flight changes. A proper AIP number should be assigned to this document.