### PR TITLE
Proposes declarative state transition guidance.

### DIFF
--- a/aip/general/0216.md
+++ b/aip/general/0216.md
@@ -125,6 +125,24 @@ message PublishBookRequest {
 - The comment for the field **should** document the resource pattern.
 - Other fields **may** be included.
 
+### Declarative-Friendly Resources
+
+Declarative-friendly resources **must not** use custom methods for state
+transitions. If state transitions are necessary for declarative-friendly
+resources, the `state` field **should** be modifiable in an [Update][aip-134]
+request. For declarative-friendly resources, the `state` field **should not**
+be output-only.
+
+The output of the `state` represents the post-reconciliation state for a
+declarative-friendly resource, it **must not** reflect ongoing transitional
+states such as `ENABLING` or `DELETING`.
+
+Declarative-friendly resources **should** use the [reconciling][reconciling-field]
+field to represent ongoing state changes. If additional information is required,
+An output-only `reconciliation_state` enum field **may** be added that reports
+ongoing transitional states. The `state` and `reconciliation_state` fields **may**
+share an enum, but `state` **must** reflect the desired state.
+
 ## Additional Guidance
 
 ### Default value
@@ -240,4 +258,6 @@ necessary.
 - **2019-07-18**: Added explicit guidance on the unspecified value.
 
 [aip-126]: ./0126.md
+[aip-134]: ./0134.md
 [long-running]: ./0151.md
+[reconciling-field]: ./0128.md#reconciliation


### PR DESCRIPTION
This proposes a declarative-friendly construct for states and state transitions that can sit reasonably comfortably on top of existing guidance. The key features of the proposal:

1. Declarative-friendly resources must allow direct modification of `state` field via `Update` requests.
2. Output of `state` field must always represent desired state while reconciling.
3. Allows for optional `reconciliation_state` field to provide fine-grained information about transitional state.
4. Allows `state` and `reconciliation_state` to share an enum for convenience (I'm not sure about this one, since `state` will never output a transitional value, but it seems like an easier way to transition existing APIs toward this).

I'm not confident that this proposal is bulletproof, but it seemed prudent to have a starting point for conversation since declarative-friendly APIs with `state` are something I'm bumping into frequently.