### PR TITLE
Offer guidance on overlapping-but-distinct view enums.

### DIFF
--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -51,6 +51,11 @@ enum BookView {
 - APIs **may** add fields to a given view over time. APIs **must not** remove a
   field from a given view (this is a breaking change).
 
+  **Note:** If a service requires (or might require) multiple views with
+  overlapping but distinct values, there is a potential for a namespace
+  conflict. In this situation, the service **should** nest the view enum within
+  the individual resource.
+
 ### Read masks
 
 Read masks are useful for granting the user fine-grained control over what

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -107,3 +107,7 @@ APIs **should not** be providing resource views unless they are truly needed.
 to either support view enums or read masks across the board, but not mix and
 match. If an API does support both, it **must not** support both a view and a
 read mask on the same resource.
+
+## Changelog
+
+- **2021-03-04:** Added guidance for conflicting view enums.


### PR DESCRIPTION
Fixes a Google internal bug (134073964).