### PR TITLE
docs(AIP-122): add multiple parents to clarify the usage of `child_type`

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -267,7 +267,6 @@ message ListBooksRequest {
   // The parent to list books from.
   // Format:
   //   - publishers/{publisher_id}
-  //   - shelves/{shelf_id}
   //   - authors/{author_id}
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -264,8 +264,11 @@ instead:
 ```proto
 // Request message for ListBooks.
 message ListBooksRequest {
-  // The publisher to list books from.
-  // Format: publishers/{publisher_id}
+  // The parent to list books from.
+  // Format:
+  //   - publishers/{publisher_id}
+  //   - shelves/{shelf_id}
+  //   - authors/{author_id}
   string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {


### PR DESCRIPTION
Currently AIP-122 recommends using `child_type` instead of `type` annotation for the `parent` field if a resource has more than one parents. 

However, the sample code snippet only shows the change from `type: "library.googleapis.com/Publisher"` to `child_type: "library.googleapis.com/Book"`. The comment for `parent` field should also document all the possible parent resource patterns, which I think is a good practice.