### PR TITLE
Require Delete Revision methods to return the resource itself

### DIFF
--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -347,7 +347,7 @@ APIs **may** define a method to delete revisions, with a structure similar to
 
 ```proto
 rpc DeleteBookRevision(DeleteBookRevisionRequest)
-    returns (google.protobuf.Empty) {
+    returns (Book) {
   option (google.api.http) = {
     delete: "/v1/{name=publishers/*/books/*}:deleteRevision"
   };
@@ -384,6 +384,10 @@ message DeleteBookRevisionRequest {
   - Because a resource **should not** exist with zero revisions, the method
     **must** fail with `FAILED_PRECONDITION` if the user attempts to delete the
     only revision.
+- The response message **must** be the resource itself. There is no
+  `DeleteBookRevisionResponse`.
+  - The response **should** include the fully-populated resource unless it is
+    infeasible to do so.
 
 ## Appendix: Character Collision
 
@@ -396,6 +400,10 @@ APIs **should** avoid permitting the `@` character in resource names, and if
 APIs that do permit it need to support resources with revisions, they
 **should** pick an appropriate separator depending on how and where the API is
 used, and **must** clearly document it.
+
+## Changelog
+
+- **2021-04-27**: Added guidance on returning the resource from Delete Revision.
 
 [aip-123]: ./0123.md
 [aip-131]: ./0131.md


### PR DESCRIPTION
Per https://github.com/googleapis/api-linter/pull/813#issuecomment-824235841.