### PR TITLE
Update AIP-152 to allow RunJobTypeJob rpc to return a resource too

### DIFF
--- a/aip/general/0152.md
+++ b/aip/general/0152.md
@@ -60,12 +60,15 @@ rpc RunWriteBookJob(RunWriteBookJobRequest)
 - The RPC's name **must** begin with the word `Run`. The remainder of the
   RPC name **should** be the singular form of the job resource being run.
 - The request message **must** match the RPC name, with a `Request` suffix.
-- The method **should** return a [long-running operation][aip-151], which
-  **must** resolve to a response message that includes the result of running
-  the job.
-  - The response message name must match the RPC name, with a `Response`
-    suffix.
-  - The method **may** use any metadata message it wishes.
+- The method **should** return a [long-running operation][aip-151].
+- The reponse message of the long-running opeariton **must** resolve to
+  a message that includes the result of running the job, that is one of
+  the following:
+  - A response message whose name must match the RPC name, with a
+    `Response` suffix.
+  - An excution result resource. See [below](#executions-and-results).
+- The method **may** inlcude any metadata message it wishes for the
+  `metadata_type` of the long-running operation.
 - The HTTP verb **must** be `POST`, as is usual for [custom methods][aip-136].
 - The body clause in the `google.api.http` annotation **should** be `"*"`.
 - The URI path **should** contain a single `name` variable corresponding to the

--- a/aip/general/0152.md
+++ b/aip/general/0152.md
@@ -62,11 +62,12 @@ rpc RunWriteBookJob(RunWriteBookJobRequest)
 - The request message **must** match the RPC name, with a `Request` suffix.
 - The method **should** return a [long-running operation][aip-151].
 - The reponse message of the long-running opeariton **must** resolve to
-  a message that includes the result of running the job, that is one of
-  the following:
+  a message that includes the result of running the job, such that it is
+  one of the following:
   - A response message whose name must match the RPC name, with a
     `Response` suffix.
-  - An excution result resource. See [below](#executions-and-results).
+  - An excution result resource. See below, under
+    [Execution and results](#executions-and-results).
 - The method **may** inlcude any metadata message it wishes for the
   `metadata_type` of the long-running operation.
 - The HTTP verb **must** be `POST`, as is usual for [custom methods][aip-136].


### PR DESCRIPTION
According to AIP-152, the `RunWriteBookJob` rpc must return an LRO with a `response_type` that is specified to be a `RunWriteBookJobResponse`. However, further down, it specifies that some jobs might be represented by a resource. In turn, this PR says that the `RunWriteBookJob` can either return `*Response` proto or the resource.