### PR TITLE
2510: clarifying project identifiers in references

### DIFF
--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -67,6 +67,46 @@ considered PII and user data, but project numbers are not.
 Therefore, when an internal service calls an external Google APIs, it
 **should** use project numbers for making API requests.
 
+### Resource References
+
+Project IDs also appear in [resource names][], which are used
+when referring to a separate resource ([example][]).
+
+In these situations, the value of the resource reference should be preserved
+regardless if the user has sent a project ID or number to identify the main
+resource.
+
+For example, for an existing resource book:
+
+```proto
+book {
+  // project-id: "foo"
+  // project-number: 12345
+  name: "project/12345/books/game-of-tones"
+  shelf: "project/123456/shelves/top-row"
+}
+```
+
+A request for the book in the format of `projects/foo/books/game-of-tones`
+should return:
+
+```proto
+book {
+  // Returning the project ID, since that was what was sent.
+  name: "project/foo/books/game-of-tones"
+  // The shelf still uses the project Number, since that is what
+  // the user has sent. If the user has set a name with the project ID,
+  // that should also be preserved.
+  shelf: "project/123456/shelves/top-row"
+}
+```
+
+Similar to how the guidance around project ID / project number is designed
+to ensure that there is a minimal difference between user input and output,
+resource references are also untranslated to minimize normalized user input.
+
+[resource names]: ./0122.md
+[example]: ./0122.md#fields-representing-another-resource
 ### Third-party services
 
 [Third-party services](https://cloud.google.com/marketplace) that are
@@ -87,6 +127,7 @@ organizations and folders.
 
 ## Changelog
 
+- **2022-10-19**: Clarified guidance for project identifiers in resource references.
 - **2021-07-29**: Reversed previous guidance on returning project IDs; this AIP
   now advocates returning what the user sent.
 - **2019-08-11**: Add an exception for resources that a service does not own.

--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -69,41 +69,75 @@ Therefore, when an internal service calls an external Google APIs, it
 
 ### Resource References
 
-Project IDs also appear in [resource names][], which are used
-when referring to a separate resource ([example][]).
+Project identifiers also appear in [resource names][]. These resource
+names are used both to identify the resource itself and can refer to
+other resources ([example][]).
 
-In these situations, the value of the resource reference should be preserved
-regardless if the user has sent a project ID or number to identify the main
-resource.
+Regardless, when project identifiers are provided, the response should
+include the identifier as it occurred in the request: if the project ID
+was provided it should be returned, and if the project number was
+provided, that is what should be in the response.
 
-For example, for an existing resource book:
+
+For example, consider a `Book` resource,
 
 ```proto
-book {
-  // project-id: "foo"
-  // project-number: 12345
-  name: "project/12345/books/game-of-tones"
-  shelf: "project/123456/shelves/top-row"
+message Book {
+  option (google.api.resource) = {
+    type: "pubsub.googleapis.com/Book"
+    pattern: "projects/{project}/shelves/{shelf}/books/{book}"
+  };
+
+  // The resource name of the Book.
+  string name = 1;
+
+  // The resource name of the Shelf to which this book belongs.
+  string shelf = 2;
+
+
+  // Other fields...
 }
 ```
 
-A request for the book in the format of `projects/foo/books/game-of-tones`
-should return:
+and a `GetBookRequest`,
 
 ```proto
-book {
-  // Returning the project ID, since that was what was sent.
-  name: "project/foo/books/game-of-tones"
-  // The shelf still uses the project Number, since that is what
-  // the user has sent. If the user has set a name with the project ID,
-  // that should also be preserved.
-  shelf: "project/123456/shelves/top-row"
+message GetBookRequest {
+  // The name of the Book to retrieve.
+  // Format: projects/{project}/shelves/{shelve}/books/{book}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "library.googleapis.com/Book"
+    }];
 }
+
 ```
 
-Similar to how the guidance around project ID / project number is designed
-to ensure that there is a minimal difference between user input and output,
-resource references are also untranslated to minimize normalized user input.
+if the value of `name` on such a request is,
+
+```
+projects/my-project/shelves/6789/books/les-miserables
+```
+
+then the value of the field, `name`, returned for the `Book`, should
+match: the project ID and not the number. But, the value for the field,
+`shelf` should use the project number, as the canonical identifier as
+follows:
+
+```
+book: projects/my-project/shelves/6789/books/les-miserables
+shelf: projects/12345/shelves/6789/books/les-miserables
+```
+
+In the event of a [list request][AIP-132], and the `parent` field is
+provided with a value, `projects/my-project/shelves/12345`, the value of
+the `name` field for each returned `Book` should reference the project
+by ID and not the number so that there is parity with the request, and
+the value of the field, `shelf`, should do the same.
+
+This guidance is to ensure that there is a minimal difference between user
+input and output.
 
 [resource names]: ./0122.md
 [example]: ./0122.md#fields-representing-another-resource

--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -85,13 +85,13 @@ For example, consider a `Book` resource,
 message Book {
   option (google.api.resource) = {
     type: "pubsub.googleapis.com/Book"
-    pattern: "projects/{project}/shelves/{shelf}/books/{book}"
+    pattern: "projects/{project}/libraries/{library}/books/{book}"
   };
 
   // The resource name of the Book.
   string name = 1;
 
-  // The resource name of the Shelf to which this book belongs.
+  // A reference to another resource, a Shelf.
   string shelf = 2;
 
 
@@ -104,7 +104,7 @@ and a `GetBookRequest`,
 ```proto
 message GetBookRequest {
   // The name of the Book to retrieve.
-  // Format: projects/{project}/shelves/{shelve}/books/{book}
+  // Format: projects/{project}/libraries/{library}/books/{book}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -117,7 +117,7 @@ message GetBookRequest {
 if the value of `name` on such a request is,
 
 ```
-projects/my-project/shelves/6789/books/les-miserables
+projects/my-project/libraries/67890/books/les-miserables
 ```
 
 then the value of the field, `name`, returned for the `Book`, should
@@ -126,21 +126,13 @@ match: the project ID and not the number. But, the value for the field,
 follows:
 
 ```
-book: projects/my-project/shelves/6789/books/les-miserables
-shelf: projects/12345/shelves/6789/books/les-miserables
+book: projects/my-project/libraries/67890/books/les-miserables
+shelf: projects/12345/shelves/6789
 ```
-
-In the event of a [list request][AIP-132], and the `parent` field is
-provided with a value, `projects/my-project/shelves/12345`, the value of
-the `name` field for each returned `Book` should reference the project
-by ID and not the number so that there is parity with the request, and
-the value of the field, `shelf`, should do the same.
 
 This guidance is to ensure that there is a minimal difference between user
 input and output.
 
-[resource names]: ./0122.md
-[example]: ./0122.md#fields-representing-another-resource
 ### Third-party services
 
 [Third-party services](https://cloud.google.com/marketplace) that are
@@ -158,6 +150,8 @@ organizations and folders.
 
 [alias]: ../0122.md#resource-id-aliases
 [resource manager api]: https://cloud.google.com/resource-manager/
+[resource names]: ../0122.md
+[example]: ../0122.md#fields-representing-another-resource
 
 ## Changelog
 

--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -73,11 +73,10 @@ Project identifiers also appear in [resource names][]. These resource
 names are used both to identify the resource itself and can refer to
 other resources ([example][]).
 
-Regardless, when project identifiers are provided, the response should
+When project identifiers are provided, the response should
 include the identifier as it occurred in the request: if the project ID
 was provided it should be returned, and if the project number was
 provided, that is what should be in the response.
-
 
 For example, consider a `Book` resource,
 
@@ -85,17 +84,28 @@ For example, consider a `Book` resource,
 message Book {
   option (google.api.resource) = {
     type: "pubsub.googleapis.com/Book"
-    pattern: "projects/{project}/libraries/{library}/books/{book}"
+    pattern: "projects/{project}/books/{book}"
   };
 
   // The resource name of the Book.
   string name = 1;
 
   // A reference to another resource, a Shelf.
-  string shelf = 2;
-
+  string shelf = 2 [(google.api.resource_reference) = {
+    type: "library.googleapis.com/Shelf"
+  }];
 
   // Other fields...
+}
+```
+
+with the following book submitted from a previous create request (represented as
+JSON in this example),
+
+```json
+{
+  "name": "projects/my-project/books/les-miserables",
+  "shelf": "projects/12345/shelves/top-shelf"
 }
 ```
 
@@ -104,7 +114,7 @@ and a `GetBookRequest`,
 ```proto
 message GetBookRequest {
   // The name of the Book to retrieve.
-  // Format: projects/{project}/libraries/{library}/books/{book}
+  // Format: projects/{project}/books/{book}
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
@@ -114,20 +124,22 @@ message GetBookRequest {
 
 ```
 
-if the value of `name` on such a request is,
+and if the value of `name` on such a request is,
 
 ```
 projects/my-project/libraries/67890/books/les-miserables
 ```
 
-then the value of the field, `name`, returned for the `Book`, should
-match: the project ID and not the number. But, the value for the field,
-`shelf` should use the project number, as the canonical identifier as
-follows:
+then the value of the field, `name`, returned for the `Book`, should match: the
+project ID and not the number should be returned. But, the value for the field,
+`shelf` should use the project number, as the create request had submitted a
+shelf with the project number in the resource name.
+
+In other words, the following values should be returned:
 
 ```
-book: projects/my-project/libraries/67890/books/les-miserables
-shelf: projects/12345/shelves/6789
+book: projects/my-project/books/les-miserables
+shelf: projects/12345/shelves/top-shelf
 ```
 
 This guidance is to ensure that there is a minimal difference between user
@@ -155,7 +167,8 @@ organizations and folders.
 
 ## Changelog
 
-- **2022-10-19**: Clarified guidance for project identifiers in resource references.
+- **2022-10-19**: Clarified guidance for project identifiers in resource
+  references.
 - **2021-07-29**: Reversed previous guidance on returning project IDs; this AIP
   now advocates returning what the user sent.
 - **2019-08-11**: Add an exception for resources that a service does not own.


### PR DESCRIPTION
As resource references also include project IDs in GCP, it is valuable to clarify how those should be handled.

In an internal conversation asking about project IDs in resource references, this was clarified to be the guidance for GCP.

Adding this detail that was previously implicit.

Raising one consideration:

Noteably, this may result in a violation of intent: since the request is for all resources to store project numbers for anonymization purposes, storing the project IDs may give a third party or internal Google services enough information to identify some relationship between project numbers and IDs. 
