### PR TITLE
AIP-203: Define the term "truthy".

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -54,9 +54,11 @@ A field **should** only be described as required if _either_:
   provided as part of the request, and failure to do so **must** cause an error
   (usually `INVALID_ARGUMENT`).
 
-**Note:** We define the term "truthy" as follows: For primitives, repeated
-fields, and maps, a value is truthy if `bool(value)` would evaluate to `True`
-in Python. For messages, a value is truthy if it is non-empty.
+We define the term "truthy" above as follows:
+
+- For primitives, values other than `0`, `0.0`, empty string/bytes, and `false`
+- For repeated fields maps, values with at least one entry
+- For messages, any message with at least one "truthy" field.
 
 Fields **should not** be described as required in order to signify:
 

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -43,7 +43,7 @@ a non-empty value) on the request or resource.
 A field **should** only be described as required if _either_:
 
 - It is a field on a resource that a user provides somewhere as input. In this
-  case, the resource is only valid if a truthy value is _stored_.
+  case, the resource is only valid if a "truthy" value is _stored_.
   - When [creating][aip-133] the resource, a value **must** be provided for the
     field on the create request.
   - When [updating][aip-134] the resource, the user **may** omit the field
@@ -53,6 +53,10 @@ A field **should** only be described as required if _either_:
   with a name usually ending in `Request`). In this case, a value **must** be
   provided as part of the request, and failure to do so **must** cause an error
   (usually `INVALID_ARGUMENT`).
+
+**Note:** We define the term "truthy" as follows: For primitives, repeated
+fields, and maps, a value is truthy if `bool(value)` would evaluate to `True`
+in Python. For messages, a value is truthy if it is non-empty.
 
 Fields **should not** be described as required in order to signify:
 
@@ -69,10 +73,10 @@ error. A corollary to this is that a required boolean must be set to `true`.
 ### Output only
 
 The use of `OUTPUT_ONLY` indicates that the field is provided in responses, but
-that including the field in a message in a request does nothing (the server **must**
-clear out any value in this field and **must not** throw an error as a result of the
-presence of a value in this field on input). Similarly, services **must** ignore the
-presence of output only fields in update field masks.
+that including the field in a message in a request does nothing (the server
+**must** clear out any value in this field and **must not** throw an error as a
+result of the presence of a value in this field on input). Similarly, services
+**must** ignore the presence of output only fields in update field masks.
 
 Additionally, a field **should** only be described as output only if it is a
 field in a resource message, or a field of a message farther down the tree.
@@ -102,7 +106,7 @@ be described as input only because this is already implied.
 
 Potential use cases for input only fields (this is not an exhaustive list) are:
 
-- The `ttl` field as described in [AIP-214][].
+- The `ttl` field as described in AIP-214.
 
 **Warning:** Input only fields are rare and should be considered carefully
 before use.
@@ -145,7 +149,6 @@ either all optional fields should be indicated, or none of them should be.
 
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md
-[aip-214]: ./0214.md
 
 ## Changelog
 


### PR DESCRIPTION
As much as I dislike coining a word, I can not think of any better term for this, so instead, just provide a formal definition.

Python is the best known useful reference language here, since JavaScript has different, less useful semantics (e.g. empty array is `true` there).

Fixes #659.