### PR TITLE
Remove Luke Sneerkinger from and add Sam Woodard to "AIP editors" list.

### DIFF
--- a/aip/general/0001.md
+++ b/aip/general/0001.md
@@ -89,7 +89,6 @@ The list of AIP editors is currently:
 - Hong Zhang ([@wora][])
 - JJ Geewax ([@jgeewax][])
 - Jon Skeet ([@jskeet][])
-- Luke Sneeringer ([@lukesneeringer][])
 
 The editors are also responsible for the administrative and editorial aspects
 of shepherding AIPs and managing the AIP pipeline and workflow. They approve

--- a/aip/general/0001.md
+++ b/aip/general/0001.md
@@ -89,6 +89,7 @@ The list of AIP editors is currently:
 - Hong Zhang ([@wora][])
 - JJ Geewax ([@jgeewax][])
 - Jon Skeet ([@jskeet][])
+- Sam Woodard ([@samwoodard][])
 
 The editors are also responsible for the administrative and editorial aspects
 of shepherding AIPs and managing the AIP pipeline and workflow. They approve


### PR DESCRIPTION
This PR edits aip#1 to remove Luke Sneeringer (fomerly lukesneeringer@google.com) from the list of AIP editors.