### PR TITLE
[AIP-4117] Add AIP 4117 External Account Credentials

### DIFF
--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -47,6 +47,11 @@ allows human users to sign-in through [3-legged OAuth flow][1], which grants the
 permissions to the application to access Google APIs on behalf of the human
 user. The auth libraries **may** support this credential type.
 
+- **External Account Credential**: A configuration file identifying
+[external non-Google credentials][8] that can be exchanged for Google access
+tokens to access Google APIs. The auth libraries **must** support this
+credential type.
+
 ### Environment Variables
 
 The auth libraries **must** support the following environment variables to allow
@@ -58,6 +63,7 @@ full path for ADC to locate the credentials file. The credentials file
 
   - Gcloud credentials
   - Service account key
+  - External account credentials
 
   The credentials **may** be the OAuth Client ID if it is supported by the
   auth library. Credentials file path specified at the program level (e.g. via
@@ -118,6 +124,7 @@ digraph d_front_back {
   1. Check the provided credential type
     1. If the credential is gcloud credentials, go to step (4)
     1. If the credential is [a service account key][6] JSON, go to step (4)
+    1. If the credential is [an external account][8] JSON, go to step (4)
     1. If the credential is unknown type, return an error saying that _[END]_
   1. Credentials not found _[END]_
 1. **Check Google Virtual Machine Credentials**
@@ -128,6 +135,7 @@ digraph d_front_back {
 1. **Determine auth flows**
   1. If the credential is gcloud credential go to step (5.3)
   1. If target audience or scope is provided by the developer go to step (5.1)
+  1. If the credential is an external account go to step (5.4)
   1. Otherwise, go to step (5.2)
 1. **Execute auth flows**
   1. Use 2LO flow to exchange for an auth token
@@ -138,6 +146,7 @@ digraph d_front_back {
     1. If certificate is presented, embed the certificate into the JWT.
     1. Use the regular [self-signed JWT flow][4] for an access token. _[END]_
   1. Use user identity flow to exchange for an access token. _[END]_
+  1. Use external account (via `sts.googleapis.com`) flow to exchange for an access token. _[END]_
 
 ## Changelog
 
@@ -145,6 +154,7 @@ digraph d_front_back {
 - **2019-08-18**: Remove STS support from ADC.
 - **2021-01-20**: Add identity token flow (AIP 4116).
 - **2021-06-29**: Guidance for GOOGLE_API_KEY temporarily removed until consensus can be established.
+- **2021-12-10**: Add external account credentials (AIP 4117).
 
 
 <!-- prettier-ignore-start -->
@@ -155,4 +165,5 @@ digraph d_front_back {
 [5]: ./4113
 [6]: ./4112
 [7]: ./4116
+[8]: ./4117
 <!-- prettier-ignore-end -->

--- a/aip/auth/4110.md
+++ b/aip/auth/4110.md
@@ -146,7 +146,7 @@ digraph d_front_back {
     1. If certificate is presented, embed the certificate into the JWT.
     1. Use the regular [self-signed JWT flow][4] for an access token. _[END]_
   1. Use user identity flow to exchange for an access token. _[END]_
-  1. Use external account (via `sts.googleapis.com`) flow to exchange for an access token. _[END]_
+  1. Use [external account][8] flow to exchange for an access token. _[END]_
 
 ## Changelog
 

--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -1,0 +1,387 @@
+---
+id: 4117
+scope: auth
+state: approved
+created: 2020-12-10
+---
+
+# External Account Credentials (Workload Identity Federation)
+
+Using workload identity federation, your application can access Google Cloud
+resources from Amazon Web Services (AWS), Microsoft Azure or any identity
+provider that supports OpenID Connect (OIDC) or SAML 2.0.
+
+Traditionally, applications running outside Google Cloud have used service
+account keys to access Google Cloud resources. Using identity federation,
+you can allow your workload to impersonate a service account. This lets you
+access Google Cloud resources directly, eliminating the maintenance and
+security burden associated with service account keys.
+
+**Note:** Because this AIP describes guidance and requirements in a
+language-neutral way, it uses generic terminology which may be imprecise or
+inappropriate in certain languages or environments.
+
+## Guidance
+
+This section describes the general guidance of supporting non-Google external
+credentials (AWS, Azure, OIDC and SAML IdPs, etc) as a means of authentication.
+
+### Prerequisite
+
+In order to use workload identity federation to access Google cloud resources
+from non-Google cloud platforms, the following steps are needed to configure
+workload identity pools, providers, service account impersonation and generate
+the JSON configuration file to be used by the auth libraries.
+
+- [Configure Workload Identity Federation from AWS][0]
+- [Configure Workload Identity Federation from Microsoft Azure][1]
+- [Configure Workload Identity Federation from an OIDC identity provider][2]
+- [Configure Workload Identity Federation from a SAML identity provider][3]
+
+### Configuration File Generation and Usage
+
+After workload identity federation is configured, the JSON configuration file
+will need to be generated. This sample shows how an AWS configuration file
+is generated:
+
+```bash
+$ gcloud iam workload-identity-pools create-cred-config \
+    projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID \
+    --service-account=$SERVICE_ACCOUNT_EMAIL \
+    --aws \
+    --output-file=$FILEPATH.json
+```
+
+The following values would need to be replaced:
+
+- **PROJECT_NUMBER**: Project number of the project that contains the workload
+  identity pool.
+- **POOL_ID**: ID of the workload identity pool.
+- **PROVIDER_ID**: ID of the workload identity pool provider.
+- **SERVICE_ACCOUNT_EMAIL**: Email address of the service account to
+  impersonate.
+- **FILEPATH**: File to save configuration to.
+
+The external identities configuration file can be used with
+[Application Default Credentials][6]. In order to use external identities with
+Application Default Credentials, the full path to this file should be stored
+in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/config.json
+```
+
+The library can now automatically choose the right type of client and initialize
+credentials from the context provided in the configuration file:
+
+```python
+import google.auth
+
+credentials, project = google.auth.default()
+```
+
+External account credentials can also be initialized explicitly using the
+generated configuration file.
+
+```python
+# Sample for Azure or OIDC/SAML providers.
+import json
+
+from google.auth import identity_pool
+
+json_config_info = json.loads(function_to_get_json_config())
+credentials = identity_pool.Credentials.from_info(json_config_info)
+scoped_credentials = credentials.with_scopes(
+    ['https://www.googleapis.com/auth/cloud-platform'])
+```
+
+```python
+# Sample for AWS.
+import json
+
+from google.auth import aws
+
+json_config_info = json.loads(function_to_get_json_config())
+credentials = aws.Credentials.from_info(json_config_info)
+scoped_credentials = credentials.with_scopes(
+    ['https://www.googleapis.com/auth/cloud-platform'])
+```
+
+### Expected Behavior
+
+The auth libraries will use the information in the JSON configuration file to
+retrieve the external credentials and exchange them for Google access tokens
+using the GCP Security Token Service (via the token exchange endpoint
+`https://sts.googleapis.com/v1/token`) and then impersonating a service account
+by calling the **IamCredentials** [generateAccessToken][5] API to access GCP
+resources.
+
+All external account JSON files share the following fields:
+
+| Field Name                        | Required | Description |
+|-----------------------------------|----------|-------------|
+| type                              | Yes      | This identifies the new type of credential object. This is always "external_account" |
+| audience                          | Yes      | This is the STS audience which contains the resource name for the workload identity pool and the provider identifier in that pool. |
+| subject_token_type                | Yes      | This is the STS subject token type based on the [OAuth 2.0 token exchange spec][7]. |
+| service_account_impersonation_url | No       | This is the URL for the service account impersonation request. If this is not available, the STS returned access token is directly used without impersonation. |
+| token_url                         | Yes      | This is the STS token exchange endpoint. |
+| credential_source.*               | Yes      | This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint. |
+
+The auth libraries and applications **must** follow the steps below for all
+types of external account credentials:
+
+- Check **credential_source** to determine the necessary logic to retrieve the
+  external credential which will be used to construct the subject token to pass
+  to the STS endpoint. This is covered in detail for every credential
+  configuration below.
+- Construct the STS request, based on [rfc8693][4]:
+  - STS audience is constructed using the **audience** field.
+  - **grant_type** is always `urn:ietf:params:oauth:grant-type:token-exchange`
+  - **requested_token_type** is always
+    `urn:ietf:params:oauth:token-type:access_token`
+  - **subject_token_type** is the **subject_token_type** field as described in
+    the RFC.
+  - **subject_token** is the retrieved external credentials. Check the
+    subsequent sections on how this is retrieved in various environments.
+  - **scope**: the list of space-delimited, case-insensitive OAuth scopes that
+    specify the desired scopes of the requested security token in the context
+    of the service or resource where the token will be used. If service account
+    impersonation is used, the cloud platform or IAM scope will be passed to
+    STS and then the customer provided scopes will be passed in the
+    **IamCredentials** call to [generateAccessToken][5].
+  - The STS token exchange URL is the **token_url** (e.g.
+    `https://sts.googleapis.com/v1/token`).
+- Send the STS token exchange request to get the Google access token and its
+  expiration.
+- If the **service_account_impersonation_url** is available, trigger service
+  account impersonation flow by POSTing to that endpoint with the previously
+  returned Google access token.
+  - If this is not available, end the flow and just use the STS access token
+    for authorization.
+  - The list of scopes also need to be provided for this endpoint. The customer
+    provided scopes will be used for this endpoint.
+  - In order to access this API, the (Cloud platform
+    `https://www.googleapis.com/auth/cloud-platform` or IAM scope
+    `https://www.googleapis.com/auth/iam`) are required in the underlying
+    access token.
+
+#### Determining the subject token in AWS
+
+External account configuration JSON files contain the following information
+in the `credential_source` object to facilitate retrieval of AWS credentials
+to be passed as subject tokens to the GCP STS token exchange endpoint.
+
+| Field Name                                       | Required | Description |
+|--------------------------------------------------|----------|-------------|
+| credential_source.environment_id                 | Yes      | This is the environment identifier, of format `aws${version}`. A version is specified to indicate to the auth library whether breaking changes were introduced to the underlying AWS implementation. So if aws1 is supported in the current version of the library but a credential file with aws2 is provided, an error is thrown instructing the developer to upgrade to a newer version of the library. |
+| credential_source.region_url                     | Yes      | This URL is used to determine the current AWS region needed for the signed request construction. |
+| credential_source.url                            | No       | This AWS metadata server URL is used to retrieve the access key, secret key and security token needed to sign the `GetCallerIdentity` request. The $ROLE_NAME needs to be retrieved from calling this endpoint without any parameter and then calling again with the returned role name appended to this URL: http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME |
+| credential_source.regional_cred_verification_url | Yes      | This defines the regional AWS `GetCallerIdentity` action URL. This is the URL used to determine the AWS account ID and its roles. This is not actually called by the Auth libraries. It is called on the STS token server. The region is substituted by SDK, e.g. sts.eu-west-1.amazonaws.com. |
+
+The JSON file for AWS configuration files will have the following form:
+
+```json
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID",
+  "subject_token_type": "urn:ietf:params:aws:token-type:aws4_request",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/$EMAIL:generateAccessToken",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "environment_id": "aws1",
+    "region_url": "http://169.254.169.254/latest/meta-data/placement/availability-zone",
+    "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+    "regional_cred_verification_url": "https://sts.{region}.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+  }
+}
+```
+
+The auth libraries and applications **must** follow the steps below:
+
+- Check **credential_source** for environment ID. If the environment ID is
+  `aws${version}`, this is an AWS native credential.
+- Inspect the version in the environment ID. If this is a newer unexpected
+  error, trigger an error that the auth library needs to be updated to handle
+  this type of credentials.
+- Check the environment variables in the following order (`AWS_REGION` and
+  then the `AWS_DEFAULT_REGION`) to determine the AWS region. If found, skip
+  using the AWS metadata server to determine this value.
+- If the region environment variable is not provided, use the **region_url**
+  to determine the current AWS region. The API returns the zone name, e.g.
+  `us-east-1d`. The region is determined by stripping the last character, e.g.
+  `us-east-1`.
+- Check the environment variables `ACCESS_ACCESS_KEY_ID`,
+  `AWS_SECRET_ACCESS_KEY` and the optional `AWS_SESSION_TOKEN` for the AWS
+  security credentials. If found, skip using the AWS metadata server to
+  determine these values.
+- If **url** is available and the security credentials environment variables
+  are not provided:
+  - Call **url** to retrieve the attached AWS IAM role name to the current
+    instance.
+  - Call **url/$ROLE_NAME** to get the access key, secret key and security
+    token needed to sign the `GetCallerIdentity` request.
+- Construct the AWS signed request ([AWS Signature Version 4][8]) using the
+  [GetCallerIdentity][9] **regional_cred_verification_url** (with the region
+  substituted). This will be serialized by formatting it as a url-encoded JSON
+  and passed as the **subject_token** to STS endpoint.
+  Here is a sample of the JSON format used:
+
+  ```json
+  {
+    "url": "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+    "headers": [
+      {
+        "value": "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID",
+        "key": "x-goog-cloud-target-resource"
+      },
+      {
+        "value": "20200228T225005Z",
+        "key": "x-amz-date"
+      },
+      {
+        "value": "AWS4-HMAC-SHA256 Credential=AKIASOZTBDV4D7ABCDEDF/20200228/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date,Signature=abcedefdfedfd",
+        "key": "Authorization"
+      }, 
+      {
+        "value": "sts.us-east-1.amazonaws.com",
+        "key": "host"
+      },
+      {
+        "value": "IQoJb3JpZ2luX2VjEIz//////////wEaCXVzLWVh...",
+        "key": "x-amz-security-token"
+      }
+    ], 
+    "method": "POST",
+    "body": ""
+  }
+  ```
+  For the AWS token, STS requires a special header `x-goog-cloud-endpoint` to recognize that the token is for a specific workload identity provider.
+
+#### Determining the subject token in Microsoft Azure and URL-sourced credentials
+
+External account configuration JSON files contain the following information
+in the `credential_source` object to facilitate retrieval of Azure and other
+URL-sourced credentials to be passed as subject tokens to the GCP STS token
+exchange endpoint.
+
+| Field Name                                        | Required | Description  |
+|---------------------------------------------------|----------|--------------|
+| credential_source.url                             | Yes      | This defines the local metadata server to retrieve the external credentials from. For Azure, this is the Azure Instance Metadata Service (IMDS) URL used to retrieve the Azure AD access token. |
+| credential_source.headers                         | No       | This defines the headers to append to the GET request to credential_source.url. |
+| credential_source.format.type                     | No       | This indicates the format of the URL response. This can be either "text" or "json". The default is "text". |
+| credential_source.format.subject_token_field_name | No       | Required for JSON URL responses. This indicates the JSON field name where the subject_token is stored. |
+
+The JSON file for URL-sourced configuration files (OIDC / SAML) will have the
+following form:
+
+```json
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/$EMAIL:generateAccessToken",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "url": "http://localhost:5000/token",
+    "format": {
+      "type": "json",
+      "subject_token_field_name": "id_token"
+    }
+  }
+}
+```
+
+Azure configuration files are a type of OIDC URL-sourced credentials.
+
+```json
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/$EMAIL:generateAccessToken",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "headers": {
+      "Metadata": "True"
+    },
+    "url": "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID",
+    "format": {
+      "type": "json",
+      "subject_token_field_name": "access_token"
+    }
+  }
+}
+```
+
+The auth libraries and applications **must** follow the steps below:
+
+- Check **credential_source** has a **url** field and no **environment_id**,
+  otherwise skip the rest of the steps.
+- An HTTP GET request should be sent to this local **url** while injecting
+  the **headers** key/values (if provided in the configuration file) in the
+  request header. The request will respond with the external credentials
+  subject token to be passed to STS token endpoint.
+- Before parsing the token, check the **format** field.
+- If the **format** is not available, assume the external credential returned
+  by the URL response is provided in plain text format.
+- If available, check if the type is **json**
+  - If json, check the **subject_token_field_name**.
+    For Azure, this is set to **access_token**.
+  - Parse the file as JSON and then retrieve the external credential from
+    the field name based on the value of **subject_token_field_name**.
+
+#### Determining the subject token file-sourced credentials
+
+External account configuration JSON files contain the following information
+in the `credential_source` object to facilitate retrieval of file-sourced
+credentials to be passed as subject tokens to the GCP STS token exchangeendpoint.
+
+| Field Name                                        | Required | Description |        
+|---------------------------------------------------|----------|-------------|
+| credential_source.file                            | Yes      | This is the source of the credential. This is used for a credential locally available. This takes precedence over `url` when both are provided. |
+| credential_source.format.type                     | No       | This indicates the format of the file where the token is stored. This can be either "text" or "json". The default is "text". |
+| credential_source.format.subject_token_field_name | No       | Required for JSON file formats. This indicates the JSON field name where the `subject_token` is stored. |
+
+The JSON file for file-sourced configuration files (OIDC / SAML) will have the
+following form:
+
+```json
+{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$PROVIDER_ID",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:saml2",
+  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/$EMAIL:generateAccessToken",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "file": "/var/run/saml/assertion/token"
+  }
+}
+```
+
+The auth libraries and applications **must** follow the steps below:
+
+- Check **credential_source** for the environment ID. If no environment ID,
+  this is a file-sourced credential.
+- Get the external credential from the file location specified by the
+  `credential_source.file` field. If not available, this is a url-sourced
+  credential.
+- Before parsing the token, check the **format** field.
+- If the **format** is not available, assume the external credential is
+  provided in plain text format.
+- If available, check if the type is **json**
+  - If json, check the **subject_token_field_name**.
+  - Parse the file as JSON and then retrieve the external credential from
+    the field name based on the value of **subject_token_field_name**.
+
+<!-- prettier-ignore-start -->
+[0]: https://cloud.google.com/iam/docs/configuring-workload-identity-federation#aws
+[1]: https://cloud.google.com/iam/docs/configuring-workload-identity-federation#azure
+[2]: https://cloud.google.com/iam/docs/configuring-workload-identity-federation#oidc
+[3]: https://cloud.google.com/iam/docs/configuring-workload-identity-federation#saml_1
+[4]: https://tools.ietf.org/html/rfc8693
+[5]: https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+[6]: https://google.aip.dev/auth/4110
+[7]: https://tools.ietf.org/html/rfc8693#section-3
+[8]: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+[9]: https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
+<!-- prettier-ignore-end -->

--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -41,8 +41,8 @@ the JSON configuration file to be used by the auth libraries.
 ### Configuration File Generation and Usage
 
 After workload identity federation is configured, the JSON configuration file
-will need to be generated. This sample shows how an AWS configuration file
-is generated:
+should be generated. This sample shows how an AWS configuration file is
+generated:
 
 ```bash
 $ gcloud iam workload-identity-pools create-cred-config \
@@ -109,21 +109,21 @@ scoped_credentials = credentials.with_scopes(
 
 ### Expected Behavior
 
-The auth libraries will use the information in the JSON configuration file to
+The auth libraries should use the information in the JSON configuration file to
 retrieve the external credentials and exchange them for Google access tokens
 using the GCP Security Token Service (via the token exchange endpoint
 `https://sts.googleapis.com/v1/token`) and then impersonating a service account
 by calling the **IamCredentials** [generateAccessToken][5] API to access GCP
 resources.
 
-All external account JSON files share the following fields:
+All external account JSON files must share the following fields:
 
 | Field Name                        | Required | Description |
 |-----------------------------------|----------|-------------|
-| type                              | Yes      | This identifies the new type of credential object. This is always "external_account" |
+| type                              | Yes      | This identifies the new type of credential object. This must be "external_account" |
 | audience                          | Yes      | This is the STS audience which contains the resource name for the workload identity pool and the provider identifier in that pool. |
 | subject_token_type                | Yes      | This is the STS subject token type based on the [OAuth 2.0 token exchange spec][7]. |
-| service_account_impersonation_url | No       | This is the URL for the service account impersonation request. If this is not available, the STS returned access token is directly used without impersonation. |
+| service_account_impersonation_url | No       | This is the URL for the service account impersonation request. If this is not available, the STS returned access token should be directly used without impersonation. |
 | token_url                         | Yes      | This is the STS token exchange endpoint. |
 | credential_source.*               | Yes      | This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint. |
 
@@ -131,13 +131,13 @@ The auth libraries and applications **must** follow the steps below for all
 types of external account credentials:
 
 - Check **credential_source** to determine the necessary logic to retrieve the
-  external credential which will be used to construct the subject token to pass
-  to the STS endpoint. This is covered in detail for every credential
+  external credential which should be used to construct the subject token to
+  pass to the STS endpoint. This is covered in detail for every credential
   configuration below.
 - Construct the STS request, based on [rfc8693][4]:
-  - STS audience is constructed using the **audience** field.
-  - **grant_type** is always `urn:ietf:params:oauth:grant-type:token-exchange`
-  - **requested_token_type** is always
+  - STS audience should be constructed using the **audience** field.
+  - **grant_type** must be `urn:ietf:params:oauth:grant-type:token-exchange`
+  - **requested_token_type** must be
     `urn:ietf:params:oauth:token-type:access_token`
   - **subject_token_type** is the **subject_token_type** field as described in
     the RFC.
@@ -145,11 +145,11 @@ types of external account credentials:
     subsequent sections on how this is retrieved in various environments.
   - **scope**: the list of space-delimited, case-insensitive OAuth scopes that
     specify the desired scopes of the requested security token in the context
-    of the service or resource where the token will be used. If service account
-    impersonation is used, the cloud platform or IAM scope will be passed to
-    STS and then the customer provided scopes will be passed in the
+    of the service or resource where the token should be used. If service
+    account impersonation is used, the cloud platform or IAM scope should be
+    passed to STS and then the customer provided scopes should be passed in the
     **IamCredentials** call to [generateAccessToken][5].
-  - The STS token exchange URL is the **token_url** (e.g.
+  - The STS token exchange URL should be the **token_url** (e.g.
     `https://sts.googleapis.com/v1/token`).
 - Send the STS token exchange request to get the Google access token and its
   expiration.
@@ -159,7 +159,7 @@ types of external account credentials:
   - If this is not available, end the flow and just use the STS access token
     for authorization.
   - The list of scopes also need to be provided for this endpoint. The customer
-    provided scopes will be used for this endpoint.
+    provided scopes should be used for this endpoint.
   - In order to access this API, the (Cloud platform
     `https://www.googleapis.com/auth/cloud-platform` or IAM scope
     `https://www.googleapis.com/auth/iam`) are required in the underlying
@@ -167,18 +167,19 @@ types of external account credentials:
 
 #### Determining the subject token in AWS
 
-External account configuration JSON files contain the following information
-in the `credential_source` object to facilitate retrieval of AWS credentials
-to be passed as subject tokens to the GCP STS token exchange endpoint.
+External account configuration JSON files should contain the following
+information in the `credential_source` object to facilitate retrieval of AWS
+credentials to be passed as subject tokens to the GCP STS token exchange
+endpoint.
 
 | Field Name                                       | Required | Description |
 |--------------------------------------------------|----------|-------------|
-| credential_source.environment_id                 | Yes      | This is the environment identifier, of format `aws${version}`. A version is specified to indicate to the auth library whether breaking changes were introduced to the underlying AWS implementation. So if aws1 is supported in the current version of the library but a credential file with aws2 is provided, an error is thrown instructing the developer to upgrade to a newer version of the library. |
-| credential_source.region_url                     | Yes      | This URL is used to determine the current AWS region needed for the signed request construction. |
-| credential_source.url                            | No       | This AWS metadata server URL is used to retrieve the access key, secret key and security token needed to sign the `GetCallerIdentity` request. The $ROLE_NAME needs to be retrieved from calling this endpoint without any parameter and then calling again with the returned role name appended to this URL: http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME |
-| credential_source.regional_cred_verification_url | Yes      | This defines the regional AWS `GetCallerIdentity` action URL. This is the URL used to determine the AWS account ID and its roles. This is not actually called by the Auth libraries. It is called on the STS token server. The region is substituted by SDK, e.g. sts.eu-west-1.amazonaws.com. |
+| credential_source.environment_id                 | Yes      | This is the environment identifier, of format `aws${version}`. A version should be specified to indicate to the auth library whether breaking changes were introduced to the underlying AWS implementation. So if aws1 is supported in the current version of the library but a credential file with aws2 is provided, an error should be thrown instructing the developer to upgrade to a newer version of the library. |
+| credential_source.region_url                     | Yes      | This URL should be used to determine the current AWS region needed for the signed request construction. |
+| credential_source.url                            | No       | This AWS metadata server URL should be used to retrieve the access key, secret key and security token needed to sign the `GetCallerIdentity` request. The $ROLE_NAME should be retrieved from calling this endpoint without any parameter and then calling again with the returned role name appended to this URL: http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME |
+| credential_source.regional_cred_verification_url | Yes      | This defines the regional AWS `GetCallerIdentity` action URL. This URL should be used to determine the AWS account ID and its roles. This should not actually be called by the Auth libraries. It should be called on the STS token server. The region should be substituted by SDK, e.g. `sts.eu-west-1.amazonaws`.com. |
 
-The JSON file for AWS configuration files will have the following form:
+The JSON file for AWS configuration files should have the following form:
 
 ```json
 {
@@ -199,7 +200,7 @@ The JSON file for AWS configuration files will have the following form:
 The auth libraries and applications **must** follow the steps below:
 
 - Check **credential_source** for environment ID. If the environment ID is
-  `aws${version}`, this is an AWS native credential.
+  `aws${version}`, this should be an AWS native credential.
 - Inspect the version in the environment ID. If this is a newer unexpected
   error, trigger an error that the auth library needs to be updated to handle
   this type of credentials.
@@ -208,8 +209,8 @@ The auth libraries and applications **must** follow the steps below:
   using the AWS metadata server to determine this value.
 - If the region environment variable is not provided, use the **region_url**
   to determine the current AWS region. The API returns the zone name, e.g.
-  `us-east-1d`. The region is determined by stripping the last character, e.g.
-  `us-east-1`.
+  `us-east-1d`. The region should be determined by stripping the last
+  character, e.g. `us-east-1`.
 - Check the environment variables `ACCESS_ACCESS_KEY_ID`,
   `AWS_SECRET_ACCESS_KEY` and the optional `AWS_SESSION_TOKEN` for the AWS
   security credentials. If found, skip using the AWS metadata server to
@@ -222,8 +223,8 @@ The auth libraries and applications **must** follow the steps below:
     token needed to sign the `GetCallerIdentity` request.
 - Construct the AWS signed request ([AWS Signature Version 4][8]) using the
   [GetCallerIdentity][9] **regional_cred_verification_url** (with the region
-  substituted). This will be serialized by formatting it as a url-encoded JSON
-  and passed as the **subject_token** to STS endpoint.
+  substituted). This should be serialized by formatting it as a url-encoded
+  JSON and passed as the **subject_token** to STS endpoint.
   Here is a sample of the JSON format used:
 
   ```json
@@ -259,19 +260,19 @@ The auth libraries and applications **must** follow the steps below:
 
 #### Determining the subject token in Microsoft Azure and URL-sourced credentials
 
-External account configuration JSON files contain the following information
-in the `credential_source` object to facilitate retrieval of Azure and other
-URL-sourced credentials to be passed as subject tokens to the GCP STS token
-exchange endpoint.
+External account configuration JSON files should contain the following
+information in the `credential_source` object to facilitate retrieval of Azure
+and other URL-sourced credentials to be passed as subject tokens to the GCP STS
+token exchange endpoint.
 
 | Field Name                                        | Required | Description  |
 |---------------------------------------------------|----------|--------------|
-| credential_source.url                             | Yes      | This defines the local metadata server to retrieve the external credentials from. For Azure, this is the Azure Instance Metadata Service (IMDS) URL used to retrieve the Azure AD access token. |
+| credential_source.url                             | Yes      | This defines the local metadata server to retrieve the external credentials from. For Azure, this should be the Azure Instance Metadata Service (IMDS) URL used to retrieve the Azure AD access token. |
 | credential_source.headers                         | No       | This defines the headers to append to the GET request to credential_source.url. |
-| credential_source.format.type                     | No       | This indicates the format of the URL response. This can be either "text" or "json". The default is "text". |
-| credential_source.format.subject_token_field_name | No       | Required for JSON URL responses. This indicates the JSON field name where the subject_token is stored. |
+| credential_source.format.type                     | No       | This indicates the format of the URL response. This can be either "text" or "json". The default should be "text". |
+| credential_source.format.subject_token_field_name | No       | Required for JSON URL responses. This indicates the JSON field name where the subject_token should be stored. |
 
-The JSON file for URL-sourced configuration files (OIDC / SAML) will have the
+The JSON file for URL-sourced configuration files (OIDC / SAML) should have the
 following form:
 
 ```json
@@ -319,7 +320,7 @@ The auth libraries and applications **must** follow the steps below:
   otherwise skip the rest of the steps.
 - An HTTP GET request should be sent to this local **url** while injecting
   the **headers** key/values (if provided in the configuration file) in the
-  request header. The request will respond with the external credentials
+  request header. The request should respond with the external credentials
   subject token to be passed to STS token endpoint.
 - Before parsing the token, check the **format** field.
 - If the **format** is not available, assume the external credential returned
@@ -334,16 +335,17 @@ The auth libraries and applications **must** follow the steps below:
 
 External account configuration JSON files contain the following information
 in the `credential_source` object to facilitate retrieval of file-sourced
-credentials to be passed as subject tokens to the GCP STS token exchangeendpoint.
+credentials to be passed as subject tokens to the GCP STS token exchange
+endpoint.
 
 | Field Name                                        | Required | Description |        
 |---------------------------------------------------|----------|-------------|
-| credential_source.file                            | Yes      | This is the source of the credential. This is used for a credential locally available. This takes precedence over `url` when both are provided. |
-| credential_source.format.type                     | No       | This indicates the format of the file where the token is stored. This can be either "text" or "json". The default is "text". |
-| credential_source.format.subject_token_field_name | No       | Required for JSON file formats. This indicates the JSON field name where the `subject_token` is stored. |
+| credential_source.file                            | Yes      | This is the source of the credential. This should be used for a credential locally available. This should take precedence over `url` when both are provided. |
+| credential_source.format.type                     | No       | This indicates the format of the file where the token is stored. This can be either "text" or "json". The default should be "text". |
+| credential_source.format.subject_token_field_name | No       | Required for JSON file formats. This indicates the JSON field name where the `subject_token` should be stored. |
 
-The JSON file for file-sourced configuration files (OIDC / SAML) will have the
-following form:
+The JSON file for file-sourced configuration files (OIDC / SAML) should have
+the following form:
 
 ```json
 {
@@ -361,10 +363,10 @@ following form:
 The auth libraries and applications **must** follow the steps below:
 
 - Check **credential_source** for the environment ID. If no environment ID,
-  this is a file-sourced credential.
+  this should be a file-sourced credential.
 - Get the external credential from the file location specified by the
-  `credential_source.file` field. If not available, this is a url-sourced
-  credential.
+  `credential_source.file` field. If not available, this should be a
+  url-sourced credential.
 - Before parsing the token, check the **format** field.
 - If the **format** is not available, assume the external credential is
   provided in plain text format.
@@ -372,6 +374,11 @@ The auth libraries and applications **must** follow the steps below:
   - If json, check the **subject_token_field_name**.
   - Parse the file as JSON and then retrieve the external credential from
     the field name based on the value of **subject_token_field_name**.
+
+## Changelog
+
+- **2021-12-10**: Add AIP for External Account Credentials (AIP 4117).
+
 
 <!-- prettier-ignore-start -->
 [0]: https://cloud.google.com/iam/docs/configuring-workload-identity-federation#aws


### PR DESCRIPTION
Added AIP for external account credentials (workload identity federation) used by
google auth libraries to authorize API calls to GCP resources.