### PR TITLE
AIP-157: Update partial response pattern with system paramter

### DIFF
--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -24,14 +24,15 @@ recommended way for an API to support partial responses.
 
 To enable field masks, an API **should** support the masks as a [system parameter][0].
 This parameter can be specified either using an HTTP query
-parameter or an HTTP header(or an equivalent [gRPC metadata][1]).
+parameter or an HTTP header (or a [gRPC metadata entry][1]).
 
 - The value of the field mask parameter **must** be a `google.protobuf.FieldMask`.
 - The field mask parameter **should** be specified using `$field` as a query parameter or `X-Goog-FieldMask` as an HTTP header.
-- The field mask paramter **must** be optional:
+- The field mask parameter **must** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all
     fields.
-  - The default value **should** be`"*"` (if the field mask is not provided, all fields **must** be returned).
+  - If the field mask parameter is not provided, all fields **must** be
+    returned.
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 
@@ -85,7 +86,8 @@ message: `google.protobuf.FieldMask read_mask`.
 - The field mask **should** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all
     fields.
-  - The default value **should** be`"*"` (if the field mask is not provided, all fields **must** be returned).
+  - If the field mask parameter is not provided, all fields **must** be
+    returned.
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -14,11 +14,35 @@ needs to give the user control over which fields it sends back.
 
 ## Guidance
 
