### PR TITLE
style: Link google.protobuf.FieldMask in AIP-134

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -87,8 +87,8 @@ message UpdateBookRequest {
   - A `name` field **must** be included in the resource message. It **should**
     be called `name`.
 - A field mask **should** be included in order to support partial update. It
-  **must** be of type `google.protobuf.FieldMask`, and it **should** be called
-  `update_mask`.
+  **must** be of type [`google.protobuf.FieldMask`][field_mask], and it
+  **should** be called `update_mask`.
   - The fields used in the field mask correspond to the resource being updated
     (not the request message).
   - The field **may** be required or optional. If it is required, it **must**
@@ -270,6 +270,7 @@ so.
 [state fields]: ./0216.md
 [required]: ./0203.md#required
 [optional]: ./0203.md#optional
+[field_mask]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/field_mask.proto
 
 ### Errors
 


### PR DESCRIPTION
Make it easier for readers of AIP-134 to quickly jump to the description of FieldMask type, saving time vs. searching for it on the net. The markup used mimics the one from AIP-142.