### PR TITLE
AIP-134: Always check for update permission for update methods

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -202,8 +202,9 @@ More specifically, the `allow_missing` flag triggers the following behavior:
 - If the method call is on a resource that already exists, only fields declared
   in the field mask are updated.
 
-The user must have _both_ the create and update permissions to call `Update`
-with `allow_missing` set to `true`.
+The user **must** have the update permissions to call `Update` even with
+`allow_missing` set to `true`. For customers that want to prevent users from
+creating resources using the update method, we propose to use IAM Conditions
 
 **Note:** Declarative-friendly resources (AIP-128) **must** expose the
 `bool allow_missing` field.
@@ -282,6 +283,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
+- **2021-11-04**: Changed the permission check if `allow_missing` is set.
 - **2021-07-08**: Added error guidance for resource not found case.
 - **2021-03-05**: Changed the etag error from `FAILED_PRECONDITION` (which
   becomes HTTP 400) to `ABORTED` (409).

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -204,7 +204,7 @@ More specifically, the `allow_missing` flag triggers the following behavior:
 
 The user **must** have the update permissions to call `Update` even with
 `allow_missing` set to `true`. For customers that want to prevent users from
-creating resources using the update method, we propose to use IAM Conditions
+creating resources using the update method, IAM conditions **should** be used.
 
 **Note:** Declarative-friendly resources (AIP-128) **must** expose the
 `bool allow_missing` field.


### PR DESCRIPTION
- Always check the update permission for all updates, even if `allow_missing` is set. 
- Recommend using IAM to restrict callers from creating resources using update methods.