### PR TITLE
style fixes for state transition method comments

### DIFF
--- a/aip/general/0216.md
+++ b/aip/general/0216.md
@@ -76,9 +76,9 @@ field. The method definition should look like the following:
 
 ```proto
 // Publishes a book.
-// The `state` of the book after publishing will be PUBLISHED.
-// `PublishBook` can be called on Books in the state DRAFT; Books in a
-// different state (including PUBLISHED) will return an error.
+// The `state` of the book after publishing is `PUBLISHED`.
+// `PublishBook` can be called on Books in the state `DRAFT`; Books in a
+// different state (including `PUBLISHED`) will return an error.
 rpc PublishBook(PublishBookRequest) returns (Book) {
   option (google.api.http) = {
     post: "/v1/{name=publishers/*/books/*}:publish"


### PR DESCRIPTION
Apply style fixes to state transition method comments that came up in a recent internal review.