### PR TITLE
Add guidance around updating resources with state fields

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -104,11 +104,35 @@ message UpdateBookRequest {
 ### Side effects
 
 In general, update methods are intended to update the data within the resource.
-Update methods **should not** trigger other side effects. Instead, side effects
-**should** be triggered by custom methods.
+Update methods **should not** trigger other side effects unless allowed by a
+[`mostDisruptiveAllowedAction` parameter](#state-restrictions) on the request.
+Instead, side effects **should** be triggered by custom methods.
 
 In particular, this entails that [state fields][] **must not** be directly
 writable in update methods.
+
+### State restrictions
+
+In general, update methods **must not** depend on a resource being in a
+specific resting state.
+
+For resources whose underlying implementation requires the resource to enter a
+certain state, such as updating certain VM settings, in order to avoid
+unexpected side effects, updates to resources with state fields **must** be
+guarded by a parameter called  `mostDisruptiveAllowedAction` that enumerates the
+states an update method can transition to, allowing users to specify how much
+disruption is allowed by the update. Following a successful update, the
+API **must** return the resource to its previous resting state. On an
+unsuccessful update, the API **may** return the resource to its prior state,or
+may leave it in the state it ended up in.
+
+An update that is not allowed by the users' `mostDisruptiveAllowedAction` choice
+**must** return [error code *3*](https://github.com/googleapis/googleapis/blob/ad96d2427aaea0d597898f0d61d6d86bc8474230/google/rpc/code.proto#L52-L58).
+
+A single update call and the corresponding update LRO **must** encapsulate the
+entire operation on the resource- transitioning to the appropriate resting
+state(s), updating any value(s) that require that state, and then transitioning
+back to the original state.
 
 ### PATCH and PUT
 
@@ -283,6 +307,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
+- **2022-05-XX**: Added guidance on updating resources with state fields.
 - **2021-11-04**: Changed the permission check if `allow_missing` is set.
 - **2021-07-08**: Added error guidance for resource not found case.
 - **2021-03-05**: Changed the etag error from `FAILED_PRECONDITION` (which

--- a/aip/general/0216.md
+++ b/aip/general/0216.md
@@ -229,9 +229,11 @@ necessary.
 ## Further reading
 
 - For information on enums generally, see [AIP-126][].
+- For information on updating resources with state fields, see [AIP-134][]'s "State restrictions" header.
 
 ## Changelog
 
+- **2022-05-XX**: Linked additional guidance on updates under "Further Reading"
 - **2020-10-20**: Added guidance on prefixing enum values with enum name.
 - **2020-09-02**: Clarified that states are not directly set on create either.
 - **2019-12-05**: Changed guidance on state transition methods, downgrading
@@ -240,4 +242,5 @@ necessary.
 - **2019-07-18**: Added explicit guidance on the unspecified value.
 
 [aip-126]: ./0126.md
+[aip-134]: ./0134.md
 [long-running]: ./0151.md


### PR DESCRIPTION
I submitted this as a general amendment, but am glad to retarget this as a Cloud AIP, i.e. 25134.

This is a problem for clients, where we struggle to enumerate the state transitions a user needs to undergo to perform an update. I drew on GCE Instance's https://cloud.google.com/compute/docs/reference/rest/v1/instances/update method as reference, where `mostDisruptiveAllowedAction` allows users to control the amount of disruption an update would cause.

Identifying the parameter and providing it to end users as a field would be fairly simple, so we can have safe behaviour by default while allowing users to make potentially dangerous changes within their risk tolerance.