### PR TITLE
fix: virtual machine environment types

### DIFF
--- a/aip/auth/4115.md
+++ b/aip/auth/4115.md
@@ -33,7 +33,8 @@ credential flow, please read [AIP-4110][2].
 There are typically two types of Google virtual machine environments where the
 auth library should obtain the identity token based on the environment type:
 
-- Google App Engine Standard 1.0 Compute Engine or equivalent runtime
+- Google App Engine Standard 1.0
+- Compute Engine or equivalent runtime
   - This typically includes Google App Engine Standard 2.0+ and Google App Engine Flex environments.
 
 The auth library **should** depend on the [Google App Engine SDK][3] to detect


### PR DESCRIPTION
I think `Google App Engine Standard 1.0` and `Compute Engine or equivalent runtime` should be listed in separate lines.