### PR TITLE
AIP-162: Forbid deleting only remaining revision

### DIFF
--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -379,6 +379,10 @@ message DeleteBookRevisionRequest {
   (this could lead to dangerous or confusing mistakes).
 - If the resource supports soft delete, then revisions of that resource
   **should** also support soft delete.
+- The method **must not** cause the _resource_ to be deleted.
+  - Because a resource **should not** exist with zero revisions, the method
+    **must** fail with `FAILED_PRECONDITION` if the user attempts to delete the
+    only revision.
 
 ## Appendix: Character Collision
 


### PR DESCRIPTION
The guidance for AIP-162 indicates that a revisioned resource should at all times have at least one revision, since it should always have a non-empty value with which to populate the revision_id field.

The behavior of Delete is to destroy the resource entirely, including any child resources if the optional 'force' flag is set. DeleteRevision doesn't indicate that the 'force' flag is permitted, which suggests that DeleteRevision can't delete a resource entirely.

Allowing DeleteRevision to delete all revisions of a resource could circumvent a policy preventing the user from deleting the resource directly.