### PR TITLE
 Update 0151.md: Fix extra '}' in URI AIP 151.

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -28,7 +28,7 @@ ultimate response message.
 // Write a book.
 rpc WriteBook(WriteBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
-    post: "/v1/{parent=publishers/*}/books}:write"
+    post: "/v1/{parent=publishers/*}/books:write"
     body: "*"
   };
   option (google.longrunning.operation_info) = {


### PR DESCRIPTION
The URI contains an extra '}' which seems to be incorrect.