### PR TITLE
move guidance for resource ref name out of note

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -283,9 +283,9 @@ other use cases, use a synonymous term if possible.
 
 ### Fields representing another resource
 
-When referencing a resource name for a different resource, the field **should**
-be of type `string` for the resource name, and the field name **should** be
-equivalent to the corresponding message's name in snake case.
+When a field represents another resource, the field **should** be of type
+`string` and accept the resource name of the other resource. The field name
+**should** be equivalent to the corresponding message's name in snake case.
 
 - Field names **may** include a leading adjective if appropriate (such as
   `string dusty_book`).
@@ -294,6 +294,8 @@ equivalent to the corresponding message's name in snake case.
 - Fields representing another resource **should** provide the
   `google.api.resource_reference` annotation with the resource type being
   referenced.
+- If using the resource name is not possible and using the ID component alone is
+strictly necessary, the field **should** use an `_id` suffix (e.g. `shelf_id`).
 
 ```proto
 // A representation of a book in a library.
@@ -316,12 +318,6 @@ message Book {
   // Other fields...
 }
 ```
-
-**Note:** When referring to other resources in this way, we use the resource
-name as the value, not just the ID component. Services **should** use the
-resource name to reference resources when possible. If using the ID component
-alone is strictly necessary, the field **should** use an `_id` suffix (e.g.
-`shelf_id`).
 
 ## Further reading
 


### PR DESCRIPTION
The guidance around resource reference using the resource name to identify the resource was in a note below the proto example, which can be easily missed.

Moving it up to a line item of "shoulds" increases visibility.