### PR TITLE
Add guiddance for skipping paginated results.

### DIFF
--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -92,6 +92,26 @@ message ListBooksResponse {
   - This total **may** be an estimate (but the API **should** explicitly
     document that).
 
+### Skipping results
+
+The request definition for a paginated operation **may** define an `int32 skip`
+field to allow the user to skip results.
+
+The `skip` value **must** refer to the number of individual resources to skip,
+not the number of pages.
+
+For example:
+
+- A request with no page token and a `skip` value of `30` returns a single page
+  of results starting with the 31st result.
+- A request with a page token corresponding to the 51st result (because the
+  first 50 results were returned on the first page) and a `skip` value of `30`
+  returns a single page of results starting with the 81st result.
+
+If a `skip` value is provided that causes the cursor to move past the end of
+the collection of results, the response **must** be `200 OK` with an empty
+result set, and not provide a `next_page_token`.
+
 ### Opacity
 
 Page tokens provided by APIs **must** be opaque (but URL-safe) strings, and
@@ -150,6 +170,7 @@ paginate) is reasonable for initially-small collections.
 
 ## Changelog
 
+- **2020-05-13**: Added guidance for skipping results.
 - **2020-08-24**: Clarified that responses are not streaming responses.
 - **2020-06-24**: Clarified that page size is always optional for users.
 - **2019-02-12**: Added guidance on the field being paginated over.


### PR DESCRIPTION
This guidance was discussed with the cross-company AIP working group, but I think it makes sense to import it here, since we get this question really frequently.

Primary collaborators: @Alfus, @mkistler, @gibson042, @hudlow