### PR TITLE
fix: Address conflict between AIP-132 and AIP-217.

### DIFF
--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -123,13 +123,13 @@ message ListBooksResponse {
 
 - The response message **must** include one repeated field corresponding to the
   resources being returned, and **should not** include any other repeated
-  fields.
+  fields unless described in another AIP (for example, AIP-217).
   - The response **should** usually include fully-populated resources unless
-    there is a reason to return a partial response (see [AIP-157][]).
+    there is a reason to return a partial response (see AIP-157).
 - The `next_page_token` field, which supports pagination, **must** be included
   on all list response messages. It **must** be set if there are subsequent
   pages, and **must not** be set if the response represents the final page. For
-  more information, see [AIP-158][].
+  more information, see AIP-158.
 - The message **may** include a `int32 total_size` (or `int64 total_size`)
   field with the number of items in the collection.
   - The value **may** be an estimate (the field **should** clearly document


### PR DESCRIPTION
AIP-132 prohibits repeated fields other than the resource, while AIP-217 prescribes one.