### PR TITLE
Clarify scope of common protos

### DIFF
--- a/aip/aog/3021.md
+++ b/aip/aog/3021.md
@@ -45,11 +45,11 @@ email the owners of the //google/actions/type directory directly.
 
 <!-- prettier-ignore-start -->
 [aip-213]: ../0213.md
-[date]: https://github.com/googleapis/api-common-protos/tree/master/google/type/date.proto
-[timeofday]: https://github.com/googleapis/api-common-protos/tree/master/google/type/timeofday.proto
+[date]: https://github.com/googleapis/googleapis/tree/master/google/type/date.proto
+[timeofday]: https://github.com/googleapis/googleapis/tree/master/google/type/timeofday.proto
 [duration]: https://github.com/protocolbuffers/protobuf/tree/master/src/google/protobuf/duration.proto
-[money]: https://github.com/googleapis/api-common-protos/tree/master/google/type/money.proto
-[postaladdress]: https://github.com/googleapis/api-common-protos/tree/master/google/type/postal_address.proto
-[type]: https://github.com/googleapis/api-common-protos/tree/master/google/type/
+[money]: https://github.com/googleapis/googleapis/tree/master/google/type/money.proto
+[postaladdress]: https://github.com/googleapis/googleapis/tree/master/google/type/postal_address.proto
+[type]: https://github.com/googleapis/googleapis/tree/master/google/type/
 [actions-type]: https://github.com/googleapis/googleapis/tree/master/google/actions/type/
 <!-- prettier-ignore-end -->

--- a/aip/aog/3022.md
+++ b/aip/aog/3022.md
@@ -144,12 +144,12 @@ following Schema.org entity types to URI parameters:
 
 <!-- prettier-ignore-start -->
 [aip-3021]: ./3021.md
-[date]: https://github.com/googleapis/api-common-protos/tree/master/google/type/date.proto
+[date]: https://github.com/googleapis/googleapis/tree/master/google/type/date.proto
 [datetime]: https://github.com/googleapis/googleapis/blob/master/google/type/datetime.proto
-[timeofday]: https://github.com/googleapis/api-common-protos/tree/master/google/type/timeofday.proto
+[timeofday]: https://github.com/googleapis/googleapis/tree/master/google/type/timeofday.proto
 [duration]: https://github.com/protocolbuffers/protobuf/tree/master/src/google/protobuf/duration.proto
-[money]: https://github.com/googleapis/api-common-protos/tree/master/google/type/money.proto
-[postaladdress]: https://github.com/googleapis/api-common-protos/tree/master/google/type/postal_address.proto
+[money]: https://github.com/googleapis/googleapis/tree/master/google/type/money.proto
+[postaladdress]: https://github.com/googleapis/googleapis/tree/master/google/type/postal_address.proto
 [app actions]: https://developers.google.com/assistant/app/intents#handling_intent_parameters
 [schema-date]: https://schema.org/Date
 [schema-datetime]: https://schema.org/DateTime

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -55,7 +55,7 @@ key in any of the standard fields (`get`, `post`, `put`, `patch`, `delete`) on
 the [`google.api.http`][http] annotation is sufficient.
 
 <!-- prettier-ignore -->
-[http]: https://github.com/googleapis/api-common-protos/blob/master/google/api/http.proto
+[http]: https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
 [rfc 6570 §3.2.2]: https://tools.ietf.org/html/rfc6570#section-3.2.2
 
 ## Changelog

--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -113,5 +113,5 @@ break user code.
 
 <!-- prettier-ignore-start -->
 [aip-203]: ../0203.md
-[method_signature]: https://github.com/googleapis/api-common-protos/blob/master/google/api/client.proto#L100
+[method_signature]: https://github.com/googleapis/googleapis/blob/master/google/api/client.proto#L100
 <!-- prettier-ignore-end -->

--- a/aip/client-libraries/4290.md
+++ b/aip/client-libraries/4290.md
@@ -47,7 +47,7 @@ convenience and not a replacement for this interface.
 Containers **must** include:
 
 - A current version of protoc, the protocol buffer compiler.
-- Common protos permitted to be used by all APIs ([api-common-protos][]).
+- Common protos permitted to be used by all APIs ([googleapis][]).
 - The applicable code generator plugin, as well as any dependencies it
   requires.
   - The code generator plugin itself **should** be added using an `ADD` or
@@ -181,7 +181,7 @@ numbers; this process will need to be amended slightly if a generator needs to
 maintain multiple version streams simultaneously.
 
 <!-- prettier-ignore-start -->
