### PR TITLE
italicize "past" for executions for emphasis

### DIFF
--- a/aip/general/0152.md
+++ b/aip/general/0152.md
@@ -106,7 +106,7 @@ deliver results to the user in this way.
 
 The service **may** store resources representing individual executions along
 with their result as a sub-collection of resources under the job, which allows
-the user to list past job executions. A service that does this **should**
+the user to list *past* job executions. A service that does this **should**
 define the `Get`, `List`, and `Delete` methods for the execution resources:
 
 ```proto


### PR DESCRIPTION
Minor change that italicized the word "past" when referring to job executions for emphasis.