### PR TITLE
AIP-4115: clarify GCE equivalent runtimes

### DIFF
--- a/aip/auth/4115.md
+++ b/aip/auth/4115.md
@@ -33,15 +33,21 @@ credential flow, please read [AIP-4110][2].
 There are typically two types of Google virtual machine environments where the
 auth library should obtain the identity token based on the environment type:
 
-- Google App Engine Standard 1.0
-- Compute Engine or equivalent runtime
-  - This typically includes Google App Engine Standard 2.0+ and Google App Engine Flex environments.
+- Google App Engine Standard 1.0 (aka 1st generation)
+- Compute Engine 
+  - GCE equivalent runtimes
+    - Google App Engine Standard 2.0+
+    - Google App Engine Flex
+    - Google Cloud Functions
+    - Cloud Run
+    - Workload Identity on Google Kubernetes Engine
 
-The auth library **should** depend on the [Google App Engine SDK][3] to detect
-if the application is running within a Google App Engine environment.
+The auth library **should** depend on the [Google App Engine SDK][3] or well 
+defined GAE environment variables to detect if the application is running within
+the 1st generation Google App Engine environment.
 
-To detect if the application is running on Compute Engine environment, the auth
-library **should** depend on the [Metadata Service Library][4].
+To detect if the application is running on Compute Engine or an equivalent runtime,
+the auth library **should** depend on the [Metadata Service Library][4].
 
 ### Compute Engine or Equivalent Runtime
 
@@ -71,8 +77,8 @@ https://www.googleapis.com/auth/storage-full scope for Cloud Storage, then the t
 from the instance's metadata server have only the `storage-full` scope.
 
 When running on GCE, the metadata server ignores requests for custom scopes.
-On Cloud Run and Workload Identity on Google Kubernetes Engine, clients can request a 
-different set of scopes to the metadata server using the `scopes` url parameter, e.g.:
+On GCE equivalent runtimes, clients can request a different set of scopes to the metadata server
+using the `scopes` url parameter, e.g.:
 
 ```
 http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token?scopes=comma-separated-list-of-scopes
@@ -81,7 +87,7 @@ http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/def
 The auth library **should** allow the caller to optionally specify a list of custom scopes,
 and add the `scopes` parameter to the request when needed.
 Depending on the runtime environment, the request for custom scopes will be transparently
-ignored by the server (GCE) or fulfilled (Cloud Run and Workload Identity).
+ignored by the server (GCE) or fulfilled (GCE equivalent).
 
 ### Google App Engine Standard 1.0 Runtime
 
@@ -90,7 +96,7 @@ auth library **should** rely on the [Google App Engine SDK][3] to retrieve the
 access token. Here is [one example][5] in Go. Essentially the SDK relies on the
 underlying App Engine Identity service to generate the token.
 
-Unlike Compute Engine, the auth library can specify scopes when requesting the
+Like GCE equivalent runtimes, the auth library can specify scopes when requesting the
 token in the App Engine Standard 1.0 runtime.
 
 Sample code of getting the access token in Go:
@@ -106,6 +112,11 @@ token, exp, err := appengine.AccessToken(context, scopes...)
 
 The access tokens expire after a short period of time. The auth library **must**
 get a new token if the existing token expires.
+
+## Changelog
+
+- **2020-12-14**: Replace note on scopes with more detailed discussion.
+- **2021-07-13**: Clarify GCE equivalent runtimes
 
 <!-- prettier-ignore-start -->
 [0]: https://cloud.google.com/appengine


### PR DESCRIPTION
Make it clearer that GAE gen2 should be treated as a GCE equivalent library instead of like GAE gen1.