### PR TITLE
Recommend restricting to lower-case for custom revision tags

### DIFF
--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -139,7 +139,7 @@ message TagBookRevisionRequest {
     }];
 
   // The tag to apply.
-  // The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,39}`.
+  // The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,38}[a-z0-9]`.
   string tag = 2 [(google.api.field_behavior) = REQUIRED];
 }
 ```
@@ -149,6 +149,7 @@ message TagBookRevisionRequest {
   - The field **should** identify the [resource type][aip-123] that it
     references.
 - The `tag` field **should** be [annotated as required][aip-203].
+  - Additionally, tags **should** restrict letters to lower-case.
 - Once a revision is tagged, the API **must** support using the tag in place of
   the revision ID in `name` fields.
   - If the user sends a tag, the API **must** return the tag in the resource's


### PR DESCRIPTION
This change also updates the example to disallow hyphens as the last character in a custom tag. Resolves #702.