### PR TITLE
fix: AIP-216 add value prefix guidance

### DIFF
--- a/aip/general/0216.md
+++ b/aip/general/0216.md
@@ -152,7 +152,7 @@ values into a single namespace.
 
 State enums **should** live inside the resource definition.
 
-### Value prefix
+### Prefixes
 
 Using a `STATE_` prefix on every enum value is unnecessary. State enum values
 **should not** be prefixed with the enum name, except for the default value

--- a/aip/general/0216.md
+++ b/aip/general/0216.md
@@ -152,6 +152,12 @@ values into a single namespace.
 
 State enums **should** live inside the resource definition.
 
+### Value prefix
+
+Using a `STATE_` prefix on every enum value is unnecessary. State enum values
+**should not** be prefixed with the enum name, except for the default value
+`STATE_UNSPECIFIED`.
+
 ### Breaking changes
 
 **TL;DR:** Clearly communicate to users that state enums may receive new values
@@ -226,6 +232,7 @@ necessary.
 
 ## Changelog
 
+- **2020-10-20**: Added guidance on prefixing enum values with enum name.
 - **2020-09-02**: Clarified that states are not directly set on create either.
 - **2019-12-05**: Changed guidance on state transition methods, downgrading
   **must** to **should** on the response type.


### PR DESCRIPTION
It came up in API review that AIP-216 doesn't provide guidance on using the enum name as prefix for all values. This suggests that State enum values (other than the default `STATE_UNSPECIFIED`) **should not** be prefixed with `STATE_`.

This could be applied to enums in general, in which case this would belong in AIP-126.