### PR TITLE
Fix typo for AIP-133

### DIFF
--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -53,7 +53,7 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
   - The collection's parent resource **should** be called `parent`, and
     **should** be the only variable in the URI path.
   - The collection identifier (`books` in the above example) **must** be
-    literal.
+    literal string.
 - There **must** be a `body` key in the `google.api.http` annotation, and it
   **must** map to the resource field in the request message.
   - All remaining fields **should** map to URI query parameters.

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -53,7 +53,7 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
   - The collection's parent resource **should** be called `parent`, and
     **should** be the only variable in the URI path.
   - The collection identifier (`books` in the above example) **must** be
-    literal string.
+    a literal string.
 - There **must** be a `body` key in the `google.api.http` annotation, and it
   **must** map to the resource field in the request message.
   - All remaining fields **should** map to URI query parameters.


### PR DESCRIPTION
Fix as same as AIP-132:

```
The collection identifier (`books` in the above example) **must** be a literal string.
```