### PR TITLE
AIP-164: Make `expire_time` guidance consistent.

### DIFF
--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -24,7 +24,7 @@ mark the resource as having been deleted, but not completely remove it from the
 system. If the method behaves this way, it **should** return the updated
 resource instead of `google.protobuf.Empty`.
 
-Resources that support soft delete **must** have an `expire_time` field as
+Resources that support soft delete **should** have an `expire_time` field as
 described in AIP-148. Additionally, resources **should** include a `DELETED`
 state value if the resource includes a `state` field (AIP-216).
 
@@ -154,6 +154,8 @@ the service **must** respond with `ALREADY_EXISTS` (HTTP 409).
 
 ## Changelog
 
+- **2021-07-12**: Changed the `expire_time` field to "should" for consistency
+  with AIP-148.
 - **2020-09-23**: Soft delete material in AIP-135 migrated to this AIP.
 
 [aip-123]: ./0123.md


### PR DESCRIPTION
Fixes #747.