### PR TITLE
AIP-140: Re-add guidance around base64 and bytes.

### DIFF
--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -98,6 +98,13 @@ Boolean fields **should** omit the prefix "is". For example:
 **Note:** Field names that would otherwise be [reserved words](#reserved-words)
 are an exception to this rule. For example, `is_new` (**not** `new`).
 
+### String vs. bytes
+
+When using `bytes`, the contents of the field are base64-encoded when using
+JSON on the wire. Services **should** use `bytes` when there is a need to send
+binary contents over the wire, and **should not** ask the user to manually
+base64-encode a field into a `string` field.
+
 ### URIs
 
 Field names representing URLs or URIs **should** always use `uri` rather than
@@ -135,6 +142,7 @@ field **should not** have a uniqueness requirement.
 
 ## Changelog
 
+- **2012-04-07**: Added base64 and bytes guidance.
 - **2021-03-05**: Added prohibition on leading, trailing, or adjacent
   underscores.
 - **2020-06-10**: Added prohibition on starting any word with a number.


### PR DESCRIPTION
We had this in the old style guide and it got lost in translation. The linter also flags it even though there is no AIP support.