### PR TITLE
AIP-157: Explicitly permit read masks on mutate methods.

### DIFF
--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -37,7 +37,7 @@ enum BookView {
 }
 ```
 
-- The enum **should** be specified as a `view` field on List/Get RPC requests.
+- The enum **should** be specified as a `view` field on the request message.
 - The enum **should** be named something ending in `-View`
 - The enum **should** at minimum have values named `BASIC` and `FULL` (although
   it **may** have values other than these).
@@ -47,7 +47,7 @@ enum BookView {
   - For Get RPCs, the effective default value **should** be either `BASIC` or
     `FULL`.
 - The enum **should** be defined at the top level of the proto file (as it is
-  needed in both the Get and List request).
+  likely to be needed in multiple requests, e.g. both `Get` and `List`).
 - APIs **may** add fields to a given view over time. APIs **must not** remove a
   field from a given view (this is a breaking change).
 
@@ -72,9 +72,11 @@ message: `google.protobuf.FieldMask read_mask`.
     certain fields are expensive to compute and it is preferable to exclude
     them by default).
   - The field mask **may** be designated as required if necessary.
-  - The default for List and Get **may** be different from each other. However,
-    if they are, the default for Get **must** be a (non-strict) superset of the
-    default for List.
+  - The default for `List` and `Get` **may** be different from each other.
+    However, if they are, the default for `Get` **must** be a (non-strict)
+    superset of the default for `List`.
+  - While it is less common, read masks **may** be used on methods other than
+    `List` and `Get`.
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 


### PR DESCRIPTION
Fixes #762.
CC: #621