### PR TITLE
fix: Etag failures should use ABORTED.

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -242,9 +242,9 @@ message Book {
 
 The `etag` field **may** be either [required][] or [optional][]. If it is set,
 then the request **must** succeed if and only if the provided etag matches the
-server-computed value, and **must** fail with a `FAILED_PRECONDITION` error
-otherwise. The `update_mask` field in the request does not affect the behavior
-of the `etag` field, as it is not a field _being_ updated.
+server-computed value, and **must** fail with an `ABORTED` error otherwise. The
+`update_mask` field in the request does not affect the behavior of the `etag`
+field, as it is not a field _being_ updated.
 
 ### Expensive fields
 
@@ -280,6 +280,8 @@ exists.
 
 ## Changelog
 
+- **2021-03-05**: Changed the etag error from `FAILED_PRECONDITION` (which
+  becomes HTTP 400) to `ABORTED` (409).
 - **2020-10-06**: Added guidance for declarative-friendly resources.
 - **2020-10-06**: Added guidance for `allow_missing`.
 - **2020-08-14**: Added error guidance for permission denied cases.

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -45,9 +45,8 @@ message Book {
   service **must** permit the request (unless there is some other reason for
   failure).
 - If a user sends back an etag which does not match the current etag value, the
-  service **must** send a `FAILED_PRECONDITION` error response (unless another
-  error takes precedence, such as `PERMISSION_DENIED` if the user is not
-  authorized).
+  service **must** send a `ABORTED` error response (unless another error takes
+  precedence, such as `PERMISSION_DENIED` if the user is not authorized).
 - If the user does not send an etag value at all, the service **should** permit
   the request. However, services with strong consistency or parallelism
   requirements **may** require users to send etags all the time and reject the
@@ -110,6 +109,8 @@ prefix as mandated by [RFC 7232][].
 
 ## Changelog
 
+- **2021-03-05**: Changed the etag error from `FAILED_PRECONDITION` (which
+  becomes HTTP 400) to `ABORTED` (409).
 - **2020-10-06**: Added declarative-friendly resource requirement.
 - **2020-09-02**: Clarified that other errors may take precedence over
   `FAILED_PRECONDITION` for etag mismatches.

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -45,7 +45,7 @@ message Book {
   service **must** permit the request (unless there is some other reason for
   failure).
 - If a user sends back an etag which does not match the current etag value, the
-  service **must** send a `ABORTED` error response (unless another error takes
+  service **must** send an `ABORTED` error response (unless another error takes
   precedence, such as `PERMISSION_DENIED` if the user is not authorized).
 - If the user does not send an etag value at all, the service **should** permit
   the request. However, services with strong consistency or parallelism


### PR DESCRIPTION
Unfortunately, `FAILED_PRECONDITION` becomes an HTTP 400, which is pretty counter-intuitive. Based on an internal discussion (Googlers: bug 173453642), we think this should be `ABORTED` instead, which properly becomes `409 Conflict`.