### PR TITLE
fix: query string parameters are camelCased

### DIFF
--- a/aip/general/0127.md
+++ b/aip/general/0127.md
@@ -56,7 +56,8 @@ message CreateBookRequest {
   // When using HTTP/JSON, this field is populated based on a query string
   // argument, such as `?bookId=foo`. This is the fallback for fields that
   // are not included in either the URI or the body.
-  // Note that clients convert the filed names to into camelCase format.
+  // Note that clients use camelCase format to communicate the field names
+  // to the service.
   string book_id = 3;
 }
 ```

--- a/aip/general/0127.md
+++ b/aip/general/0127.md
@@ -56,7 +56,7 @@ message CreateBookRequest {
   // When using HTTP/JSON, this field is populated based on a query string
   // argument, such as `?bookId=foo`. This is the fallback for fields that
   // are not included in either the URI or the body.
-  // Note that the field names are converted to camelCase.
+  // Note that clients convert the filed names to into camelCase format.
   string book_id = 3;
 }
 ```

--- a/aip/general/0127.md
+++ b/aip/general/0127.md
@@ -54,8 +54,9 @@ message CreateBookRequest {
 
   // The user-specified ID for the book.
   // When using HTTP/JSON, this field is populated based on a query string
-  // argument, such as `?book_id=foo`. This is the fallback for fields that
+  // argument, such as `?bookId=foo`. This is the fallback for fields that
   // are not included in either the URI or the body.
+  // Note that the field names are converted to camelCase.
   string book_id = 3;
 }
 ```
@@ -127,6 +128,8 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
 
 ## Changelog
 
+- **2022-08-18**: Added the comment that query string parameter names are
+  in camelCase.
 - **2021-01-06**: Added clarification around `body` and nested fields.
 - **2019-09-23**: Added a statement about request body encoding, and guidance
   discouraging `json_name`.


### PR DESCRIPTION
We got an issue https://github.com/googleapis/google-cloud-node-core/issues/307 and the customer was misguided by the comment in AIP-127. Actually, the query string parameters are supposed to be camelCased, not snake_cased.