### PR TITLE
Correct style for AIP-132

### DIFF
--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -143,7 +143,7 @@ message ListBooksResponse {
 
 ### Ordering
 
-`List` methods **may** allow clients to specify sorting order; if they do, the
+List methods **may** allow clients to specify sorting order; if they do, the
 request message **should** contain a `string order_by` field.
 
 - Values **should** be a comma separated list of fields. For example:


### PR DESCRIPTION
Correct formatting style for AIP-132

In AIP-131

```md
### Request Message
Get methods implement~
```

In AIP-132

```md
### Request Message
List methods implement~

### Response message
List methods implement~

### Ordering
`List` methods **may** ~ <- Inconsistent format style

### Filtering
List methods **may** ~ 
```

Also in AIP-133, 134..

If there is a reason for doing this on purpose, I will close pr.