### PR TITLE
fix(AIP-134): Add clearer condition about including update_mask

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -87,9 +87,9 @@ message UpdateBookRequest {
   - The field **should** be [annotated as required][aip-203].
   - A `name` field **must** be included in the resource message. It **should**
     be called `name`.
-- A field mask **should** be included in order to support partial update. It
-  **must** be of type `google.protobuf.FieldMask`, and it **should** be called
-  `update_mask`.
+- If partial resource update is supported, a field mask **must** be included.
+  It **must** be of type `google.protobuf.FieldMask`, and it **should** be
+  called `update_mask`.
   - The fields used in the field mask correspond to the resource being updated
     (not the request message).
   - The field **may** be required or optional. If it is required, it **must**


### PR DESCRIPTION
IIUC, this field **must** be included if partial update is supported not **should** be included to support partial update. The latter sounds to me like: "If you want to support partial update, you **should but you don't have to** include `update_mask`. Instead you can include something else".

Therefore, I think we should rephrase the sentences to clarify it.