### PR TITLE
Change should to must for Resources

### DIFF
--- a/aip/general/0131.md
+++ b/aip/general/0131.md
@@ -20,9 +20,10 @@ resource.
 
 ## Guidance
 
-APIs **should** generally provide a get method for resources unless it is not
-valuable for users to do so. The purpose of the get method is to return data
-from a single resource.
+APIs **must** provide a `Get` method *for resources* and **should** do so otherwise,
+unless there is a strong reason not to do so. An example of such, would be if there
+is sensitive data that would be included in the response. The purpose of the `Get` method
+is to return data from a single resource.
 
 Get methods are specified using the following pattern:
 


### PR DESCRIPTION
# Change to AIP 131

This change indicates that, for Resources, APIs **must** provide `Get` and otherwise **should.** An example is provided for when an API might not provide a Get.