### PR TITLE
Declarative-friendly API interfaces

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -308,9 +308,10 @@ message Book {
 ```
 
 **Note:** When referring to other resources in this way, we use the resource
-name as the value, not just the ID component. APIs **should** use the resource
-name to reference resources when possible. If using the ID component alone is
-strictly necessary, use an `_id` suffix (e.g. `shelf_id`).
+name as the value, not just the ID component. Services **should** use the
+resource name to reference resources when possible. If using the ID component
+alone is strictly necessary, the field **should** use an `_id` suffix (e.g.
+`shelf_id`).
 
 ## Further reading
 

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -43,6 +43,14 @@ the leading slash:
     characters that require URL-escaping, or characters outside of ASCII.
   - If Unicode characters can not be avoided, resource names **must** be stored
     in Normalization Form C (see [AIP-210][]).
+- Resources **must** expose a `name` field that contains its resource name.
+  - Resources **may** provide the resource ID as a separate field (e.g.
+    `book_id`).
+  - Resources **may** expose a separate, system-generated unique ID field
+    (`uid`).
+  - Resources **must not** expose tuples, self-links, or other forms of
+    resource identification.
+  - All ID fields **should** be strings.
 
 **Note:** Resource names as described here are used within the scope of a
 single API (or else in situations where the owning API is clear from the
@@ -102,17 +110,26 @@ ID for the publisher, and `les-miserables` is the resource ID for the book.
   server-generated if unset), or never set by users (not accepted at resource
   creation). They **should** be immutable once created.
   - If resource IDs are user-settable, the API **must** document allowed
-    formats.
+    formats. User-settable resource IDs **should** conform to [RFC-1034][],
+    which restricts to letters, numbers, and hyphen, with a 63 character
+    maximum.
+    - Additionally, user-settable resource IDs **should** restrict letters to
+      lower-case.
+    - Characters outside of ASCII **should not** be permitted; however, if
+      Unicode characters are necessary, APIs **must** follow guidance in
+      AIP-210.
+    - User-settable IDs **should not** be permitted to be a UUID (or any value
+      that syntactically appears to be a UUID).
   - If resource IDs are not user-settable, the API **should** document the
-    basic format, and any upper boundaries (for example, "at most 256
+    basic format, and any upper boundaries (for example, "at most 63
     characters").
   - For more information, see the [create][] standard method.
-- Resource IDs **should** only use characters that do not require URL-escaping.
-  - Characters outside of ASCII are discouraged; however, if Unicode characters
-    are necessary, APIs **must** follow guidance in [AIP-210][].
+
+**Important:** Resources that are declarative-friendly (AIP-128) **must** use
+user-settable resource IDs.
 
 [create]: ./0133.md#user-specified-ids
-[aip-210]: ./0210.md
+[rfc-1034]: https://tools.ietf.org/html/rfc1034
 
 ### Resource ID aliases
 
@@ -166,7 +183,7 @@ and the full resource does not change between these.
 When defining a resource, the first field **should** be the resource name,
 which **must** be of type `string` and **must** be called `name` for the
 resource name. The message **should** include a `google.api.resource`
-annotation declaring the type (see [AIP-123][] for more on this).
+annotation declaring the type (see AIP-123 for more on this).
 
 ```proto
 // A representation of a book in the library.
@@ -295,10 +312,12 @@ strictly necessary, use an `_id` suffix (e.g. `shelf_id`).
 
 - For evolving resource names over time, see
   [AIP-180](./0180.md#changing-resource-names).
-- For resource types, see [AIP-123][].
+- For resource types, see AIP-123.
 
 ## Changelog
 
+- **2020-09-17**: Added declarative-friendly guidance, and tightened character
+  set restrictions.
 - **2020-05-19**: Clarified that resource _IDs_ avoid capital characters, not
   the entire resource _name_.
 - **2020-04-27**: Tighten the restriction on valid characters.
@@ -308,5 +327,3 @@ strictly necessary, use an `_id` suffix (e.g. `shelf_id`).
   example from a Pub/Sub example to the usual Book example.
 - **2019-07-30**: Changed the nested collection brevity suggestion from "may"
   to "should"
-
-[aip-123]: ./0123.md

--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -1,7 +1,7 @@
 ---
 id: 128
 state: reviewing
-created: 2020-09-14
+created: 2020-10-06
 placement:
   category: resource-design
   order: 65

--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -84,8 +84,8 @@ database.
 ### Reconciliation
 
 If a resource takes time (more than a few seconds) for updates to be realized,
-the service **should** include an output only `bool reconciling` field to
-disclose that changes are in flight.
+the service **should** include a `bool reconciling` field to disclose that
+changes are in flight. This field **must** be output only.
 
 A resource **must** set the `reconciling` field to `true` if the current state
 of the resource does not match the user's intended state, and the system is

--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -1,0 +1,106 @@
+---
+id: 128
+state: reviewing
+created: 2020-09-14
+placement:
+  category: resource-design
+  order: 65
+---
+
+# Declarative-friendly interfaces
+
+Many services need to interact with common DevOps tools, particularly those
+that create and manage network-addressible resources (such as virtual machines,
+load balancers, database instances, and so on). These tools revolve around the
+principle of "configuration as code": the user specifies the complete intended
+landscape, and tooling is responsible for making whatever changes are necessary
+to achieve the user's specification.
+
+These tools are **declarative**: rather than specifying specific _actions_ to
+take, they specify the desired _outcome_, with the actions being derived based
+on the differences between the current landscape and the intended one.
+
+Furthermore, there are numerous popular DevOps tools, with more being
+introduced each year. Integrating hundreds of resource types with multiple
+tools requires strong consistency, so that integration can be automated.
+
+## Guidance
+
+Services **should** clearly delineate between "control plane" operations and
+"data plane" operations, ideally through the use of distinct services with
+their own interface definition documents.
+
+- Control plane operations are responsible for managing the _lifecycle_ of
+  resources.
+- Data plane operations are responsible for managing the _content_ of
+  resources.
+
+The same resource **may** have both control plane operations and data plane
+operations associated with it. For example, a database API would have
+operations to create or delete database tables (control plane) as well as
+operations to write and read rows to that table (data plane).
+
+### Resources
+
+Resources that are declarative-friendly **must** use only strongly-consistent
+standard methods for managing resource lifecycle, which allows tools to support
+these resources generically, as well as conforming to other
+declarative-friendly guidance (see [further reading](#further-reading)).
+
+Declarative-friendly resources **should** designate that they follow the
+declarative-friendly style:
+
+```proto
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+    style: DECLARATIVE_FRIENDLY
+  };
+
+  string name = 1;
+  // Other fields...
+}
+```
+
+### Annotations
+
+Declarative-friendly resources **must** include a
+`map<string, string> annotations` field to allow clients to store small amounts
+of arbitrary data.
+
+The `annotations` field **must** use the [Kubernetes limits][] to maintain wire
+compatibility, and **should** require dot-namespaced annotation keys to prevent
+tools from trampling over one another.
+
+**Note:** Annotations are distinct from various forms of labels. Labels can be
+used by server-side policies, such as IAM conditions. Annotations exist to
+allow client tools to store their own state information without requiring a
+database.
+
+<!-- prettier-ignore -->
+[kubernetes limits]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+
+### Reconciliation
+
+If a resource takes time (more than a few seconds) for updates to be realized,
+the service **should** include an output only `bool reconciling` field to
+disclose that changes are in flight.
+
+A resource **must** set the `reconciling` field to `true` if the current state
+of the resource does not match the user's intended state, and the system is
+working to reconcile them. This is regardless of whether the root cause of
+going into reconciliation was user or system action.
+
+**Note:** Services responding to a `GET` request **must** return the resource's
+current state (not the intended state).
+
+## Further reading
+
+A significant amount of guidance is more strict for declarative-friendly
+interfaces, due to the focus on automation on top of these resources. This list
+is a comprehensive reference to declarative-friendly guidance in other AIPs:
+
+- Resources **must** use user-settable resource IDs: see AIP-122.
+- Resources **must** include certain standard fields: see AIP-148.
+- Resources **must** have an `etag` field: see AIP-154.

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -93,7 +93,7 @@ message CreateBookRequest {
 
 Some resources take longer to create a resource than is reasonable for a
 regular API request. In this situation, the API **should** use a long-running
-operation instead:
+operation (AIP-151) instead:
 
 ```proto
 rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
@@ -111,6 +111,10 @@ rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
   be if the RPC was not long-running).
 - Both the `response_type` and `metadata_type` fields **must** be specified.
 
+**Important:** Declarative-friendly resources (AIP-128) **should** use
+long-running operations. The service **may** return an LRO that is already set
+to done if the request is effectively immediate.
+
 ### User-specified IDs
 
 Sometimes, an API needs to allow a client to specify the ID component of a
@@ -120,7 +124,7 @@ users are allowed to choose that portion of their resource names.
 For example:
 
 ```
-// Using user-settable IDs.
+// Using user-specified IDs.
 publishers/lacroix/books/les-miserables
 
 // Using system-generated IDs.
@@ -168,6 +172,9 @@ message CreateBookRequest {
     duplicate resource, the service **must** error with `PERMISSION_DENIED`
     instead.
 
+**Important:** Declarative-friendly resources (AIP-128) **must** support
+user-specified IDs.
+
 ## Further reading
 
 - For ensuring idempotency in `Create` methods, see [AIP-155][].
@@ -182,6 +189,7 @@ message CreateBookRequest {
 
 ## Changelog
 
+- **2020-09-17**: Added declarative-friendly guidance.
 - **2020-08-14**: Updated error guidance to use permission denied over
   forbidden.
 - **2020-06-08**: Added guidance on returning the full resource.

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -189,7 +189,7 @@ user-specified IDs.
 
 ## Changelog
 
-- **2020-09-17**: Added declarative-friendly guidance.
+- **2020-10-06**: Added declarative-friendly guidance.
 - **2020-08-14**: Updated error guidance to use permission denied over
   forbidden.
 - **2020-06-08**: Added guidance on returning the full resource.

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -111,7 +111,7 @@ rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
   be if the RPC was not long-running).
 - Both the `response_type` and `metadata_type` fields **must** be specified.
 
-**Important:** Declarative-friendly resources (AIP-128) **should** use
+**Important:** Declarative-friendly resources (AIP-128) **must** use
 long-running operations. The service **may** return an LRO that is already set
 to done if the request is effectively immediate.
 

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -111,7 +111,7 @@ rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
   be if the RPC was not long-running).
 - Both the `response_type` and `metadata_type` fields **must** be specified.
 
-**Important:** Declarative-friendly resources (AIP-128) **must** use
+**Important:** Declarative-friendly resources (AIP-128) **should** use
 long-running operations. The service **may** return an LRO that is already set
 to done if the request is effectively immediate.
 

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -279,8 +279,8 @@ exists.
 
 ## Changelog
 
-- **2020-09-22**: Added guidance for declarative-friendly resources.
-- **2020-09-22**: Added guidance for `allow_missing`.
+- **2020-10-06**: Added guidance for declarative-friendly resources.
+- **2020-10-06**: Added guidance for `allow_missing`.
 - **2020-08-14**: Added error guidance for permission denied cases.
 - **2020-06-08**: Added guidance on returning the full resource.
 - **2019-10-18**: Added guidance on annotations.

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -42,7 +42,7 @@ rpc UpdateBook(UpdateBookRequest) returns (Book) {
   `UpdateBookResponse`.)
   - The response **should** include the fully-populated resource, and **must**
     include any fields that were sent and included in the update mask unless
-    they are input only (see [AIP-203][]).
+    they are input only (see AIP-203).
   - If the update RPC is [long-running](#long-running-update), the response
     message **must** be a `google.longrunning.Operation` which resolves to the
     resource itself.
@@ -91,8 +91,12 @@ message UpdateBookRequest {
   `update_mask`.
   - The fields used in the field mask correspond to the resource being updated
     (not the request message).
-  - The field **may** be required or optional. If it is required, it **should**
-    include the corresponding annotation.
+  - The field **may** be required or optional. If it is required, it **must**
+    include the corresponding annotation. If optional, the service **must**
+    treat an omitted field mask as an implied field mask equivalent to all
+    fields that are set on the wire.
+  - Update masks **must** support a special value `*`, meaning full replacement
+    (the equivalent of `PUT`).
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
   or another AIP.
@@ -142,7 +146,7 @@ wiped out data because the previous version did not know about it.
 
 Some resources take longer to update a resource than is reasonable for a
 regular API request. In this situation, the API **should** use a long-running
-operation ([AIP-151][]) instead:
+operation (AIP-151) instead:
 
 ```proto
 rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
@@ -160,16 +164,48 @@ rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
   be if the RPC was not long-running).
 - Both the `response_type` and `metadata_type` fields **must** be specified.
 
+**Note:** Declarative-friendly resources (AIP-128) **must** use long-running
+update.
+
 ### Create or update
 
-If the API accepts client-assigned resource names, the server **may** allow the
-client to specify a non-existent resource name and create a new resource
-(effectively implementing the "upsert" concept). Otherwise, the Update method
-**should** fail with `NOT_FOUND`.
+If the service uses client-assigned resource names, `Update` methods **may**
+expose a `bool allow_missing` field, which will cause the method to succeed in
+the event that the user attempts to update a resource that is not present (and
+will create the resource in the process):
 
-An API with an update method that supports resource creation **should** also
-provide a [create][] method, because otherwise it may not be clear to users how
-to create resources.
+```proto
+message UpdateBookRequest {
+  // The book to update.
+  //
+  // The book's `name` field is used to identify the book to be updated.
+  // Format: publishers/{publisher}/books/{book}
+  Book book = 1 [(google.api.field_behavior) = REQUIRED];
+
+  // The list of fields to be updated.
+  google.protobuf.FieldMask update_mask = 2;
+
+  // If set to true, and the book is not found, a new book will be created.
+  bool allow_missing = 3;
+}
+```
+
+More specifically, the `allow_missing` flag triggers the following behavior:
+
+- If the method call is on a resource that does not exist, the resource is
+  created. All fields are applied regardless of any provided field mask.
+  - However, if any required fields are missing or fields have invalid values,
+    an `INVALID_ARGUMENT` error is returned.
+- If the method call is on a resource that already exists, and all fields
+  match, the existing resource is returned unchanged.
+- If the method call is on a resource that already exists, only fields declared
+  in the field mask are updated.
+
+The user must have _both_ the create and update permissions to call `Update`
+with `allow_missing` set to `true`.
+
+**Note:** Declarative-friendly resources (AIP-128) **must** expose the
+`bool allow_missing` field.
 
 ### Etags
 
@@ -227,8 +263,6 @@ so.
 
 [aip-121]: ./0121.md
 [create]: ./0133.md
-[aip-151]: ./0151.md
-[aip-203]: ./0203.md
 [state fields]: ./0216.md
 [required]: ./0203.md#required
 [optional]: ./0203.md#optional
@@ -242,6 +276,8 @@ exists.
 
 ## Changelog
 
+- **2020-09-22**: Added guidance for declarative-friendly resources.
+- **2020-09-22**: Added guidance for `allow_missing`.
 - **2020-08-14**: Added error guidance for permission denied cases.
 - **2020-06-08**: Added guidance on returning the full resource.
 - **2019-10-18**: Added guidance on annotations.

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -164,10 +164,12 @@ rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
   be if the RPC was not long-running).
 - Both the `response_type` and `metadata_type` fields **must** be specified.
 
-**Note:** Declarative-friendly resources (AIP-128) **must** use long-running
+**Note:** Declarative-friendly resources (AIP-128) **should** use long-running
 update.
 
 ### Create or update
+
+[^reviewing]
 
 If the service uses client-assigned resource names, `Update` methods **may**
 expose a `bool allow_missing` field, which will cause the method to succeed in
@@ -186,6 +188,7 @@ message UpdateBookRequest {
   google.protobuf.FieldMask update_mask = 2;
 
   // If set to true, and the book is not found, a new book will be created.
+  // In this situation, `update_mask` is ignored.
   bool allow_missing = 3;
 }
 ```

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -170,8 +170,8 @@ field for Delete requests.
 
 If the service uses client-assigned resource names, `Delete` methods **may**
 expose a `bool allow_missing` field, which will cause the method to succeed in
-the event that the user attempts to delete a resource that is not present (and
-no-op):
+the event that the user attempts to delete a resource that is not present (in
+which case the request is a no-op):
 
 ```proto
 message DeleteBookRequest {
@@ -192,7 +192,8 @@ message DeleteBookRequest {
 
 More specifically, the `allow_missing` flag triggers the following behavior:
 
-- If the method call is on a resource that does not exist, the request no-ops.
+- If the method call is on a resource that does not exist, the request is a
+  no-op.
   - The `etag` field is ignored.
 - If the method call is on a resource that already exists, the resource is
   deleted (subject to other checks).

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -107,11 +107,11 @@ rpc DeleteBook(DeleteBookRequest) returns (google.longrunning.Operation) {
 
 - The response type **must** be set to the appropriate return type if the RPC
   was not long-running: `google.protobuf.Empty` for most Delete RPCs, or the
-  resource itself for [soft delete](#soft-delete).
+  resource itself for soft delete (AIP-164).
 - Both the `response_type` and `metadata_type` fields **must** be specified
   (even if they are `google.protobuf.Empty`).
 
-**Note:** Declarative-friendly resources (AIP-128) **must** use long-running
+**Note:** Declarative-friendly resources (AIP-128) **should** use long-running
 delete.
 
 ### Cascading delete
@@ -165,6 +165,8 @@ request **must** fail with a `FAILED_PRECONDITION` error code.
 field for Delete requests.
 
 ### Delete if existing
+
+[^reviewing]
 
 If the service uses client-assigned resource names, `Delete` methods **may**
 expose a `bool allow_missing` field, which will cause the method to succeed in

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -226,10 +226,10 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
-- **2020-09-23**: Added guidance for declarative-friendly resources.
-- **2020-09-23**: Added guidance for allowing no-op delete for missing
+- **2020-10-06**: Added guidance for declarative-friendly resources.
+- **2020-10-06**: Added guidance for allowing no-op delete for missing
   resources.
-- **2020-09-23**: Moved soft delete and undelete guidance into a new AIP-164.
+- **2020-10-06**: Moved soft delete and undelete guidance into a new AIP-164.
 - **2020-06-08**: Added guidance for `Get` of soft-deleted resources.
 - **2020-02-03**: Added guidance for error cases.
 - **2019-10-18**: Added guidance on annotations.

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -13,7 +13,7 @@ In REST APIs, it is customary to make a `DELETE` request to a resource's URI
 (for example, `/v1/publishers/{publisher}/books/{book}`) in order to delete
 that resource.
 
-Resource-oriented design ([AIP-121][]) honors this pattern through the `Delete`
+Resource-oriented design (AIP-121) honors this pattern through the `Delete`
 method. These RPCs accept the URI representing that resource and usually return
 an empty response.
 
@@ -84,29 +84,8 @@ message DeleteBookRequest {
 
 ### Soft delete
 
-APIs **may** support the ability to "undelete", to allow for situations where
-users mistakenly delete resources and need the ability to recover.
-
-If a resource needs to support undelete, the Delete method **should** simply
-mark the resource as having been deleted, but not completely remove it from the
-system. If the method behaves this way, it **should** return the updated
-resource (not `google.protobuf.Empty`), with its [state][aip-216] set to
-`DELETED`.
-
-Soft-deleted resources **should not** show up in [`List`][aip-132] requests by
-default (unless `bool show_deleted` is true). [`Get`][aip-131] requests for
-soft-deleted resources **should** return the resource (rather than a
-`NOT_FOUND` error).
-
-The undelete functionality **should** be implemented through an "undelete"
-[custom method][aip-136].
-
-APIs that soft delete resources **may** choose a reasonable strategy for
-purging those resources, including automatic purging after a reasonable time
-(such as 30 days), allowing users to [set an expiry time][aip-214], or
-retaining the resources indefinitely. Regardless of what strategy is selected,
-the API **should** document when soft deleted resources will be completely
-removed.
+**Note:** This material was moved into its own document to provide a more
+comprehensive treatment: AIP-164.
 
 ### Long-running delete
 
@@ -131,6 +110,9 @@ rpc DeleteBook(DeleteBookRequest) returns (google.longrunning.Operation) {
   resource itself for [soft delete](#soft-delete).
 - Both the `response_type` and `metadata_type` fields **must** be specified
   (even if they are `google.protobuf.Empty`).
+
+**Note:** Declarative-friendly resources (AIP-128) **must** use long-running
+delete.
 
 ### Cascading delete
 
@@ -179,6 +161,43 @@ message DeleteBookRequest {
 If the etag is provided and does not match the server-computed etag, the
 request **must** fail with a `FAILED_PRECONDITION` error code.
 
+**Note:** Declarative-friendly resources (AIP-128) **must** provide the `etag`
+field for Delete requests.
+
+### Delete if existing
+
+If the service uses client-assigned resource names, `Delete` methods **may**
+expose a `bool allow_missing` field, which will cause the method to succeed in
+the event that the user attempts to delete a resource that is not present (and
+no-op):
+
+```proto
+message DeleteBookRequest {
+  // The book to delete.
+  //
+  // The book's `name` field is used to identify the book to be updated.
+  // Format: publishers/{publisher}/books/{book}
+  Book book = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+
+  // If set to true, and the book is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
+}
+```
+
+More specifically, the `allow_missing` flag triggers the following behavior:
+
+- If the method call is on a resource that does not exist, the request no-ops.
+  - The `etag` field is ignored.
+- If the method call is on a resource that already exists, the resource is
+  deleted (subject to other checks).
+
+**Note:** Declarative-friendly resources (AIP-128) **should** expose the
+`bool allow_missing` field.
+
 ### Errors
 
 If the user does not have permission to access the resource, regardless of
@@ -187,9 +206,9 @@ whether or not it exists, the service **must** error with `PERMISSION_DENIED`
 exists.
 
 If the user does have proper permission, but the requested resource does not
-exist, the service **must** error with `NOT_FOUND` (HTTP 404).
+exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
+`allow_missing` is set to `true`.
 
-[aip-121]: ./0121.md
 [aip-123]: ./0123.md
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md
@@ -198,8 +217,17 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 [aip-216]: ./0216.md
 [etag]: ./0134.md#etags
 
+## Further reading
+
+- For soft delete and undelete, see AIP-164.
+- For bulk deleting large numbers of resources based on a filter, see AIP-165.
+
 ## Changelog
 
+- **2020-09-23**: Added guidance for declarative-friendly resources.
+- **2020-09-23**: Added guidance for allowing no-op delete for missing
+  resources.
+- **2020-09-23**: Moved soft delete and undelete guidance into a new AIP-164.
 - **2020-06-08**: Added guidance for `Get` of soft-deleted resources.
 - **2020-02-03**: Added guidance for error cases.
 - **2019-10-18**: Added guidance on annotations.

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -9,7 +9,7 @@ placement:
 
 # Custom methods
 
-[Resource-oriented design][aip-121] uses custom methods to provide a means to
+Resource-oriented design (AIP-121) uses custom methods to provide a means to
 express arbitrary actions that are difficult to model using only the standard
 methods. Custom methods are important because they provide a means for an API's
 vocabulary to adhere to user intent.
@@ -105,9 +105,19 @@ rpc TranslateText(TranslateTextRequest) returns (TranslateTextResponse) {
   collection). For example, `:translateText` is preferable to `text:translate`.
 - Stateless methods **must** use `POST` if they involve billing.
 
-[aip-121]: ./0121.md
+### Declarative-friendly resources
+
+Declarative-friendly resources usually **should not** employ custom methods
+(except specific declarative-friendly custom methods discussed in other AIPs),
+because declarative-friendly tools are unable to automatically determine what
+to do with them.
+
+An exception to this is for rarely-used, fundamentally imperative method, such
+as a `Move` or `Rename` method, for which there would not be an expectation of
+declarative support.
 
 ## Changelog
 
-- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+- **2020-09-22:** Added declarative-friendly guidance.
+- **2019-08-01:** Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -120,6 +120,6 @@ expectation of declarative support.
 
 ## Changelog
 
-- **2020-09-22:** Added declarative-friendly guidance.
+- **2020-10-06:** Added declarative-friendly guidance.
 - **2019-08-01:** Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -107,14 +107,16 @@ rpc TranslateText(TranslateTextRequest) returns (TranslateTextResponse) {
 
 ### Declarative-friendly resources
 
+[^reviewing]
+
 Declarative-friendly resources usually **should not** employ custom methods
 (except specific declarative-friendly custom methods discussed in other AIPs),
 because declarative-friendly tools are unable to automatically determine what
 to do with them.
 
-An exception to this is for rarely-used, fundamentally imperative method, such
-as a `Move` or `Rename` method, for which there would not be an expectation of
-declarative support.
+An exception to this is for rarely-used, fundamentally imperative operations,
+such as a `Move` or `Rename` operation, for which there would not be an
+expectation of declarative support.
 
 ## Changelog
 

--- a/aip/general/0148.md
+++ b/aip/general/0148.md
@@ -43,20 +43,6 @@ resource. When provided, this field **should** be a [UUID4][].
 <!-- prettier-ignore -->
 [uuid4]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
 
-#### short_name
-
-The `string short_name` field **must** refer to a short, human-friendly value
-that uniquely identifies a resource of a specific type within a namespace.
-Policies **may** reference resources by using their short name as the final
-component of the resource name.
-
-**Note:** Short names **should** be immutable, because policies of various
-types might reference resources using the short name, and mutable short names
-have the potential to cause reference confusion.
-
-**Note:** A short name does not represent a general alias because it is
-immutable, and the resource type is required context.
-
 ### Other names
 
 #### display_name

--- a/aip/general/0148.md
+++ b/aip/general/0148.md
@@ -1,0 +1,139 @@
+---
+id: 148
+state: reviewing
+created: 2020-09-14
+placement:
+  category: fields
+  order: 90
+---
+
+# Standard fields
+
+Certain concepts are common throughout any corpus of APIs. In these situations,
+it is useful to have a standard field name that is used consistently to
+communicate that concept.
+
+## Guidance
+
+Standard fields **should** be used to describe their corresponding concept, and
+**should not** be used for any other purpose.
+
+### Resource names and IDs
+
+#### name
+
+Every resource **must** have a `string name` field, used for the resource name
+(AIP-122), which **should** be the first field in the resource.
+
+**Note:** The `_name` suffix **should not** be used to describe other types of
+names unless otherwise covered in this AIP.
+
+#### parent
+
+The `string parent` field refers to the resource name of the parent of a
+collection, and **should** be used in most `List` (AIP-132) and `Create`
+(AIP-133) requests.
+
+#### uid
+
+The `string uid` field refers to a system-assigned, unique identifier for a
+resource. When provided, this field **should** be a [UUID4][].
+[Declarative-friendly resources][] **should** include this field.
+
+<!-- prettier-ignore -->
+[uuid4]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
+
+#### short_name
+
+The `string short_name` field **must** refer to a short, human-friendly value
+that uniquely identifies a resource of a specific type within a namespace.
+Policies **may** reference resources by using their short name as the final
+component of the resource name.
+
+**Note:** Short names **should** be immutable, because policies of various
+types might reference resources using the short name, and mutable short names
+have the potential to cause reference confusion.
+
+**Note:** A short name does not represent a general alias because it is
+immutable, and the resource type is required context.
+
+### Other names
+
+#### display_name
+
+The `string display_name` field **must** be a mutable, user-settable field
+where the user can provide a human-readable name to be used in user interfaces.
+[Declarative-friendly resources][] **should** include this field.
+
+Display names **should not** have uniqueness requirements, and **should** be
+limited to <= 63 characters.
+
+#### title
+
+The `string title` field **should** be the official name of an entity, such as
+a company's name. This is a more formal variant of `string display_name`.
+
+#### given_name
+
+The `string given_name` field **must** refer to a human or animal's given name.
+Resources **must not** use `first_name` for this concept, because the given
+name is not placed first in many cultures.
+
+#### family_name
+
+The `string family_name` field **must** refer to a human or animal's family
+name. Resources **must not** use `last_name` for this concept, because the
+family name is not placed last in many cultures.
+
+### Lifecycle
+
+#### deleted
+
+The output only `bool deleted` field **must** be provided on resources that
+support soft delete (AIP-135), and set to `true` if the resource is currently
+soft deleted.
+
+### Timestamps
+
+#### create_time
+
+The output only `google.protobuf.Timestamp create_time` field **must**
+represent the timestamp when the resource was created. This **may** be either
+the time creation was initiated or the time it was completed.
+[Declarative-friendly resources][] **should** include this field.
+
+#### update_time
+
+The output only `google.protobuf.Timestamp update_time` field **must**
+represent the timestamp when the resource was most recently updated. Any change
+to the resource made by users **must** refresh this value; changes to a
+resource made internally by the service **may** refresh this value.
+[Declarative-friendly resources][] **should** include this field.
+
+#### delete_time
+
+The `google.protobuf.Timestamp delete_time` field **must** represent the
+timestamp that a resource was soft deleted. This **may** correspond to either
+the time when the user requested deletion, or when the service successfully
+soft deleted the resource. If a resource is not soft deleted, the `delete_time`
+field **must** be empty.
+
+Resources that support soft delete (AIP-164) **should** provide this field.
+
+#### expire_time
+
+The `google.protobuf.Timestamp expire_time` field **should** usually represent
+the time when a soft deleted resource will be purged from the system. It
+**may** be used for similar forms of expiration as described in AIP-214.
+Resources that support soft delete **should** include this field.
+
+In some situations, it can be difficult to provide an exact `expire_time`
+value, because of implementation dependencies. Services **may** provide an
+`expire_time` value that is inexact, but the resource **must not** be expired
+from the system before that time.
+
+Resources that support soft delete (AIP-164) **should** provide this field.
+
+## Further reading
+
+[declarative-friendly resources]: ./0128.md#resources

--- a/aip/general/0148.md
+++ b/aip/general/0148.md
@@ -1,7 +1,7 @@
 ---
 id: 148
 state: reviewing
-created: 2020-09-14
+created: 2020-10-06
 placement:
   category: fields
   order: 90

--- a/aip/general/0148.md
+++ b/aip/general/0148.md
@@ -71,14 +71,6 @@ The `string family_name` field **must** refer to a human or animal's family
 name. Resources **must not** use `last_name` for this concept, because the
 family name is not placed last in many cultures.
 
-### Lifecycle
-
-#### deleted
-
-The output only `bool deleted` field **must** be provided on resources that
-support soft delete (AIP-135), and set to `true` if the resource is currently
-soft deleted.
-
 ### Timestamps
 
 #### create_time

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -58,6 +58,8 @@ For example, a valid etag is `"foo"`, not `foo`.
 
 ### Declarative-friendly resources
 
+[^reviewing]
+
 A resource that is declarative-friendly (AIP-128) **must** include an `etag`
 field.
 
@@ -65,8 +67,7 @@ field.
 
 In some situations, the etag needs to belong on a request message rather than
 the resource itself. For example, an `Update` standard method can "piggyback"
-off the `etag` field on the resource, but the `Delete` standard method can
-not:
+off the `etag` field on the resource, but the `Delete` standard method can not:
 
 ```proto
 message DeleteBookRequest {

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -110,7 +110,7 @@ prefix as mandated by [RFC 7232][].
 
 ## Changelog
 
-- **2020-09-22**: Added declarative-friendly resource requirement.
+- **2020-10-06**: Added declarative-friendly resource requirement.
 - **2020-09-02**: Clarified that other errors may take precedence over
   `FAILED_PRECONDITION` for etag mismatches.
 - **2020-09-02**: Add guidance for etags on request messages.

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -54,6 +54,11 @@ message Book {
 **Note:** ETag values **should** include quotes as described in [RFC 7232][].
 For example, a valid etag is `"foo"`, not `foo`.
 
+### Declarative-friendly resources
+
+A resource that is declarative-friendly (AIP-128) **must** include an `etag`
+field.
+
 ### Strong and weak etags
 
 ETags can be either "strongly validated" or "weakly validated":
@@ -76,4 +81,5 @@ prefix as mandated by [RFC 7232][].
 
 ## Changelog
 
+- **2020-09-22**: Added declarative-friendly resource requirement.
 - **2019-09-23**: Changed the title to "resource freshness validation".

--- a/aip/general/0163.md
+++ b/aip/general/0163.md
@@ -48,6 +48,8 @@ validation requests in this situation.
 
 ### Declarative-friendly resources
 
+[^reviewing]
+
 A resource that is declarative-friendly (AIP-128) **must** include a
 `validate_only` field on methods that mutate the resource.
 

--- a/aip/general/0163.md
+++ b/aip/general/0163.md
@@ -45,3 +45,12 @@ if it determines that the actual request would fail.
 example, if creating a resource would create an auto-generated ID, it does not
 make sense to do this on validation. APIs **should** omit such fields on
 validation requests in this situation.
+
+### Declarative-friendly resources
+
+A resource that is declarative-friendly (AIP-128) **must** include a
+`validate_only` field on methods that mutate the resource.
+
+## Changelog
+
+- **2020-09-22:** Added declarative-friendly resource requirement.

--- a/aip/general/0163.md
+++ b/aip/general/0163.md
@@ -55,4 +55,4 @@ A resource that is declarative-friendly (AIP-128) **must** include a
 
 ## Changelog
 
-- **2020-09-22:** Added declarative-friendly resource requirement.
+- **2020-10-06:** Added declarative-friendly resource requirement.

--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -1,7 +1,7 @@
 ---
 id: 164
 state: reviewing
-created: 2020-09-23
+created: 2020-10-06
 placement:
   category: design-patterns
   order: 95

--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -19,8 +19,8 @@ resources that were deleted by accident.
 APIs **may** support the ability to "undelete", to allow for situations where
 users mistakenly delete resources and need the ability to recover.
 
-If a resource needs to support undelete, the Delete method **must** simply mark
-the resource as having been deleted, but not completely remove it from the
+If a resource needs to support undelete, the `Delete` method **must** simply
+mark the resource as having been deleted, but not completely remove it from the
 system. If the method behaves this way, it **should** return the updated
 resource instead of `google.protobuf.Empty`.
 
@@ -97,8 +97,8 @@ rpc UndeleteBook(UndeleteBookRequest) returns (google.longrunning.Operation) {
 
 ### List and Get
 
-Soft-deleted resources **should not** show up in `List` (AIP-132) requests by
-default (unless `bool show_deleted` is true). `Get` (AIP-131) requests for
+Soft-deleted resources **should not** be returned in `List` (AIP-132) responses
+by default (unless `bool show_deleted` is true). `Get` (AIP-131) requests for
 soft-deleted resources **should** return the resource (rather than a
 `NOT_FOUND` error).
 

--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -1,0 +1,155 @@
+---
+id: 164
+state: reviewing
+created: 2020-09-23
+placement:
+  category: design-patterns
+  order: 95
+---
+
+# Soft delete
+
+There are several reasons why a client could desire soft delete and undelete
+functionality, but one over-arching reason stands out: recovery from mistakes.
+A service that supports undelete makes it possible for users to recover
+resources that were deleted by accident.
+
+## Guidance
+
+APIs **may** support the ability to "undelete", to allow for situations where
+users mistakenly delete resources and need the ability to recover.
+
+If a resource needs to support undelete, the Delete method **must** simply mark
+the resource as having been deleted, but not completely remove it from the
+system. If the method behaves this way, it **should** return the updated
+resource instead of `google.protobuf.Empty`.
+
+Resources that support soft delete **must** have an `expire_time` field as
+described in AIP-148. Additionally, resources **should** include a `DELETED`
+state value if the resource includes a `state` field (AIP-216).
+
+### Undelete
+
+A resource that supports soft delete **should** provide an `Undelete` method:
+
+```proto
+rpc UndeleteBook(UndeleteBookRequest) returns (Book) {
+  post: "/v1/{name=publishers/*/books/*}:undelete"
+  body: "*"
+}
+```
+
+- The HTTP verb **must** be `POST`.
+- The `body` clause **must** be `"*"`.
+- The response message **must** be the resource itself. There is no
+  `UndeleteBookResponse`.
+  - The response **should** include the fully-populated resource unless it is
+    infeasible to do so.
+  - If the create RPC is [long-running](#long-running-undelete), the response
+    message **must** be a `google.longrunning.Operation` which resolves to the
+    resource itself.
+
+### Undelete request message
+
+Undelete methods implement a common request message pattern:
+
+```proto
+message UndeleteBookRequest {
+  // The name of the deleted book.
+  // Format: publishers/{publisher}/books/{book}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"];
+}
+```
+
+- A `name` field **must** be included. It **should** be called `name`.
+  - The field **should** be annotated as required.
+  - The field **should** identify the [resource type][aip-123] that it
+    references.
+  - The comment for the field **should** document the resource pattern.
+- The request message **must not** contain any other required fields, and
+  **should not** contain other optional fields except those described in this
+  or another AIP.
+
+### Long-running undelete
+
+Some resources take longer to undelete a resource than is reasonable for a
+regular API request. In this situation, the API **should** use a long-running
+operation (AIP-151) instead:
+
+```proto
+rpc UndeleteBook(UndeleteBookRequest) returns (google.longrunning.Operation) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*}:undelete"
+    body: "*"
+  };
+  option (google.longrunning.operation_info) = {
+    response_type: "Book"
+    metadata_type: "OperationMetadata"
+  }
+}
+```
+
+- The response type **must** be set to the resource (what the return type would
+  be if the RPC was not long-running).
+- Both the `response_type` and `metadata_type` fields **must** be specified.
+
+### List and Get
+
+Soft-deleted resources **should not** show up in `List` (AIP-132) requests by
+default (unless `bool show_deleted` is true). `Get` (AIP-131) requests for
+soft-deleted resources **should** return the resource (rather than a
+`NOT_FOUND` error).
+
+APIs that soft delete resources **may** choose a reasonable strategy for
+purging those resources, including automatic purging after a reasonable time
+(such as 30 days), allowing users to set an expiry time (AIP-214), or retaining
+the resources indefinitely. Regardless of what strategy is selected, the API
+**should** document when soft deleted resources will be completely removed.
+
+### Declarative-friendly resources
+
+A resource that is declarative-friendly (AIP-128) **should** support soft
+delete and undelete.
+
+**Important:** There is an ambiguity in declarative tooling between "create"
+and "undelete". When given an alias which was previously deleted and a
+directive to make it exist, tooling usually does not know if the intent is to
+restore the previously-deleted resource, or create a new one with the same
+alias. Declarative tools **should** resolve this ambiguity in favor of creating
+a new resource: the only way to undelete is to explicitly use the undelete RPC
+(an imperative operation), and declarative tools **may** elect not to map
+anything to undelete at all.
+
+Declarative-friendly resources **must** use long-running operations for both
+soft delete and undelete. The service **may** return an LRO that is already set
+to done if the request is effectively immediate.
+
+Declarative-friendly resources **must** include `validate_only` (AIP-163) and
+`etag` (AIP-154) in their `Undelete` methods.
+
+### Errors
+
+If the user does not have permission to access the resource, regardless of
+whether or not it exists, the service **must** error with `PERMISSION_DENIED`
+(HTTP 403). Permission **must** be checked prior to checking if the resource
+exists.
+
+If the user does have proper permission, but the requested resource does not
+exist (either it was never created or already expunged), the service **must**
+error with `NOT_FOUND` (HTTP 404).
+
+If the user has proper permission, but the requested resource is not deleted,
+the service **must** respond with `ALREADY_EXISTS` (HTTP 409).
+
+## Further reading
+
+- For the `Delete` standard method, see AIP-135.
+- For long-running operations, see AIP-151.
+- For resource freshness validation (`etag`), see AIP-154.
+- For change validation (`validate_only`), see AIP-163.
+
+## Changelog
+
+- **2020-09-23**: Soft delete material in AIP-135 migrated to this AIP.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aip-site-generator==0.3.0
+aip-site-generator==0.4.0


### PR DESCRIPTION
This takes our internal declarative-friendly API interfaces doc and distills the information into AIPs.

This adds:
- AIP-128: Declarative-friendly interfaces
- AIP-148: Standard fields
- AIP-164: Soft delete

This modifies to add declarative-friendly guidance:
- AIP-122: Resource names
- AIP-133: Create
- AIP-134: Update
- AIP-135: Delete
- AIP-136: Custom methods
- AIP-144: Repeated fields
- AIP-154: Etags
- AIP-163: Change validation
- AIP-216: States