### PR TITLE
fix: update AIP-4115 with details on GCE detection

### DIFF
--- a/aip/auth/4115.md
+++ b/aip/auth/4115.md
@@ -47,7 +47,34 @@ defined GAE environment variables to detect if the application is running within
 the 1st generation Google App Engine environment.
 
 To detect if the application is running on Compute Engine or an equivalent runtime,
-the auth library **should** depend on the [Metadata Service Library][4].
+the auth library **should** follow the steps below:
+
+1. **Attempt to reach the Metadata Service**
+  Send request with the following parameters:
+  ```
+  URI: http://169.254.169.254
+  Number of retries: 3
+  Request timeout: 500ms
+  ```
+  
+  Also, any request to metadata server **must** provide the following header: 
+  ```
+  Metadata-Flavor: Google
+  ``` 
+    
+  1. If response is successful (200), the Compute Engine runtime is detected _[END]_
+  1. If all the attempts fail - go to step (2)
+1. **Check SMBIOS settings in the well-known locations**
+  This step is platform-specific.
+
+  - For Linux
+    1. Check if the `/sys/class/dmi/id/product_name` file exists and contains a line that starts with `Google`. If true the Compute Engine runtime is detected _[END]_
+    2. Otherwise the application is not running on Compute Engine _[END]_
+
+  - For Windows
+    1. Check if the Windows Registry key `SystemProductName` under the path `SYSTEM\HardwareConfig\Current\` contains a string that starts with `Google`. If true the Compute Engine runtime is detected _[END]_
+    2. Otherwise the application is not running on Compute Engine _[END]_
+
 
 ### Compute Engine or Equivalent Runtime
 
@@ -117,6 +144,7 @@ get a new token if the existing token expires.
 
 - **2020-12-14**: Replace note on scopes with more detailed discussion.
 - **2021-07-13**: Clarify GCE equivalent runtimes
+- **2022-09-12**: Clarify detection algoritms for GCE equivalent runtimes
 
 <!-- prettier-ignore-start -->
 [0]: https://cloud.google.com/appengine


### PR DESCRIPTION
Updating the AIP with latest details on Metadata service detection. See go/auth-library-noping for more details