### PR TITLE
AIP-140: Normalize display name guidance to "should".

### DIFF
--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -127,8 +127,8 @@ code in some languages.
 ### Display names
 
 Many resources have a human-readable name, often used for display in UI. This
-field **must** generally be called `display_name`, and **must not** have a
-uniqueness requirement.
+field **should** be called `display_name`, and **should not** have a uniqueness
+requirement.
 
 If an entity has an official, formal name (such as a company name or the title
 of a book), an API **may** use `title` as the field name instead. The `title`
@@ -142,7 +142,8 @@ field **should not** have a uniqueness requirement.
 
 ## Changelog
 
-- **2012-04-07**: Added base64 and bytes guidance.
+- **2021-07-12**: Normalized display name guidance to "should".
+- **2021-04-07**: Added base64 and bytes guidance.
 - **2021-03-05**: Added prohibition on leading, trailing, or adjacent
   underscores.
 - **2020-06-10**: Added prohibition on starting any word with a number.


### PR DESCRIPTION
- Replaces "must generally" (oof) with "should".
- Normalizes uniqueness requirement toward "should" to be consistent
  with AIP-148.

Fixes #767.