### PR TITLE
Explain enum naming style

### DIFF
--- a/aip/general/0126.md
+++ b/aip/general/0126.md
@@ -55,12 +55,18 @@ message Book {
   - An exception to this rule is if there is a clearly useful zero value. In
     particular, if an enum needs to present an `UNKNOWN`, it is usually clearer
     and more useful for it to be a zero value rather than having both.
+- The other values **should not** be prefixed by the name of the enum itself.
+  This generally requires users to write `MyState.MYSTATE_ACTIVE` in their
+  code, which is unnecessarily verbose.
+  - Note that some languages (including C++) hoist enum values into the parent
+    namespace, which can result in conflicts for enums with the same values in
+    the same proto package. To avoid this, multiple enums in the same proto
+    package **must not** share any values. To avoid sharing values, APIs
+    **may** prefix enum values with the name of the enum. In this case, they
+    **must** do so consistently within the enum.
 - Enums which will only be used in a single message **should** be nested within
   that message. In this case, the enum **should** be declared immediately
   before it is used.
-- If multiple enums are in the same namespace, they **must not** share any
-  values. (This is because enums do not provide their own namespace for their
-  values in some languages.)
 - Enums **should** document whether the enum is frozen or they expect to add
   values in the future.
 


### PR DESCRIPTION
AIP-126 uses an enum naming style that is preferred for most languages, but too short for C++. Explain the rationale behind the style, and offer the style explained in the Protocol Buffer Style Guide as an alternative for C++ users.