### PR TITLE
fix(AIP-154): allow behavior annotations on request etag

### DIFF
--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -38,7 +38,7 @@ message Book {
 ```
 
 - The etag field **must** be a string, and **must** be named `etag`.
-- The etag field on the resource **should not** be given any behavior
+- The etag field on the _resource_ **should not** be given any behavior
   annotations.
 - The etag field **must** be provided by the server on output, and values
   **should** conform to [RFC 7232][].
@@ -83,8 +83,8 @@ message DeleteBookRequest {
 }
 ```
 
-In this case, the `etag` field **should** be given a behavior annotation -
-either `REQUIRED` or `OPTIONAL`. See AIP-203 for more information.
+On a request message, the `etag` field **should** be given a behavior annotation
+- either `REQUIRED` or `OPTIONAL`. See AIP-203 for more information.
 
 An `etag` field **may** also be used on custom methods, similar to the example
 above.

--- a/aip/general/0154.md
+++ b/aip/general/0154.md
@@ -38,7 +38,8 @@ message Book {
 ```
 
 - The etag field **must** be a string, and **must** be named `etag`.
-- The etag field **should not** be given any behavior annotations
+- The etag field on the resource **should not** be given any behavior
+  annotations.
 - The etag field **must** be provided by the server on output, and values
   **should** conform to [RFC 7232][].
 - If a user sends back an etag which matches the current etag value, the
@@ -78,9 +79,12 @@ message DeleteBookRequest {
   // The current etag of the book.
   // If an etag is provided and does not match the current etag of the book,
   // deletion will be blocked and an ABORTED error will be returned.
-  string etag = 2;
+  string etag = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 ```
+
+In this case, the `etag` field **should** be given a behavior annotation -
+either `REQUIRED` or `OPTIONAL`. See AIP-203 for more information.
 
 An `etag` field **may** also be used on custom methods, similar to the example
 above.


### PR DESCRIPTION
The original language of AIP-154 states that `etag` field should not have behavior annotations. It also states that in some cases, services may include an `etag` field on request messages e.g. for Standard Delete. However, it does not make allowances for this case with regards to giving a behavior annotation to the request `etag` field. A service is permitted to **require** the presence of an `etag` in the request, so it makes sense to allow for behavior annotations to be given to an `etag` field that is part of a request message. 

This updates the existing guidance with regards to *not* giving a behavior annotation to an `etag` field specifically on the resource message to be specific to that case. It also adds new guidance that allows the use of behavior annotations on an `etag` field present in a request message, recommending either `REQUIRED` or `OPTIONAL`. 

Note: There is still an open question with regards to AIP-134 guidance and use of behavior annotations on the resource `etag` field. See #952.