### PR TITLE
fix: replace resource ID with revision ID

### DIFF
--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -232,7 +232,7 @@ there are two potential variants:
   of_ the parent resource.
 
 If a child resource is a child of a single revision, the child resource's name
-**must** always explicitly include the parent's resource ID:
+**must** always explicitly include the parent's revision ID:
 
     publishers/123/books/les-miserables@c7cfa2a8/pages/42
 


### PR DESCRIPTION
From the context, it should be revision ID.