### PR TITLE
feat: Specify how to handle deprecated option in services and RPCs

### DIFF
--- a/aip/client-libraries/4210.md
+++ b/aip/client-libraries/4210.md
@@ -91,7 +91,7 @@ methods for each RPC.
 - Services that have set the `deprecated` protobuf option to `true` **should** have an
   equivalent deprecation tag generated in the generated class, with a comment
   specifying when the service will be removed. This is typically the next major
-  version update. Similarly, RPCs with this option set to true **should** have
+  version update. Similarly, RPCs with this option set to `true` **should** have
   their generated language method(s) marked as deprecated.
 - Finally, service classes **must** also accept credentials, which are used
   appropriately when requests are made. (Accepting a custom gRPC channel

--- a/aip/client-libraries/4210.md
+++ b/aip/client-libraries/4210.md
@@ -88,7 +88,7 @@ methods for each RPC.
 - Additionally, if the classes generated for each service support using OAuth
   and service credentials, they **must** honor the `google.api.oauth_scopes`
   annotation (if it is provided), and use these scopes by default.
-- Services that have set the `deprecated` protobuf option **should** have an
+- Services that have set the `deprecated` protobuf option to `true` **should** have an
   equivalent deprecation tag generated in the generated class, with a comment
   specifying when the service will be removed. This is typically the next major
   version update. Similarly, RPCs with this option set to true **should** have

--- a/aip/client-libraries/4210.md
+++ b/aip/client-libraries/4210.md
@@ -89,10 +89,10 @@ methods for each RPC.
   and service credentials, they **must** honor the `google.api.oauth_scopes`
   annotation (if it is provided), and use these scopes by default.
 - Services that have set the `deprecated` protobuf option to `true` **should** have an
-  equivalent deprecation tag generated in the generated class, with a comment
-  specifying when the service will be removed. This is typically the next major
-  version update. Similarly, RPCs with this option set to `true` **should** have
-  their generated language method(s) marked as deprecated.
+  equivalent deprecation tag generated in the generated class. If applicable, this
+  tag may include a comment that specifies when the service will be removed, which
+  is typically the next major version update. Similarly, RPCs with this option set
+  to `true` **should** have their generated language method(s) marked as deprecated.
 - Finally, service classes **must** also accept credentials, which are used
   appropriately when requests are made. (Accepting a custom gRPC channel
   satisfies this requirement.)

--- a/aip/client-libraries/4210.md
+++ b/aip/client-libraries/4210.md
@@ -88,6 +88,11 @@ methods for each RPC.
 - Additionally, if the classes generated for each service support using OAuth
   and service credentials, they **must** honor the `google.api.oauth_scopes`
   annotation (if it is provided), and use these scopes by default.
+- Services that have set the `deprecated` protobuf option **should** have an
+  equivalent deprecation tag generated in the generated class, with a comment
+  specifying when the service will be removed. This is typically the next major
+  version update. Similarly, RPCs with this option set to true **should** have
+  their generated language method(s) marked as deprecated.
 - Finally, service classes **must** also accept credentials, which are used
   appropriately when requests are made. (Accepting a custom gRPC channel
   satisfies this requirement.)

--- a/aip/general/0192.md
+++ b/aip/general/0192.md
@@ -108,6 +108,12 @@ colloquial use that avoiding it would obscure the reference (example: [IBM][]).
 Comments **should** spell and capitalize trademarked names consistent with the
 trademark owner's current branding.
 
+### Deprecations
+
+To deprecate a service or RPC, the `deprecated` option **must** be set to
+`true`, and the first line of the respective comment **mus**t start with
+`"Deprecated: "` and provide alternative solutions for developers.
+
 ### Internal comments
 
 <!-- TODO: This does not work outside of Google.

--- a/aip/general/0192.md
+++ b/aip/general/0192.md
@@ -1,8 +1,11 @@
---------------------------------------------------------------------------------
-
-id: 192 state: approved created: 2019-07-25 placement: category: polish
-
-## order: 20
+---
+id: 192
+state: approved
+created: 2019-07-25
+placement:
+  category: polish
+  order: 20
+---
 
 # Documentation
 
@@ -52,24 +55,24 @@ comments are necessarily perfunctory because there is little to be said;
 however, before jumping to that conclusion, consider whether some of the
 following questions are relevant:
 
--   What is it?
--   How do you use it?
--   What does it do if it succeeds? What does it do if it fails?
--   Is it idempotent?
--   What are the units? (Examples: meters, degrees, pixels)
--   What are the side effects?
--   What are common errors that may break it?
-    -   What is the expected input format?
-    -   What range of values does it accept? (Examples: `[0.0, 1.0)`, `[1, 10]`)
-    -   Is the range inclusive or exclusive?
-    -   For strings, what is the minimum and maximum length, and what characters
-        are allowed?
-    -   If a value is above the maximum length, do you truncate or send an
-        error?
--   Is it always present? (Example: "Container for voting information. Present
-    only when voting information is recorded.")
--   Does it have a default setting? (Example: "If `page_size` is omitted, the
-    default is 50.")
+- What is it?
+- How do you use it?
+- What does it do if it succeeds? What does it do if it fails?
+- Is it idempotent?
+- What are the units? (Examples: meters, degrees, pixels)
+- What are the side effects?
+- What are common errors that may break it?
+  - What is the expected input format?
+  - What range of values does it accept? (Examples: `[0.0, 1.0)`, `[1, 10]`)
+    - Is the range inclusive or exclusive?
+  - For strings, what is the minimum and maximum length, and what characters
+    are allowed?
+    - If a value is above the maximum length, do you truncate or send an error?
+- Is it always present? (Example: "Container for voting information. Present
+  only when voting information is recorded.")
+- Does it have a default setting? (Example: "If `page_size` is omitted, the
+  default is 50.")
+
 
 ### Formatting
 
@@ -134,6 +137,7 @@ of inadvertent omissions of the internal content annotation.
 
 ## Changelog
 
+-   **2021-04-20**: Added guidance for deprecated services and RPCs.
 -   **2020-04-01**: Added guidance requiring absolute URLs for external links.
 -   **2020-02-14**: Added guidance around the use of trademarked names.
 -   **2019-09-23**: Added guidance about not using both leading and trailing

--- a/aip/general/0192.md
+++ b/aip/general/0192.md
@@ -112,7 +112,7 @@ trademark owner's current branding.
 
 To deprecate a service or RPC, the `deprecated` option **must** be set to
 `true`, and the first line of the respective comment **must** start with
-`"Deprecated: "` and provide alternative solutions for developers.
+`"Deprecated: "` and provide alternative solutions for developers. If there is no alternative solution, a deprecation reason **must** be given.
 
 ### Internal comments
 

--- a/aip/general/0192.md
+++ b/aip/general/0192.md
@@ -111,7 +111,7 @@ trademark owner's current branding.
 ### Deprecations
 
 To deprecate a service or RPC, the `deprecated` option **must** be set to
-`true`, and the first line of the respective comment **mus**t start with
+`true`, and the first line of the respective comment **must** start with
 `"Deprecated: "` and provide alternative solutions for developers.
 
 ### Internal comments

--- a/aip/general/0192.md
+++ b/aip/general/0192.md
@@ -1,11 +1,8 @@
----
-id: 192
-state: approved
-created: 2019-07-25
-placement:
-  category: polish
-  order: 20
----
+--------------------------------------------------------------------------------
+
+id: 192 state: approved created: 2019-07-25 placement: category: polish
+
+## order: 20
 
 # Documentation
 
@@ -27,10 +24,10 @@ Services, in particular, **should** have descriptive comments that explain what
 the service is and what users are able to do with it.
 
 **Note:** Many readers will not be native English speakers. Comments **should**
-avoid jargon, slang, complex metaphors, pop culture references, or anything
-else that will not easily translate. Additionally, many readers will have
-different backgrounds and viewpoints; if writing examples involving people,
-comments **should** use people who are non-controversial and no longer alive.
+avoid jargon, slang, complex metaphors, pop culture references, or anything else
+that will not easily translate. Additionally, many readers will have different
+backgrounds and viewpoints; if writing examples involving people, comments
+**should** use people who are non-controversial and no longer alive.
 
 ### Style
 
@@ -55,23 +52,24 @@ comments are necessarily perfunctory because there is little to be said;
 however, before jumping to that conclusion, consider whether some of the
 following questions are relevant:
 
-- What is it?
-- How do you use it?
-- What does it do if it succeeds? What does it do if it fails?
-- Is it idempotent?
-- What are the units? (Examples: meters, degrees, pixels)
-- What are the side effects?
-- What are common errors that may break it?
-  - What is the expected input format?
-  - What range of values does it accept? (Examples: `[0.0, 1.0)`, `[1, 10]`)
-    - Is the range inclusive or exclusive?
-  - For strings, what is the minimum and maximum length, and what characters
-    are allowed?
-    - If a value is above the maximum length, do you truncate or send an error?
-- Is it always present? (Example: "Container for voting information. Present
-  only when voting information is recorded.")
-- Does it have a default setting? (Example: "If `page_size` is omitted, the
-  default is 50.")
+-   What is it?
+-   How do you use it?
+-   What does it do if it succeeds? What does it do if it fails?
+-   Is it idempotent?
+-   What are the units? (Examples: meters, degrees, pixels)
+-   What are the side effects?
+-   What are common errors that may break it?
+    -   What is the expected input format?
+    -   What range of values does it accept? (Examples: `[0.0, 1.0)`, `[1, 10]`)
+    -   Is the range inclusive or exclusive?
+    -   For strings, what is the minimum and maximum length, and what characters
+        are allowed?
+    -   If a value is above the maximum length, do you truncate or send an
+        error?
+-   Is it always present? (Example: "Container for voting information. Present
+    only when voting information is recorded.")
+-   Does it have a default setting? (Example: "If `page_size` is omitted, the
+    default is 50.")
 
 ### Formatting
 
@@ -79,8 +77,8 @@ Any formatting in comments **must** be in [CommonMark][]. Headings and tables
 **must not** be used, as these cause problems for several tools, and are
 unsuitable for client library reference documentation.
 
-Comments **should** use `code font` for property names and for literals (such
-as `true`).
+Comments **should** use `code font` for property names and for literals (such as
+`true`).
 
 Raw HTML **must not** be used.
 
@@ -92,12 +90,11 @@ Markdown reference link. For example: `[Book][google.example.v1.Book]`
 
 ### External links
 
-Comments **may** link to external pages to provide background information
-beyond what is described in the public comments themselves. External links
-**must** use absolute (rather than relative) URLs, including the protocol
-(usually `https`), and **should not** assume the documentation is located on
-any particular host. For example:
-`[Spanner Documentation](https://cloud.google.com/spanner/docs)`
+Comments **may** link to external pages to provide background information beyond
+what is described in the public comments themselves. External links **must** use
+absolute (rather than relative) URLs, including the protocol (usually `https`),
+and **should not** assume the documentation is located on any particular host.
+For example: `[Spanner Documentation](https://cloud.google.com/spanner/docs)`
 
 ### Trademarked names
 
@@ -110,9 +107,11 @@ trademark owner's current branding.
 
 ### Deprecations
 
-To deprecate a service or RPC, the `deprecated` option **must** be set to
-`true`, and the first line of the respective comment **must** start with
-`"Deprecated: "` and provide alternative solutions for developers. If there is no alternative solution, a deprecation reason **must** be given.
+To deprecate a service or RPC, the `deprecated`
+[option](https://developers.google.com/protocol-buffers/docs/proto#options)
+**must** be set to `true`, and the first line of the respective comment **must**
+start with `"Deprecated: "` and provide alternative solutions for developers. If
+there is no alternative solution, a deprecation reason **must** be given.
 
 ### Internal comments
 
@@ -135,9 +134,9 @@ of inadvertent omissions of the internal content annotation.
 
 ## Changelog
 
-- **2020-04-01**: Added guidance requiring absolute URLs for external links.
-- **2020-02-14**: Added guidance around the use of trademarked names.
-- **2019-09-23**: Added guidance about not using both leading and trailing
-  comments.
-- **2019-08-01**: Changed the examples from "shelves" to "publishers", to
-  present a better example of resource ownership.
+-   **2020-04-01**: Added guidance requiring absolute URLs for external links.
+-   **2020-02-14**: Added guidance around the use of trademarked names.
+-   **2019-09-23**: Added guidance about not using both leading and trailing
+    comments.
+-   **2019-08-01**: Changed the examples from "shelves" to "publishers", to
+    present a better example of resource ownership.


### PR DESCRIPTION
This is needed for notifying users about deprecated generated classes or methods, so they can be removed in upcoming major version updates.