### PR TITLE
chore: Update site generator to 0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aip-site-generator==0.4.0
+aip-site-generator==0.5.0


### PR DESCRIPTION
I can not for the life of me determine why Renovate is not just handling this.