### PR TITLE
Attempt to make AIP-180 the only starting point needed for compatibility

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -108,6 +108,11 @@ Errors that occur over the course of an operation **may** be placed in the
 metadata message. The errors themselves **must** still be represented with a
 [google.rpc.Status][] object.
 
+### Backwards compatibility
+
+Changing either the `response_type` or `metadata_type` of a long-running operation
+is a breaking change.
+
 <!-- prettier-ignore-start -->
 [aip-128]: ./0128.md
 [aip-131]: ./0131.md
@@ -125,6 +130,7 @@ metadata message. The errors themselves **must** still be represented with a
 
 ## Changelog
 
+- **2022-06-??**: Added compatibility section
 - **2020-08-24**: Clarified that responses are not streaming responses.
 - **2020-06-24**: Added guidance for parallel operations.
 - **2020-03-20**: Clarified that both `response_type` and `metadata_type` are

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -133,16 +133,23 @@ this guidance could ostensibly prevent _any_ change (which is not the intent).
 ## Further reading
 
 - For compatibility around pagination, see [AIP-158][].
+- For compatibility around long-running operations, see [AIP-151][].
 - For understanding stability levels and expectations, see [AIP-181][].
+- For compatibility with client library resource name parsing, see [AIP-4231][]
+- For compatibility with client library method signatures, see [AIP-4232][]
 
 ## Changelog
 
+- **2022-06-??**: Added more links to other AIPs with compatibility concerns
 - **2019-12-16**: Clarified that moving existing fields into oneofs is
   breaking.
 
 <!-- prettier-ignore-start -->
 [aip-122]: ./0122.md
+[aip-151]: ./0151.md
 [aip-158]: ./0158.md
 [aip-181]: ./0181.md
+[aip-4231]: ./client-libraries/4231.md
+[aip-4232]: ./client-libraries/4232.md
 [ec2]: https://aws.amazon.com/blogs/aws/theyre-here-longer-ec2-resource-ids-now-available/
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
(Not everything needs to be in AIP-180, but anything in other APIs
should be linked from AIP-180.)