### PR TITLE
Change examples to use "publishers" instead of "shelves" in AIPs 2603 and 4221

### DIFF
--- a/aip/client-libraries/4221.md
+++ b/aip/client-libraries/4221.md
@@ -94,9 +94,8 @@ service, except for those that are explicitly named which get no `RetryPolicy`.
   },
   {
     "name": [
-      { "service": "google.example.library.v1.LibraryService", "method": "CreateShelf" },
-      { "service": "google.example.library.v1.LibraryService", "method": "DeleteShelf" },
-      { "service": "google.example.library.v1.LibraryService", "method": "MergeShelves" },
+      { "service": "google.example.library.v1.LibraryService", "method": "CreatePublisher" },
+      { "service": "google.example.library.v1.LibraryService", "method": "DeletePublisher" },
       { "service": "google.example.library.v1.LibraryService", "method": "CreateBook" },
       { "service": "google.example.library.v1.LibraryService", "method": "DeleteBook" },
       { "service": "google.example.library.v1.LibraryService", "method": "UpdateBook" },
@@ -129,3 +128,8 @@ does not retry anything unless configured to do so by the user.
 ## Further reading
 
 - For which error codes to retry, see [AIP-194](https://aip.dev/194).
+
+## Changelog
+
+- **2020-09-23**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.

--- a/aip/cloud/2603.md
+++ b/aip/cloud/2603.md
@@ -10,13 +10,13 @@ placement:
 # List command arguments
 
 Some list requests take argument(s) for the parent collection in which to list
-resources. For example, suppose an API has book resources belonging to shelf
-resources, and consider a request to list books in a shelf:
+resources. For example, suppose an API has book resources belonging to publisher
+resources, and consider a request to list books belonging to a publisher:
 
 ```proto
 message ListBooksRequest {
-  // Required. The shelf containing the books to list, for example,
-  // "projects/project1/shelves/shelf1".
+  // The parent, which owns this collection of books.
+  // Format: publishers/{publisher}
   string parent = 1;
 
   // The maximum number of items to return.
@@ -28,8 +28,8 @@ message ListBooksRequest {
 ```
 
 For the corresponding gcloud list command, we have the choice between
-`gcloud shelves books list SHELF` (positional) and
-`gcloud shelves books list --shelf=SHELF` (flag).
+`gcloud publishers books list PUBLISHER` (positional) and
+`gcloud publishers books list --publisher=PUBLISHER` (flag).
 
 ## Guidance
 
@@ -40,10 +40,15 @@ In the case of a list command that takes an argument, the argument will refer
 to the parent resource and not the command group's resource; therefore, it
 should be a flag instead of a positional.
 
-In the example above, the list command takes an argument for a shelf. Commands
+In the example above, the list command takes an argument for a publisher. Commands
 in the `books` command group should reserve positional arguments for book
-resources. Thus, the shelf argument for the list command should be a flag:
+resources. Thus, the publisher argument for the list command should be a flag:
 
 ```
-gcloud shelves books list --shelf=SHELF
+gcloud publishers books list --publisher=PUBLISHER
 ```
+
+## Changelog
+
+- **2020-09-23**: Changed the examples from "shelves" to "publishers", to
+  present a better example of resource ownership.


### PR DESCRIPTION
These were missed in #226.