### PR TITLE
docs: corrects link to AIP-4110 (ADC)

### DIFF
--- a/aip/auth/4111.md
+++ b/aip/auth/4111.md
@@ -27,7 +27,7 @@ JWT as a means of authentication.
 ### Application Default Credentials
 
 Supporting self-signed JWT is considered a part of [application default
-credentials][2]. To understand the overall flow, please read [AIP-4110][2].
+credentials][2]. To understand the overall flow, please read [AIP-4110][0].
 
 ### Scope vs. Audience
 

--- a/aip/auth/4111.md
+++ b/aip/auth/4111.md
@@ -27,7 +27,7 @@ JWT as a means of authentication.
 ### Application Default Credentials
 
 Supporting self-signed JWT is considered a part of [application default
-credentials][2]. To understand the overall flow, please read [AIP-4110][0].
+credentials][0]. To understand the overall flow, please read [AIP-4110][0].
 
 ### Scope vs. Audience
 


### PR DESCRIPTION
The published page currently links to the wrong AIP.