### PR TITLE
fix: Name of special header for AWS credential

### DIFF
--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -240,7 +240,9 @@ The auth libraries and applications **must** follow the steps below:
   **imdsv2_session_token_url** fields if they are provided. The host should
   either be **169.254.169.254** or **fd00:ec2::254**.
 - If **imdsv2_session_token_url** is available, then fetch session token
-  from **imdsv2_session_token_url**.
+  from **imdsv2_session_token_url**. Note: only perform this step if you
+  need to communicate with the metadata server to fetch the region and/or
+  the security credentials
 - Check the environment variables in the following order (`AWS_REGION` and
   then the `AWS_DEFAULT_REGION`) to determine the AWS region. If found, skip
   using the AWS metadata server to determine this value.

--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -277,7 +277,7 @@ The auth libraries and applications **must** follow the steps below:
         "key": "x-amz-date"
       },
       {
-        "value": "AWS4-HMAC-SHA256 Credential=AKIASOZTBDV4D7ABCDEDF/20200228/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date,Signature=abcedefdfedfd",
+        "value": "AWS4-HMAC-SHA256 Credential=AKIASOZTBDV4D7ABCDEDF/20200228/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-goog-cloud-target-resource, Signature=abcedefdfedfd",
         "key": "Authorization"
       },
       {

--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -293,7 +293,7 @@ The auth libraries and applications **must** follow the steps below:
     "body": ""
   }
   ```
-  For the AWS token, STS requires a special header `x-goog-cloud-endpoint` to recognize that the token is for a specific workload identity provider.
+  For the AWS token, STS requires a special header `x-goog-cloud-target-resource` to recognize that the token is for a specific workload identity provider.
 
 ### Determining the subject token in Microsoft Azure and URL-sourced credentials
 

--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -533,6 +533,7 @@ The auth libraries and applications **must** follow the steps below:
 
 ## Changelog
 
+- **2025-10-17**: Corrections in specification and examples for External Account Credentials (AIP 4117).
 - **2021-12-10**: Add AIP for External Account Credentials (AIP 4117).
 - **2022-05-18**: Document executable-sourced credentials (AIP 4117).
 - **2022-08-31**: Document configurable token lifetime (AIP 4117).


### PR DESCRIPTION
The JSON example is correct.
See b/151677419 for more context.