### PR TITLE
Clarify behavior of long-running deletes on resources which are already being deleted.

### DIFF
--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -110,6 +110,8 @@ rpc DeleteBook(DeleteBookRequest) returns (google.longrunning.Operation) {
   resource itself for soft delete (AIP-164).
 - Both the `response_type` and `metadata_type` fields **must** be specified
   (even if they are `google.protobuf.Empty`).
+- A call to delete a resource which is already being deleted **should** not fail
+  and return the ongoing delete long-running operation.
 
 **Note:** Declarative-friendly resources (AIP-128) **should** use long-running
 delete.


### PR DESCRIPTION
Clarify behavior of long-running deletes. In particular, what should happen if a client tries to delete a resource which is already being deleted.

Clients should be able to get idempotent deletions by combining this with `allow_missing: true`.