### PR TITLE
Make $fields "should" be optional in AIP-157

### DIFF
--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -28,7 +28,7 @@ parameter or an HTTP header (or a [gRPC metadata entry][1]).
 
 - The value of the field mask parameter **must** be a `google.protobuf.FieldMask`.
 - The field mask parameter **should** be specified using `$field` as a query parameter or `X-Goog-FieldMask` as an HTTP header.
-- The field mask parameter **must** be optional:
+- The field mask parameter **should** be optional:
   - An explicit value of `"*"` **should** be supported, and **must** return all
     fields.
   - If the field mask parameter is not provided, all fields **must** be


### PR DESCRIPTION
This makes both read masks as a field and read masks as a system parameter have the same requirements.

This matches the requirements for $field as documented in https://cloud.google.com/apis/docs/system-parameters