### PR TITLE
Updates extra `FAILED_PRECONDITION` in comment

### DIFF
--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -79,7 +79,7 @@ message DeleteBookRequest {
 
   // The current etag of the book.
   // If an etag is provided and does not match the current etag of the book,
-  // deletion will be blocked and a FAILED_PRECONDITION error will be returned.
+  // deletion will be blocked and a ABORTED error will be returned.
   string etag = 2;
 }
 ```
@@ -108,7 +108,7 @@ prefix as mandated by [RFC 7232][].
 - For how to retry on errors in client libraries, see AIP-194.
 
 ## Changelog
-
+- **2021-03-24**: Updated an additional reference to `FAILED_PRECONDITION` to `ABORTED`.
 - **2021-03-05**: Changed the etag error from `FAILED_PRECONDITION` (which
   becomes HTTP 400) to `ABORTED` (409).
 - **2020-10-06**: Added declarative-friendly resource requirement.

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -108,7 +108,8 @@ prefix as mandated by [RFC 7232][].
 - For how to retry on errors in client libraries, see AIP-194.
 
 ## Changelog
-- **2021-03-24**: Updated an additional reference to `FAILED_PRECONDITION` to `ABORTED`.
+- **2021-04-01**: Updated an additional reference to `FAILED_PRECONDITION`
+  to `ABORTED`.
 - **2021-03-05**: Changed the etag error from `FAILED_PRECONDITION` (which
   becomes HTTP 400) to `ABORTED` (409).
 - **2020-10-06**: Added declarative-friendly resource requirement.

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -79,7 +79,7 @@ message DeleteBookRequest {
 
   // The current etag of the book.
   // If an etag is provided and does not match the current etag of the book,
-  // deletion will be blocked and a ABORTED error will be returned.
+  // deletion will be blocked and an ABORTED error will be returned.
   string etag = 2;
 }
 ```


### PR DESCRIPTION
The comment in the code sample for DeleteBooksRequest mismatches the text describing the behavior. I believe this was missed in the previous update.