### PR TITLE
fix: Align Etag Error Code With Freshness Documentation

### DIFF
--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -232,7 +232,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
-- **2022-02-02**: Changed the etag error from FAILED_PRECONDITION (which becomes HTTP 400) to ABORTED (409).
+- **2022-02-02**: Changed eTag response from `FAILED_PRECONDITION` to `ABORTED` making it consistent with change to [AIP-134][etag] on 2021-03-05.
 - **2020-10-06**: Added guidance for declarative-friendly resources.
 - **2020-10-06**: Added guidance for allowing no-op delete for missing
   resources.

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -167,7 +167,7 @@ message DeleteBookRequest {
 ```
 
 If the etag is provided and does not match the server-computed etag, the
-request **must** fail with a `FAILED_PRECONDITION` error code.
+request **must** fail with a `ABORTED` error code.
 
 **Note:** Declarative-friendly resources (AIP-128) **must** provide the `etag`
 field for Delete requests.
@@ -232,6 +232,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
+- **2022-02-02**: Changed the etag error from FAILED_PRECONDITION (which becomes HTTP 400) to ABORTED (409).
 - **2020-10-06**: Added guidance for declarative-friendly resources.
 - **2020-10-06**: Added guidance for allowing no-op delete for missing
   resources.

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -220,6 +220,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 [aip-131]: ./0131.md
 [aip-132]: ./0132.md
 [aip-136]: ./0136.md
+[aip-154]: ./0154.md
 [aip-203]: ./0203.md
 [aip-214]: ./0214.md
 [aip-216]: ./0216.md
@@ -232,7 +233,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
-- **2022-02-02**: Changed eTag response from `FAILED_PRECONDITION` to `ABORTED` making it consistent with change to [AIP-134][etag] on 2021-03-05.
+- **2022-02-02**: Changed eTag error from `FAILED_PRECONDITION` to `ABORTED` making it consistent with change to [AIP-154][] & [AIP-134][etag] on 2021-03-05.
 - **2020-10-06**: Added guidance for declarative-friendly resources.
 - **2020-10-06**: Added guidance for allowing no-op delete for missing
   resources.


### PR DESCRIPTION
Changing the Error code when a delete does not match the etag of the existing resource.

Changed the etag error from FAILED_PRECONDITION (which becomes HTTP 400) to ABORTED (409).