### PR TITLE
Clarify file/dir structural guidance in AIP-191

### DIFF
--- a/aip/general/0191.md
+++ b/aip/general/0191.md
@@ -48,6 +48,9 @@ file per service.
 APIs with only one file **should** use a filename corresponding to the name of
 the API.
 
+API `service` definitions and associated RPC request and response `message`
+definitions **should** be defined in the same file.
+
 Bear in mind that the file names often become module names in client libraries,
 and customers use them in `import` or `use` statements. Therefore, choosing a
 descriptive and language keyword-free filename does matter. For example, a file


### PR DESCRIPTION
In issue #151, @lukesneeringer suggested mandating that service definitions and
request/response definitions "should definitely be in the same file,
particularly for import hygiene in generated code."  The language of one of the
existing requirements

> The RPC request and response `message` definitions, in the same order of the
> corresponding methods. Each request message **must** precede its
> corresponding response message (if any).

implies this to an extent but it's never made explicit.