### PR TITLE
Update "GSuite" to "Google Workspace" in FAQ

### DIFF
--- a/pages/general/faq.md
+++ b/pages/general/faq.md
@@ -22,7 +22,7 @@ complete. If you see things like "Submit a CL" or "Talk to your PA lead", feel
 free to send pull requests to fix these oversights.
 
 (CL stands for "Change List" which is sort of like a GitHub Pull Request, and
-PA stands for "Product Area" meaning things like "Google Maps" or "GSuite".)
+PA stands for "Product Area" meaning things like "Google Maps" or "Google Workspace".)
 
 ### I like most of these AIPs, but some make no sense for me. What do I do?
 


### PR DESCRIPTION
GSuite has become Google Workspace since this was written.