### PR TITLE
remove invalid example condition

### DIFF
--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -30,7 +30,6 @@ some cases but not others, as appropriate in the environment. For example, any
 of the following strategies would be permissible:
 
 - Providing overloads iff all arguments in the signature are primitives.
-- Providing overloads iff all arguments in the signature are required.
 - Providing overloads only for the first of multiple signatures when providing
   more than one would produce a conflict.
 - Any combination of the above.


### PR DESCRIPTION
I believe this is actually an incorrect condition. In protobuf, `required` arguments are allowed to move to `optional` without being considered a breaking change. So in this condition, the client libraries could potentially remove the overload, which would constitute a breaking change. 

A more accurate example would be if all arguments in the signature are `optional`, which unfortunately I don't believe would ever happen with the `method_signature` annotation.