### PR TITLE
Make CRUDL rpcs call resource field "resource"

### DIFF
--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -30,9 +30,9 @@ Create methods are specified using the following pattern:
 rpc CreateBook(CreateBookRequest) returns (Book) {
   option (google.api.http) = {
     post: "/v1/{parent=publishers/*}/books"
-    body: "book"
+    body: "resource"
   };
-  option (google.api.method_signature) = "parent,book";
+  option (google.api.method_signature) = "parent,resource";
 }
 ```
 
@@ -78,7 +78,7 @@ message CreateBookRequest {
     }];
 
   // The book to create.
-  Book book = 2 [(google.api.field_behavior) = REQUIRED];
+  Book resource = 2 [(google.api.field_behavior) = REQUIRED];
 }
 ```
 
@@ -87,7 +87,9 @@ message CreateBookRequest {
   - The field **should** be [annotated as required][aip-203].
   - The field **should** identify the [resource type][aip-123] of the resource
     being created.
-- The resource field **must** be included and **must** map to the POST body.
+- The resource field **must** be included.
+- The resource field **must** map to the POST body.
+- The resource field name **must** be `resource`.
 - The request message **must not** contain any other required fields and
   **should not** contain other optional fields except those described in this
   or another AIP.

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -30,9 +30,9 @@ Update methods are specified using the following pattern:
 rpc UpdateBook(UpdateBookRequest) returns (Book) {
   option (google.api.http) = {
     patch: "/v1/{book.name=publishers/*/books/*}"
-    body: "book"
+    body: "resource"
   };
-  option (google.api.method_signature) = "book,update_mask";
+  option (google.api.method_signature) = "resource,update_mask";
 }
 ```
 
@@ -75,7 +75,7 @@ message UpdateBookRequest {
   //
   // The book's `name` field is used to identify the book to update.
   // Format: publishers/{publisher}/books/{book}
-  Book book = 1 [(google.api.field_behavior) = REQUIRED];
+  Book resource = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The list of fields to update.
   google.protobuf.FieldMask update_mask = 2;
@@ -83,6 +83,7 @@ message UpdateBookRequest {
 ```
 
 - The request message **must** contain a field for the resource.
+  - The resource field name **must** be `resource`.
   - The field **must** map to the `PATCH` body.
   - The field **should** be [annotated as required][aip-203].
   - A `name` field **must** be included in the resource message. It **should**


### PR DESCRIPTION
In the current CRUDL methods, it's difficult to determine which field in the
request refers to the resource.

e.g. for the example: a code generator would have to do the following
to determine the field containing the resource is "book":

1. read the message
2. strip the operation prefix, which has to be inferred from the parent
  operation referring to the resource.
3. strip the suffix "Request/Response"

Compare this to a static string that refers to the same concept.

This change will require change in the AIP linter:

- https://linter.aip.dev/134/request-resource-field
- https://linter.aip.dev/133/request-resource-field