-[api-common-protos]: https://github.com/googleapis/api-common-protos
+[googleapis]: https://github.com/googleapis/googleapis
 [docker]: https://docker.com/
 [google container registry]: https://cloud.google.com/container-registry/
 [multi-stage builds]: https://docs.docker.com/develop/develop-images/multistage-build/

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -89,8 +89,8 @@ resource:
 [aip-122]: ./0122.md
 [API Group]: https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups
 [Object]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-[resource]: https://github.com/googleapis/api-common-protos/blob/master/google/api/resource.proto
-[service configuration]: https://github.com/googleapis/api-common-protos/blob/master/google/api/service.proto
+[resource]: https://github.com/googleapis/googleapis/blob/master/google/api/resource.proto
+[service configuration]: https://github.com/googleapis/googleapis/blob/master/google/api/service.proto
 <!-- prettier-ignore-end -->
 
 ## Changelog

--- a/aip/general/0141.md
+++ b/aip/general/0141.md
@@ -69,5 +69,5 @@ the suffix for the field name if it makes intuitive sense to do so.
 
 <!-- prettier-ignore-start -->
 [duration]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto
-[money]: https://github.com/googleapis/api-common-protos/blob/master/google/type/money.proto
+[money]: https://github.com/googleapis/googleapis/blob/master/google/type/money.proto
 <!-- prettier-ignore-end -->

--- a/aip/general/0142.md
+++ b/aip/general/0142.md
@@ -134,12 +134,12 @@ use.
 
 <!-- prettier-ignore-start -->
 [aip-213]: ./0213.md
-[date]: https://github.com/googleapis/api-common-protos/blob/master/google/type/date.proto
+[date]: https://github.com/googleapis/googleapis/blob/master/google/type/date.proto
 [datetime]: https://github.com/googleapis/googleapis/blob/master/google/type/datetime.proto
 [duration]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto
 [iso-8601]: https://www.iso.org/iso-8601-date-and-time-format.html
 [py_datetime]: https://docs.python.org/3/library/datetime.html#datetime.datetime
 [py_timedelta]: https://docs.python.org/3/library/datetime.html#datetime.timedelta
-[time_of_day]: https://github.com/googleapis/api-common-protos/blob/master/google/type/timeofday.proto
+[time_of_day]: https://github.com/googleapis/googleapis/blob/master/google/type/timeofday.proto
 [timestamp]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
 <!-- prettier-ignore-end -->

--- a/aip/general/0143.md
+++ b/aip/general/0143.md
@@ -102,5 +102,5 @@ format][] to represent this, and the field **must** be named `utc_offset`.
 [iso-4217]: https://en.wikipedia.org/wiki/ISO_4217
 [iso-8601 format]: https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
 [list]: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
-[money]: https://github.com/googleapis/api-common-protos/blob/master/google/type/money.proto
+[money]: https://github.com/googleapis/googleapis/blob/master/google/type/money.proto
 <!-- prettier-ignore-end -->

--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -117,8 +117,8 @@ metadata message. The errors themselves **must** still be represented with a
 [aip-135]: ./0135.md
 [aip-193]: ./0193.md
 [aip-216]: ./0216.md
