### PR TITLE
AIP-211: Add a Rationale section.

### DIFF
--- a/aip/general/0211.md
+++ b/aip/general/0211.md
@@ -26,14 +26,6 @@ If a request can not pass the authorization check for any reason, the service
 **should** look like: "Permission `{p}` denied on resource `{r}` (or it might
 not exist)." This avoids leaking resource existence.
 
-**Note:** This guidance conflicts with the guidance in the HTTP specification,
-which argues for the use of 404 in cases where the user lacks permission to
-know whether or not a resource exists. This variance is because of real-world
-challenges: the practice of "getting `NOT_FOUND` until you have enough
-permission to get `PERMISSION_DENIED`" is counter-intuitive and increases the
-difficulty of troubleshooting. Additionally, the guidance here is more
-consistent with most other real-world authorization systems.
-
 If it is not possible to determine authorization for a resource because the
 resource does not exist, the service **should** check authorization to read
 children on the parent resource, and return `NOT_FOUND` if the authorization
@@ -61,3 +53,34 @@ For example, posit a scenario where:
 In this situation, the get or create methods **should** still only check
 _their_ permissions when determining what error to return, and not one
 another's.
+
+## Rationale
+
+[RFC 7231 §6.5.3][] states that services are permitted to use `404 Not Found`
+in lieu of `403 Forbidden` in situations where the service does not want to
+divulge existance, whereas this AIP argues for the use of `PERMISSION_DENIED`
+(which corresponds to `403 Forbidden` in HTTP) instead. We take this position
+for the following reasons:
+
+- The practice of "getting `404 Not Found` until you have enough permission to
+  get `403 Forbidden`" is counter-intuitive and increases the difficulty of
+  troubleshooting.
+  - A service _could_ ameliorate this by sending information about missing
+    permissions while still using the `404 Not Found` status code, but this
+    constitutes a mixed message.
+- While `403 Forbidden` is essentially always an error requiring manual action,
+  `404 Not Found` is often a valid response that the application can handle
+  (e.g. "get or create"); overloading it for permission errors deprives
+  applications of this benefit.
+- RFC 7231 §6.5.4 states that `404 Not Found` results are cacheable, but
+  permission errors are not generally cacheable. Sending explicit cache
+  controls on a conditional basis could ameliorate this, but would defeat the
+  purpose.
+- The guidance here is more consistent with most other real-world authorization
+  systems.
+
+[rfc 7231 §6.5.3]: https://tools.ietf.org/html/rfc7231#section-6.5.3
+
+## Changelog
+
+- **2021-05-11:** Added a more detailed "Rationale" section.


### PR DESCRIPTION
The cross-company AIP team debated this AIP at length, and decided to endorse the current Google position more widely. During this debate, the group fleshed out a much more detailed rationale, which we believe should live within the AIP in this case.

This PR ports the cross-company rationale section (currently in a private repo) back to the Google AIP.