### PR TITLE
Add a Cloud AIP with new optional keyword guidance

### DIFF
--- a/aip/cloud/25149.md
+++ b/aip/cloud/25149.md
@@ -1,0 +1,76 @@
+---
+id: 25149
+state: reviewing
+created: 2022-05-04
+placement:
+  category: gcp
+---
+
+# Unset field values
+
+AIP-149 includes the guidance:
+
+    Services defined in protocol buffers should use the `optional` keyword
+    for primitives if and only if it is necessary to distinguish setting
+    the field to its default value (`0`, `false`, or empty string) from not
+    setting it at all
+
+While Google Cloud Platform APIs are *defined* using protocol buffers, these
+APIs are not always *accessed* using protocol buffers. For
+instance, many clients use the JSON-over-HTTP endpoints. Because the [proto3
+JSON mapping](https://developers.google.com/protocol-buffers/docs/proto3#json)
+does not distinguish between "default value" and "unset" it is
+impossible for these API consumers to successfully use APIs that rely on
+`optional` behavior.
+
+## Guidance
+
+Google Cloud Platform defined in protocol buffers **must not** use the
+`optional` keyword. Instead, APIs that rely on the distinction between "set"
+and "unset" should use an alternative design that explicitly defines whether
+a field is set or unset. For instance, the `optional` example provided by
+AIP-149:
+
+```proto
+// A representation of a book in a library.
+message Book {
+  // The name of the book.
+  string name = 1;
+
+  // The rating for the book, from 0 to 5.
+  // 0 is distinct from no rating.
+  optional int32 rating = 2;
+}
+```
+
+Could be instead be implemented as:
+
+```proto
+// A representation of a book in a library.
+message Book {
+    // The name of the book.
+    string name = 1;
+
+    // Whether or not the the book has a rating.
+    bool is_rated = 2;
+
+    // The rating for the book, from 0 to 5.
+    // 0 is distinct from no rating. Only valid
+    // when is_rated == true.
+    int32 rating = 3;
+}
+```
+
+Or:
+
+```proto
+// A representation of a book in a library.
+message Book {
+    // The name of the book.
+    string name = 1;
+
+    // The rating for the book, from 1 to 5.
+    // 0 indicates "no rating".
+    int32 rating = 2;
+}
+```

--- a/aip/cloud/25149.md
+++ b/aip/cloud/25149.md
@@ -25,7 +25,7 @@ impossible for these API consumers to successfully use APIs that rely on
 
 ## Guidance
 
-Google Cloud Platform defined in protocol buffers **must not** use the
+Google Cloud Platform APIs defined in protocol buffers **must not** use the
 `optional` keyword. Instead, APIs that rely on the distinction between "set"
 and "unset" should use an alternative design that explicitly defines whether
 a field is set or unset. For instance, the `optional` example provided by


### PR DESCRIPTION
This is a result of #863 and some additional discussions that occurred offline. Instead of revising the general guidance involving the use of proto `optional` we are scoping it specifically to GCP APIs.