### PR TITLE
Update AIP-151 to specify that operations must exist

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -59,6 +59,7 @@ rpc WriteBook(WriteBookRequest) returns (google.longrunning.Operation) {
 - APIs with messages that return `Operation` **must** implement the
   [`Operations`][lro] service. Individual APIs **must not** define their own
   interfaces for long-running operations to avoid inconsistency.
+- The operation **must** exist at the time the response is issued.
 
 **Note:** User expectations can vary on what is considered "a significant
 amount of time" depending on what work is being done. A good rule of thumb is


### PR DESCRIPTION
Specify that operations must exist at the time that they are returned from the API. This prevents clients from attempting to query the operation and having a 404 returned as the operation does not exist yet. This behavior is seen in datastore index creation requests for times up to several minutes, and causes significant issues in handling the operation

Context in b/229380899