### PR TITLE
fix: moving components between files is breaking

### DIFF
--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -86,6 +86,15 @@ add the new component, but **must not** remove the existing one. In situations
 where this can allow users to specify conflicting values for the same semantic
 idea, the behavior **must** be clearly specified.
 
+### Moving components between files
+
+Components **must not** be moved between files.
+
+Even though moving a component from one proto file to another proto file within
+the same package is wire compatible, it is a breaking change for the source code
+since the way how the specific component is imported (`import` / `#include` /
+etc.) may need to change in some languages (e.g. Python, C++).
+
 ### Moving into oneofs
 
 Existing fields **must not** be moved into or out of a oneof. This is a
@@ -140,7 +149,9 @@ this guidance could ostensibly prevent _any_ change (which is not the intent).
 
 ## Changelog
 
-- **2022-06-??**: Added more links to other AIPs with compatibility concerns
+- **2022-08-11**: Clarified that moving components to a different file is
+  breaking.
+- **2022-06-01**: Added more links to other AIPs with compatibility concerns
 - **2019-12-16**: Clarified that moving existing fields into oneofs is
   breaking.
 

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -93,7 +93,7 @@ Components **must not** be moved between files.
 Even though moving a component from one proto file to another proto file within
 the same package is wire compatible, it is a breaking change for code that directly
 imports the file previously containing the component  (`import` / `#include` /
-etc.) may need to change in some languages (e.g. Python, C++).
+etc.) in some languages (e.g. Python, C++).
 
 ### Moving into oneofs
 

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -91,8 +91,8 @@ idea, the behavior **must** be clearly specified.
 Components **must not** be moved between files.
 
 Even though moving a component from one proto file to another proto file within
-the same package is wire compatible, it is a breaking change for the source code
-since the way how the specific component is imported (`import` / `#include` /
+the same package is wire compatible, it is a breaking change for code that directly
+imports the file previously containing the component  (`import` / `#include` /
 etc.) may need to change in some languages (e.g. Python, C++).
 
 ### Moving into oneofs

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -149,8 +149,7 @@ this guidance could ostensibly prevent _any_ change (which is not the intent).
 
 ## Changelog
 
-- **2022-08-11**: Clarified that moving components to a different file is
-  breaking.
+- **2022-08-11**: Added "Moving components between files" section.
 - **2022-06-01**: Added more links to other AIPs with compatibility concerns
 - **2019-12-16**: Clarified that moving existing fields into oneofs is
   breaking.

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -88,12 +88,12 @@ idea, the behavior **must** be clearly specified.
 
 ### Moving components between files
 
-Components **must not** be moved between files.
+Existing components **must not** be moved between files.
 
-Even though moving a component from one proto file to another proto file within
-the same package is wire compatible, it is a breaking change for code that directly
-imports the file previously containing the component  (`import` / `#include` /
-etc.) in some languages (e.g. Python, C++).
+Moving a component from one proto file to another within the same package is
+wire compatible, however, the code generated for languages like C++ or Python
+will result in breaking change since `import` and `#include` will no longer
+point to the correct code location.
 
 ### Moving into oneofs
 


### PR DESCRIPTION
We recently had a case where an API wanted to move a message to another proto file within the same package. We should not allow this since it will very likely break customers' code if they import that message direclty.