### PR TITLE
Fix a broken link in 0001.md

### DIFF
--- a/aip/general/0001.md
+++ b/aip/general/0001.md
@@ -89,7 +89,7 @@ The list of AIP editors is currently:
 - Hong Zhang ([@wora][])
 - JJ Geewax ([@jgeewax][])
 - Jon Skeet ([@jskeet][])
-- Sam Woodard ([@samwoodard][])
+- Sam Woodard ([@shwoodard][])
 
 The editors are also responsible for the administrative and editorial aspects
 of shepherding AIPs and managing the AIP pipeline and workflow. They approve
@@ -277,3 +277,4 @@ state, and will link to the new, current AIP.
 [@jskeet]: https://github.com/jskeet
 [@lukesneeringer]: https://github.com/lukesneeringer
 [@wora]: https://github.com/wora
+[@shwoodard]: https://github.com/shwoodard


### PR DESCRIPTION
Hello, I found the one link for Sam is broken on this page: [AIP-1: AIP Purpose and Guidelines](https://google.aip.dev/1). This PR fixes the link by adding a footnote link.

## Screenshots

**Before**
<img width="767" alt="Screen Shot 2021-12-20 at 1 56 11" src="https://user-images.githubusercontent.com/1425259/146683593-ba32ad9e-6c5b-421a-ad1a-7d427827a655.png">

**After**
<img width="582" alt="Screen Shot 2021-12-19 at 2 41 48" src="https://user-images.githubusercontent.com/1425259/146683648-7b25e8bd-da5a-428c-8919-8c16cd70b055.png">

I also changed the `@name` part to match the GitHub name. I hope this change is appropriate. 

\# Thank you for sharing documents that have much insight into API architecture! 🙂 