### PR TITLE
fix(AIP-234): update requests execute independently, unordered

### DIFF
--- a/aip/general/0234.md
+++ b/aip/general/0234.md
@@ -43,7 +43,7 @@ rpc BatchUpdateBooks(BatchUpdateBooksRequest) returns (BatchUpdateBooksResponse)
   - If the operation covers multiple locations and at least one location is
     down, the operation **must** fail.
 - The operation **must** execute independent updates based on a point-in-time
-  snapshot. It it thus independent of the order of requests.
+  snapshot. It is thus independent of the order of requests.
 
 ### Request message
 

--- a/aip/general/0234.md
+++ b/aip/general/0234.md
@@ -42,6 +42,8 @@ rpc BatchUpdateBooks(BatchUpdateBooksRequest) returns (BatchUpdateBooksResponse)
   succeed for all resources (no partial success).
   - If the operation covers multiple locations and at least one location is
     down, the operation **must** fail.
+- The operation **must** execute independent updates based on a point-in-time
+  snapshot. It it thus independent of the order of requests.
 
 ### Request message
 
@@ -111,6 +113,7 @@ message BatchUpdateBooksResponse {
 
 ## Changelog
 
+- **2022-05-13**: Added required order independence.
 - **2020-09-16**: Suggested annotating `parent` and `requests` fields.
 - **2020-08-27**: Removed parent recommendations for top-level resources.
 - **2019-09-11**: Fixed the wording about which child field the `parent` field


### PR DESCRIPTION
This was also discussed with @jgeewax 