### PR TITLE
Suggests "preempt" pattern for LROs.

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -83,9 +83,13 @@ but is not obligated to do so:
 
 - Resources that accept multiple parallel operations **may** place them in a
   queue rather than work on the operations simultaneously.
-- Resource that does not permit multiple operations in parallel (denying any
+- Resources that do not permit multiple operations in parallel (denying any
   new operation until the one that is in progress finishes) **must** return
   `ABORTED` if a user attempts a parallel operation, and include an error
+  message explaining the situation.
+- Resources with declarative-friendly APIs **may** allow subsequent updates to
+  preempt existing operations. In this case, the last update continues
+  processing and previous operations are marked as `ABORTED` with an error
   message explaining the situation.
 
 ### Expiration

--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -87,10 +87,10 @@ but is not obligated to do so:
   new operation until the one that is in progress finishes) **must** return
   `ABORTED` if a user attempts a parallel operation, and include an error
   message explaining the situation.
-- Resources with declarative-friendly APIs **may** allow subsequent updates to
-  preempt existing operations. In this case, the last update continues
-  processing and previous operations are marked as `ABORTED` with an error
-  message explaining the situation.
+- Resources with [declarative-friendly APIs][aip-128] **may** allow subsequent
+  updates to preempt existing operations. In this case, the latest update
+  begins processing and previous operations are marked as `ABORTED` with an
+  error message explaining the situation.
 
 ### Expiration
 
@@ -109,6 +109,7 @@ metadata message. The errors themselves **must** still be represented with a
 [google.rpc.Status][] object.
 
 <!-- prettier-ignore-start -->
+[aip-128]: ./0128.md
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md
 [aip-133]: ./0133.md


### PR DESCRIPTION
In a declarative-friendly API, the user is generally specifying the state of the world they want and expecting the resources to eventually reach that state. In this case it may be desirable for the user to preempt the existing operation in favor of the new state.

This isn't really explicitly covered in the guidance but seems compatible with the patterns overall, so I've tried to specify it. PTAL! 