### PR TITLE
Surface more RFC-1034 guidance in AIP-122

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -110,9 +110,9 @@ ID for the publisher, and `les-miserables` is the resource ID for the book.
   server-generated if unset), or never set by users (not accepted at resource
   creation). They **should** be immutable once created.
   - If resource IDs are user-settable, the API **must** document allowed
-    formats. User-settable resource IDs **should** conform to [RFC-1034][],
-    which restricts to letters, numbers, and hyphen, with a 63 character
-    maximum.
+    formats. User-settable resource IDs **should** conform to [RFC-1034][];
+    which restricts to letters, numbers, and hyphen, with the first character
+    a letter, the last a letter or a number, and a 63 character maximum.
     - Additionally, user-settable resource IDs **should** restrict letters to
       lower-case.
     - Characters outside of ASCII **should not** be permitted; however, if


### PR DESCRIPTION
The current summary of RFC-1034 name requirements has been observed to cause confusion about whether trailing hyphens should be supported among readers who have read the summary but not the body of RFC-1034.

This is not a change in the guidance, just an elaboration of the summary.