### PR TITLE
Update 0128.md

### DIFF
--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -101,7 +101,7 @@ A significant amount of guidance is more strict for declarative-friendly
 interfaces, due to the focus on automation on top of these resources. This list
 is a comprehensive reference to declarative-friendly guidance in other AIPs:
 
-- Resources **must** use user-settable resource IDs: see AIP-122.
+- Resources **must** use user-settable resource IDs: see AIP-133.
 - Resources **must** permit "create or update": see AIP-134.
 - Resources **should** permit "delete if existing": see AIP-135.
 - Resources **should not** employ custom methods: see AIP-136.


### PR DESCRIPTION
Fix link, where AIP 133 is actually the one defining the user-settable resource IDs