### PR TITLE
Approve declarative-friendly guidance.

### DIFF
--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -1,6 +1,6 @@
 ---
 id: 128
-state: reviewing
+state: approved
 created: 2020-10-06
 placement:
   category: resource-design

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -169,8 +169,6 @@ update.
 
 ### Create or update
 
-[^reviewing]
-
 If the service uses client-assigned resource names, `Update` methods **may**
 expose a `bool allow_missing` field, which will cause the method to succeed in
 the event that the user attempts to update a resource that is not present (and

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -174,8 +174,6 @@ field for Delete requests.
 
 ### Delete if existing
 
-[^reviewing]
-
 If the service uses client-assigned resource names, `Delete` methods **may**
 expose a `bool allow_missing` field, which will cause the method to succeed in
 the event that the user attempts to delete a resource that is not present (in

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -107,8 +107,6 @@ rpc TranslateText(TranslateTextRequest) returns (TranslateTextResponse) {
 
 ### Declarative-friendly resources
 
-[^reviewing]
-
 Declarative-friendly resources usually **should not** employ custom methods
 (except specific declarative-friendly custom methods discussed in other AIPs),
 because declarative-friendly tools are unable to automatically determine what

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -57,8 +57,6 @@ For example, a valid etag is `"foo"`, not `foo`.
 
 ### Declarative-friendly resources
 
-[^reviewing]
-
 A resource that is declarative-friendly (AIP-128) **must** include an `etag`
 field.
 

--- a/aip/general/0163.md
+++ b/aip/general/0163.md
@@ -48,8 +48,6 @@ validation requests in this situation.
 
 ### Declarative-friendly resources
 
-[^reviewing]
-
 A resource that is declarative-friendly (AIP-128) **must** include a
 `validate_only` field on methods that mutate the resource.
 


### PR DESCRIPTION
It is time. We have been using this for six months and shipped a couple of APIs. I assert we are confident in this guidance at this point.