### PR TITLE
Fix example create URI in AIP-127

### DIFF
--- a/aip/general/0127.md
+++ b/aip/general/0127.md
@@ -32,7 +32,7 @@ using the `google.api.http` annotation:
 ```proto
 rpc CreateBook(CreateBookRequest) returns (Book) {
   option (google.api.http) = {
-    post: "/v1/{parent=publishers/*}/books/*"
+    post: "/v1/{parent=publishers/*}/books"
     body: "book"
   };
 }


### PR DESCRIPTION
For Create methods, the URI should be the collection being written to, as in https://google.aip.dev/133#guidance.

Fixes #649.