-APIs **may** support partial responses in one of two ways (but the same API
-**must not** use both):
+APIs **may** support partial responses in one of the three ways:
+
+**Note:** If an API requires partial responses, it **should** generally decide
+a way to support across the board, but not mix and match.
+
+### Field masks parameter
+
+Field masks (`google.protobuf.FieldMask`) can be used for granting the user
+fine-grained control over what fields are returned. It is generally the
+recommended way for an API to support partial responses.
+
+To enable field masks, an
+API **should** support the masks as a [system
+parameter](https://cloud.google.com/apis/docs/system-parameters).
+This parameter can be specified either using an HTTP query parameter or an HTTP
+header.
+
+- The value of field mask parameter **must** be a `google.protobuf.FieldMask`.
+- The field mask parameter **should** be specified using `$field` as a query parameter or `X-Goog-FieldMask` as an HTTP header.
+- The field mask paramter **must** be optional:
+  - An explicit value of `"*"` **should** be supported, and **must** return all
+    fields.
+  - The default value **should** be`"*"` (if the field mask is not provided, all fields **must** be returned).
+- An API **may** allow read masks with non-terminal repeated fields (unlike
+  update masks), but is not obligated to do so.
 
 ### View enumeration
 
+Alternatively, an API **may** support partial responses with view enums.
 View enums are useful for situations where an API only wants to expose a small
 number of permutations to the user:
 
@@ -56,13 +80,12 @@ enum BookView {
   conflict. In this situation, the service **should** nest the view enum within
   the individual resource.
 
-### Read masks
+### Read masks as a request field
 
-Read masks are useful for granting the user fine-grained control over what
-fields are returned, and are specified as a single field on the request
+Similar to a system parameter, an API **may** support read masks as a single field on the request
 message: `google.protobuf.FieldMask read_mask`.
 
-- The field mask **must** be a `google.protobuf.FieldMask` and **should** be
+- The read mask **must** be a `google.protobuf.FieldMask` and **should** be
   named `read_mask`.
 - The field mask **should** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all
@@ -71,36 +94,7 @@ message: `google.protobuf.FieldMask read_mask`.
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 
-### Choosing a strategy
-
-Individual APIs have their own needs, and a partial response strategy that is
-appropriate for one API may not be appropriate for another. However, generally
-APIs **should not** be providing resource views unless they are truly needed.
-
-#### Benefits of view enums
-
-- View enums allow an API to present the user with a limited number of choices,
-  and are useful when presenting fine-grained control will be cumbersome, or in
-  situations where the additional information returned represents a different
-  tier of service.
-- View enums allow the API to add fields to each view over time, if desired.
-- View enums usually require less upkeep for users.
-- View enums are effective when the API knows which fields are expensive to
-  compute, and that this cost will not significantly change over time.
-
-#### Benefits of read masks
-
-- Read masks allow the user fine-grained control, and are ideal when the user
-  wants to get precisely a certain set of fields back, and there are too many
-  combinations to reasonably represent with view enums.
-- Read masks are beneficial when separate fields are independently expensive to
-  compute, and an API wants to send back only the subset that the user needs.
-
-**Note:** If an API requires partial responses, it **should** generally decide
-to either support view enums or read masks across the board, but not mix and
-match. If an API does support both, it **must not** support both a view and a
-read mask on the same resource.
-
 ## Changelog
 
 - **2021-03-04:** Added guidance for conflicting view enums.
+- **2021-10-06:** Updated the guidance with system parameters

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -16,9 +16,6 @@ needs to give the user control over which fields it sends back.
 
 APIs **may** support partial responses in one of the three ways:
 
-**Note:** If an API requires partial responses, it **should** generally decide
-a way to support across the board, but not mix and match.
-
 ### Field masks parameter
 
 Field masks (`google.protobuf.FieldMask`) can be used for granting the user

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -22,11 +22,9 @@ Field masks (`google.protobuf.FieldMask`) can be used for granting the user
 fine-grained control over what fields are returned. It is generally the
 recommended way for an API to support partial responses.
 
-To enable field masks, an
-API **should** support the masks as a [system
-parameter](https://cloud.google.com/apis/docs/system-parameters).
-This parameter can be specified either using an HTTP query parameter or an HTTP
-header.
+To enable field masks, an API **should** support the masks as a [system parameter][0].
+This parameter can be specified either using an HTTP query
+parameter or an HTTP header(or an equivalent [gRPC metadata][1]).
 
 - The value of the field mask parameter **must** be a `google.protobuf.FieldMask`.
 - The field mask parameter **should** be specified using `$field` as a query parameter or `X-Goog-FieldMask` as an HTTP header.
@@ -95,3 +93,6 @@ message: `google.protobuf.FieldMask read_mask`.
 
 - **2021-03-04:** Added guidance for conflicting view enums.
 - **2021-10-06:** Updated the guidance with system parameters
+
+[0]: https://cloud.google.com/apis/docs/system-parameters
+[1]: https://grpc.io/docs/what-is-grpc/core-concepts/#metadata

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -64,19 +64,10 @@ message: `google.protobuf.FieldMask read_mask`.
 
 - The field mask **must** be a `google.protobuf.FieldMask` and **should** be
   named `read_mask`.
-- The field mask **should** be optional, and the API **should** provide and
-  document an appropriate default if the field mask is not provided.
+- The field mask **should** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all
     fields.
-  - The default value **may** be something other than `"*"` (for example, if
-    certain fields are expensive to compute and it is preferable to exclude
-    them by default).
-  - The field mask **may** be designated as required if necessary.
-  - The default for `List` and `Get` **may** be different from each other.
-    However, if they are, the default for `Get` **must** be a (non-strict)
-    superset of the default for `List`.
-  - While it is less common, read masks **may** be used on methods other than
-    `List` and `Get`.
+  - The default value **must** be`"*"` (if the field mask is not provided, all fields **must** be returned).
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -31,7 +31,7 @@ parameter](https://cloud.google.com/apis/docs/system-parameters).
 This parameter can be specified either using an HTTP query parameter or an HTTP
 header.
 
-- The value of field mask parameter **must** be a `google.protobuf.FieldMask`.
+- The value of the field mask parameter **must** be a `google.protobuf.FieldMask`.
 - The field mask parameter **should** be specified using `$field` as a query parameter or `X-Goog-FieldMask` as an HTTP header.
 - The field mask paramter **must** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -87,7 +87,7 @@ message: `google.protobuf.FieldMask read_mask`.
 - The field mask **should** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all
     fields.
-  - The default value **must** be`"*"` (if the field mask is not provided, all fields **must** be returned).
+  - The default value **should** be`"*"` (if the field mask is not provided, all fields **must** be returned).
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
 

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -93,8 +93,8 @@ message: `google.protobuf.FieldMask read_mask`.
 
 ## Changelog
 
+- **2021-10-06:** Updated the guidance with system parameters.
 - **2021-03-04:** Added guidance for conflicting view enums.
-- **2021-10-06:** Updated the guidance with system parameters
 
 [0]: https://cloud.google.com/apis/docs/system-parameters
 [1]: https://grpc.io/docs/what-is-grpc/core-concepts/#metadata


### PR DESCRIPTION
- Updated the AIP to list all three ways to support partial responses
   - System parameter (recommended)
   - View enum
   - Read masks as a request field
- The default value of field mask should be `*`. This means the caller does not provide a explicit field mask, **all fields** should be returned in the response to avoid confusion. 
  - This description aligns with https://cloud.google.com/apis/docs/system-parameters
