### PR TITLE
Replace resource with string in delete-if-existing example

### DIFF
--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -184,10 +184,8 @@ which case the request is a no-op):
 ```proto
 message DeleteBookRequest {
   // The book to delete.
-  //
-  // The book's `name` field is used to identify the book to be updated.
   // Format: publishers/{publisher}/books/{book}
-  Book book = 1 [
+  string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference).type = "library.googleapis.com/Book"
   ];


### PR DESCRIPTION
Delete requests specify the resource name, not the resource itself.