### PR TITLE
fix(AIP-4231): pattern variables must not change

### DIFF
--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -238,6 +238,7 @@ deprecated, and must not be used.
 
 ## Changelog
 
+- **2022-10-28**: Pattern variables are considered final
 - **2020-09-14**: Disallow simultaneous use of both `type` and `child_type`.
 - **2020-05-14**: Added complex resource ID path segments.
 - **2020-05-07**: Updated backwards compatibility guidance.

--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -224,7 +224,8 @@ to the following backwards-compatibility expectations:
   - New patterns must use a distinct sequence of collection identifiers (see
     [AIP-122][]) compared with all existing patterns within this resource.
 - The identifiers within the pattern variables are final - they **must not** be
-  changed.
+  changed. These identifiers are used in the surface of generated client
+  libraries.
 - The addition of a `google.api.resource_reference` annotation on an existing
   field **must** be a backwards-compatible change.
 

--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -223,6 +223,8 @@ to the following backwards-compatibility expectations:
   - New patterns must always be appended to the list.
   - New patterns must use a distinct sequence of collection identifiers (see
     [AIP-122][]) compared with all existing patterns within this resource.
+- The identifiers within the pattern variables are final - they **must not** be
+  changed.
 - The addition of a `google.api.resource_reference` annotation on an existing
   field **must** be a backwards-compatible change.
 

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -71,6 +71,9 @@ message Topic {
 - Patterns **must** correspond to the [resource name][aip-122].
 - Pattern variables (the segments within braces) **must** use `snake_case`, and
   **must not** use an `_id` suffix.
+- Pattern variables **must** be the singular form of the resource type e.g. the
+  pattern variable representing a `Topic` resource ID is named `{topic}`.
+- Pattern variables **must** conform to the format `[_a-z]+`.
 
 #### Pattern uniqueness
 

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -73,7 +73,7 @@ message Topic {
   **must not** use an `_id` suffix.
 - Pattern variables **must** be the singular form of the resource type e.g. the
   pattern variable representing a `Topic` resource ID is named `{topic}`.
-- Pattern variables **must** conform to the format `[_a-z]+`.
+- Pattern variables **must** conform to the format `[a-z][_a-z]+[a-z]`.
 
 #### Pattern uniqueness
 

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -73,7 +73,7 @@ message Topic {
   **must not** use an `_id` suffix.
 - Pattern variables **must** be the singular form of the resource type e.g. the
   pattern variable representing a `Topic` resource ID is named `{topic}`.
-- Pattern variables **must** conform to the format `[a-z][_a-z]+[a-z]`.
+- Pattern variables **must** conform to the format `[a-z][_a-z0-9]*[a-z]`.
 
 #### Pattern uniqueness
 

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -73,7 +73,7 @@ message Topic {
   **must not** use an `_id` suffix.
 - Pattern variables **must** be the singular form of the resource type e.g. the
   pattern variable representing a `Topic` resource ID is named `{topic}`.
-- Pattern variables **must** conform to the format `[a-z][_a-z0-9]*[a-z]`.
+- Pattern variables **must** conform to the format `[a-z][_a-z0-9]*[a-z0-9]`.
 
 #### Pattern uniqueness
 

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -98,6 +98,7 @@ resource:
 
 ## Changelog
 
+- **2022-10-28**: Added pattern variable format guidance.
 - **2020-05-14**: Added pattern uniqueness.
 - **2019-12-05**: Added guidance on patterns.
 - **2019-07-17**: Fleshed out the annotation example somewhat.


### PR DESCRIPTION
States in the AIP-4231 Backwards Compatibility section (referenced by the AIP-180 section concerning Resources) that the identifiers within pattern variables of a resource name pattern **must not** be changed. They are considered final because code generators depend on those pattern variables to name class properties, key-word arguments, methods, etc.

Also includes specific guidance in AIP-123 on the form the pattern variables should take. This codifies the practice that exists in today's resources.

Fixes #969 