-[google.rpc.Status]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/status.proto
-[lro]: https://github.com/googleapis/api-common-protos/blob/master/google/longrunning/operations.proto
+[google.rpc.Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
+[lro]: https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto
 [node.js promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises
 [python future]: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future
 <!-- prettier-ignore-end -->

--- a/aip/general/0152.md
+++ b/aip/general/0152.md
@@ -135,5 +135,5 @@ the child resource.
 [aip-136]: ./0136.md
 [aip-151]: ./0151.md
 [aip-203]: ./0203.md
-[status]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/status.proto
+[status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
 <!-- prettier-ignore-end -->

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -83,10 +83,10 @@ message. The errors themselves **must** still be represented with a
 
 <!-- prettier-ignore-start -->
 [aip-4221]: ../client-libraries/4221.md
-[details]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/error_details.proto
-[ErrorInfo]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/error_details.proto#L111
+[details]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+[ErrorInfo]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L111
 [grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
-[Code]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/code.proto
-[Status]: https://github.com/googleapis/api-common-protos/blob/master/google/rpc/status.proto
+[Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+[Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
 [long-running operations]: ./0151.md
 <!-- prettier-ignore-end -->

--- a/aip/general/0213.md
+++ b/aip/general/0213.md
@@ -40,22 +40,22 @@ doing so, APIs **should** keep the field names and numbers the same.
 The common protos, which public-facing protos for an API **may** safely import,
 are as follows:
 
-- [`google.api.http`](https://github.com/googleapis/api-common-protos/blob/master/google/api/http.proto)
-- [`google.longrunning.Operation`](https://github.com/googleapis/api-common-protos/blob/master/google/longrunning/operations.proto)
+- [`google.api.http`](https://github.com/googleapis/googleapis/blob/master/google/api/http.proto)
+- [`google.longrunning.Operation`](https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto)
 - [`google.protobuf.*`](https://github.com/protocolbuffers/protobuf/tree/master/src/google/protobuf)
-- [`google.rpc.Code`](https://github.com/googleapis/api-common-protos/blob/master/google/rpc/code.proto)
-- [`google.rpc.Status`](https://github.com/googleapis/api-common-protos/blob/master/google/rpc/status.proto)
+- [`google.rpc.Code`](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto)
+- [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
 - [`google.type.*`][type]
 
 Note that some common protos may have internal-only fields. APIs **should**
 generally only rely on fields which have been
-[released into open source](https://github.com/googleapis/api-common-protos).
+[released into open source](https://github.com/googleapis/googleapis).
 
 Google APIs **may** also import [`google.iam.v1.*`][iam], which provides the
 IAM messages used throughout Google.
 
 <!-- prettier-ignore -->
-[iam]: https://github.com/googleapis/api-common-protos/tree/master/google/iam/v1
+[iam]: https://github.com/googleapis/googleapis/tree/master/google/iam/v1
 
 **Note:** Many APIs also import protos from other packages for internal-only
 use (e.g. to apply visibility labels or provide instructions to internal
@@ -111,14 +111,14 @@ and the definitive list is always [the code][type], several types deserve note:
   zone component.
 
 <!-- prettier-ignore-start -->
-[type]: https://github.com/googleapis/api-common-protos/tree/master/google/type
-[color]: https://github.com/googleapis/api-common-protos/blob/master/google/type/color.proto
-[date]: https://github.com/googleapis/api-common-protos/blob/master/google/type/date.proto
-[day_of_week]: https://github.com/googleapis/api-common-protos/blob/master/google/type/dayofweek.proto
-[lat_lng]: https://github.com/googleapis/api-common-protos/blob/master/google/type/latlng.proto
-[money]: https://github.com/googleapis/api-common-protos/blob/master/google/type/money.proto
-[postal_address]: https://github.com/googleapis/api-common-protos/blob/master/google/type/postal_address.proto
-[time_of_day]: https://github.com/googleapis/api-common-protos/blob/master/google/type/timeofday.proto
+[type]: https://github.com/googleapis/googleapis/tree/master/google/type
+[color]: https://github.com/googleapis/googleapis/blob/master/google/type/color.proto
+[date]: https://github.com/googleapis/googleapis/blob/master/google/type/date.proto
+[day_of_week]: https://github.com/googleapis/googleapis/blob/master/google/type/dayofweek.proto
+[lat_lng]: https://github.com/googleapis/googleapis/blob/master/google/type/latlng.proto
+[money]: https://github.com/googleapis/googleapis/blob/master/google/type/money.proto
+[postal_address]: https://github.com/googleapis/googleapis/blob/master/google/type/postal_address.proto
+[time_of_day]: https://github.com/googleapis/googleapis/blob/master/google/type/timeofday.proto
 <!-- prettier-ignore-end -->
 
 ## Appendix: Adding to common protos

--- a/aip/general/0213.md
+++ b/aip/general/0213.md
@@ -40,11 +40,10 @@ doing so, APIs **should** keep the field names and numbers the same.
 The common protos, which public-facing protos for an API **may** safely import,
 are as follows:
 
-- [`google.api.http`](https://github.com/googleapis/googleapis/blob/master/google/api/http.proto)
+- [`google.api.*`](https://github.com/googleapis/googleapis/blob/master/google/api) (but *not* subpackages of `google.api`)
 - [`google.longrunning.Operation`](https://github.com/googleapis/googleapis/blob/master/google/longrunning/operations.proto)
 - [`google.protobuf.*`](https://github.com/protocolbuffers/protobuf/tree/master/src/google/protobuf)
-- [`google.rpc.Code`](https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto)
-- [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+- [`google.rpc.*`](https://github.com/googleapis/googleapis/blob/master/google/rpc/)
 - [`google.type.*`][type]
 
 Note that some common protos may have internal-only fields. APIs **should**


### PR DESCRIPTION
Note that the common protos have been duplicated in https://github.com/googleapis/googleapis and https://github.com/googleapis/api-common-protos for some time; we are hoping to retire the `api-common-protos` repo. The text `api-common-protos` *does* still exist after this change, in [AIP-4290](https://google.aip.dev/client-libraries/4290) as the container image gcr.io/gapic-images/api-common-protos.

I'm very much open to discuss whether we *do* want to broaden the scope of common protos like this.