### PR TITLE
TL;DR must match the guidelines below it.

### DIFF
--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -22,7 +22,7 @@ different services use different project identifiers.
 ## Guidance
 
 **TL;DR:** The project number is the canonical identifier, and the project ID
-is an [alias][]; however, unlike normal aliases, it **may** be returned if it
+is an [alias][]; however, unlike normal aliases, it **should** be returned if it
 is what the user sent. Additionally, third-party services are unable to
 _accept_ project IDs.
 


### PR DESCRIPTION
Below the TL;DR, it says, "services **should** return which ID the user sent", but the TL;DR says **may**. Adjusting the TL;DR to mach the formal guidelines.