### PR TITLE
AIP-4113: fix quota_project_id typo

### DIFF
--- a/aip/auth/4113.md
+++ b/aip/auth/4113.md
@@ -103,7 +103,7 @@ access_token, _, _, _ = google_auth_client.refresh_grant(
 ```
 
 - The application calls GCP API with the access token obtained from the
-  previous step. ‘project_project_id’ in the gcloud default credentials
+  previous step. ‘quota_project_id’ in the gcloud default credentials
   **should** be added to the ‘X-Goog-User-Project’ http header so that the
   associated account will be charged for billing and quota.
 


### PR DESCRIPTION
I think `quota_project_id` is a correct property name that is used for `X-Goog-User-Project` header.