### PR TITLE
update aip-156 to use a clearly singular example.

### DIFF
--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -11,7 +11,7 @@ placement:
 
 APIs sometimes need to represent a resource where exactly one instance of the
 resource always exists within any given parent. A common use case for this is
-for a settings object.
+for a config object.
 
 ## Guidance
 
@@ -20,16 +20,16 @@ always exist by virtue of the existence of its parent, with one and exactly one
 per parent.
 
 ```proto
-rpc GetSettings(GetSettingsRequest) returns (Settings) {
+rpc GetConfig(GetConfigRequest) returns (Config) {
   option (google.api.http) = {
-    get: "/v1/{name=users/*/settings}"
+    get: "/v1/{name=users/*/config}"
   };
 }
 
-rpc UpdateSettings(UpdateSettingsRequest) returns (Settings) {
+rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
   option (google.api.http) = {
-    patch: "/v1/{settings.name=users/*/settings}"
-    body: "settings"
+    patch: "/v1/{config.name=users/*/config}"
+    body: "config"
   };
 }
 ```
@@ -37,13 +37,15 @@ rpc UpdateSettings(UpdateSettingsRequest) returns (Settings) {
 - Singleton resources **must not** have a user-provided or system-generated ID;
   their [resource name][aip-122] includes the name of their parent followed by
   one static-segment.
-  - Example: `users/1234/settings`
+  - Example: `users/1234/config`
 - Singleton resources **must not** define the [`Create`][aip-133],
   [`List`][aip-132], or [`Delete`][aip-135] standard methods. The singleton is
   implicitly created or deleted when its parent is created or deleted.
 - Singleton resource **should** define the [`Get`][aip-131] and
   [`Update`][aip-134] methods, and **may** define custom methods as
   appropriate.
+- Singleton resources are always singular.
+   - Example: 'users/1234/thing'
 
 [aip-122]: ./0122.md
 [aip-131]: ./0131.md

--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -47,6 +47,10 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
 - Singleton resources are always singular.
    - Example: 'users/1234/thing'
 
+## Changelog
+
+- **2021-01-14:** Changed example from `settings` to `config` for clarity.
+
 [aip-122]: ./0122.md
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md


### PR DESCRIPTION
Changed from "settings" to "config".  This makes it clearer that singleton objects are singular and not plural.