### PR TITLE
docs(AIP-134): add `NOT_FOUND` error requirement

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -276,8 +276,13 @@ whether or not it exists, the service **must** error with `PERMISSION_DENIED`
 (HTTP 403). Permission **must** be checked prior to checking if the resource
 exists.
 
+If the user does have proper permission, but the requested resource does not
+exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
+`allow_missing` is set to `true`.
+
 ## Changelog
 
+- **2021-07-08**: Added error guidance for resource not found case.
 - **2021-03-05**: Changed the etag error from `FAILED_PRECONDITION` (which
   becomes HTTP 400) to `ABORTED` (409).
 - **2020-10-06**: Added guidance for declarative-friendly resources.


### PR DESCRIPTION
AIP-131 and AIP-135 already require the service to return `NOT_FOUND` if the requested resource does not exist. This should also apply to AIP-134 as well if the user is trying to update a resource that does not exist.