### PR TITLE
Use library.googleapis.com consistently instead of library-example

### DIFF
--- a/aip/general/0131.md
+++ b/aip/general/0131.md
@@ -63,7 +63,7 @@ message GetBookRequest {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "library-example.googleapis.com/Book"
+      type: "library.googleapis.com/Book"
     }];
 }
 ```

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -61,7 +61,7 @@ message ListBooksRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type: "library-example.googleapis.com/Book"
+      child_type: "library.googleapis.com/Book"
     }];
 
   // The maximum number of books to return. The service may return fewer than

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -71,7 +71,7 @@ message CreateBookRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type: "library-example.googleapis.com/Book"
+      child_type: "library.googleapis.com/Book"
     }];
 
   // The book to create.
@@ -137,7 +137,7 @@ message CreateBookRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type: "library-example.googleapis.com/Book"
+      child_type: "library.googleapis.com/Book"
     }];
 
   // The book to create.

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -68,7 +68,7 @@ message DeleteBookRequest {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "library-example.googleapis.com/Book"
+      type: "library.googleapis.com/Book"
     }];
 }
 ```

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -69,7 +69,7 @@ message DeleteBookRequest {
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "library-example.googleapis.com/Book"
+      type: "library.googleapis.com/Book"
     }];
 
   // The current etag of the book.

--- a/aip/general/0163.md
+++ b/aip/general/0163.md
@@ -26,7 +26,7 @@ field in the request message:
 ```proto
 message ReviewBookRequest {
   string name = 1 [(google.api.resource_reference) = {
-    type: "library-example.googleapis.com/Book"
+    type: "library.googleapis.com/Book"
   }];
   int32 rating = 2;
   string comment = 3;

--- a/aip/general/0165.md
+++ b/aip/general/0165.md
@@ -61,7 +61,7 @@ message PurgeBooksRequest {
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      child_type: "library-example.googleapis.com/Book"
+      child_type: "library.googleapis.com/Book"
     }];
 
   // A filter matching the books to be purged.


### PR DESCRIPTION
Fixes #618.