### PR TITLE
AIP-156: add example message and allow child resources

### DIFF
--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -63,6 +63,7 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
 
 ## Changelog
 
+- **2021-11-02**: Added an example message and state parent eligibility.
 - **2021-01-14:** Changed example from `settings` to `config` for clarity.
 
 [aip-122]: ./0122.md

--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -63,7 +63,7 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
 
 ## Changelog
 
-- **2021-11-02**: Added an example message and state parent eligibility.
+- **2021-11-02:** Added an example message and state parent eligibility.
 - **2021-01-14:** Changed example from `settings` to `config` for clarity.
 
 [aip-122]: ./0122.md

--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -19,6 +19,19 @@ An API **may** define _singleton resources_. A singleton resource **must**
 always exist by virtue of the existence of its parent, with one and exactly one
 per parent.
 
+For example:
+```proto
+message Config {
+  option (google.api.resource) = {
+    type: "api.googleapis.com/Config"
+    pattern: "users/{user}/config"
+  };
+
+  string name = 1;
+}
+```
+
+The `Config` singleton would have the following RPCs:
 ```proto
 rpc GetConfig(GetConfigRequest) returns (Config) {
   option (google.api.http) = {
@@ -41,11 +54,12 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
 - Singleton resources **must not** define the [`Create`][aip-133],
   [`List`][aip-132], or [`Delete`][aip-135] standard methods. The singleton is
   implicitly created or deleted when its parent is created or deleted.
-- Singleton resource **should** define the [`Get`][aip-131] and
+- Singleton resources **should** define the [`Get`][aip-131] and
   [`Update`][aip-134] methods, and **may** define custom methods as
   appropriate.
 - Singleton resources are always singular.
-   - Example: 'users/1234/thing'
+  - Example: 'users/1234/thing'
+- Singleton resources **may** parent other resources.
 
 ## Changelog
 


### PR DESCRIPTION
Adds an example of the actual resource definition for a Singleton resource instead of forcing the user to infer the resource definition from the `google.api.http` annotations.

Explicitly calls out that Singleton Resources **may** parent other resources. Albeit an uncommon scenario, it is not disallowed and stating as much is important for clarity in parser implementations and for API producers. http://yaqs/5015898246217728 seems to imply that this is allowed. 