### PR TITLE
Fixed formatting

### DIFF
--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -20,9 +20,9 @@ add that information to the routing header.
 There are two annotations that specify how to extract routing information from
 the request payload:
 
-  * the [`google.api.routing`][routing] annotation that specifies how to construct 
+* the [`google.api.routing`][routing] annotation that specifies how to construct 
 routing headers explicitly 
-  * the [`google.api.http`][http] annotation that may specify how to construct 
+* the [`google.api.http`][http] annotation that may specify how to construct 
 routing headers implicitly.
 
 For any given RPC, if the explicit routing headers annotation is present, the code
@@ -49,6 +49,7 @@ rpc CreateTopic(CreateTopicRequest) {
   }
 }
 ```
+
 **Note:** An empty `google.api.routing` annotation is acceptable. It means that no
 routing headers should be generated for the RPC, when they otherwise would be
 e.g. implicitly from the `google.api.http` annotation.
@@ -71,10 +72,9 @@ routing_parameters {
 }
 ```
 
-**Note** It is acceptable to omit the `path_template` field altogether. An omitted 
+**Note:** It is acceptable to omit the `path_template` field altogether. An omitted 
 `path_template` is equivalent to a `path_template` with the same resource ID name as
 the field and the pattern `**`, and **must** be parsed, e.g.:
-
 ```proto
 routing_parameters {
   field: "parent"
@@ -138,6 +138,7 @@ option (google.api.routing) = {
   }
 }
 ```
+
 In this case if in a given request the `billing_project` field is set to an non-empty value,
 its value will be sent with the `project` key because the routing parameter looking at `billing_project` field is specified last. If the `billing_project` field is not set, the `parent` field will be considered, first trying to send a
 project with a subproject specified, and then without. Note that if a given request has a


### PR DESCRIPTION
* Fix: Formatting of bullets resulted in lins not being displaed correctly
* Fix: **Note:** required a colon ':' to make it into a  note box.
* Fix: Sapcing for a `Note:` box that was causing for the note to be
  displaed inline