### PR TITLE
Use present tense in proto comments

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -72,11 +72,11 @@ Update methods implement a common request message pattern:
 message UpdateBookRequest {
   // The book to update.
   //
-  // The book's `name` field is used to identify the book to be updated.
+  // The book's `name` field is used to identify the book to update.
   // Format: publishers/{publisher}/books/{book}
   Book book = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The list of fields to be updated.
+  // The list of fields to update.
   google.protobuf.FieldMask update_mask = 2;
 }
 ```

--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -31,11 +31,11 @@ Field masks **must** always be relative to the resource:
 message UpdateBookRequest {
   // The book to update.
   //
-  // The book's `name` field is used to identify the book to be updated.
+  // The book's `name` field is used to identify the book to update.
   // Format: publishers/{publisher}/books/{book}
   Book book = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // The list of fields to be updated.
+  // The list of fields to update.
   // Fields are specified relative to the book
   // (e.g. `title`, `rating`; *not* `book.title` or `book.rating`).
   google.protobuf.FieldMask update_mask = 2;


### PR DESCRIPTION
Use present tense in proto comments, this is the preferred style in Google's developer documentation https://developers.google.com/style/tense