### PR TITLE
feat(AIP-122): add guidance for cyclic references

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -84,7 +84,8 @@ have sole responsibility and authority for maintaining the application state.
 ### Cyclic References
 
 The relationship between resources, such as parent-child or
-[resource references][], **must** be representable via an acylic graph.
+[resource references][], **must** be representable via a
+[directed acyclic graph][].
 
 A cyclic relationship between resources increases the complexity of managing
 resources. Consider resources A and B that refer to
@@ -109,6 +110,7 @@ and in turn do not increase resource management complexity.
 [update]: ./0134.md
 [delete]: ./0135.md
 [custom methods]: ./0136.md
+[directed acyclic graph]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 [resource references]: ./0122.md#fields-representing-another-resource
 [output only]: ./0203.md#output-only
 

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -81,6 +81,27 @@ In an API with a stateless protocol, the server has the responsibility for
 persisting data, which may be shared between multiple clients, while clients
 have sole responsibility and authority for maintaining the application state.
 
+### Cyclic References
+
+The relationship between resources, such as parent-child or
+[resource references][], **must** be representable via an acylic graph.
+
+A cyclic relationship between resources increases the complexity of managing
+resources significantly more complex. Consider a resource A and B that refer to
+each other. The process to create said resources are:
+
+1. create resource A without a reference to B. Retrieve id for resource A.
+2. create resource B with a reference to A. Retrieve id for resource B.
+3. update resource A with the reference to B.
+
+The delete operation may also become more complex, due to reasoning about which resource must be dereferenced first for a successful deletion.
+
+This requirement does not apply to relationships that are expressed via
+[output only][] fields. Output only fields with cyclic references can be
+useful to help reduce the need to retrieve multiple resources to understand the relationship, and do not increase complexity in the management of resources as
+they do not require the user to specify the values during create, update, and
+delete operations.
+
 [rest]: https://en.wikipedia.org/wiki/Representational_state_transfer
 [rpc]: https://en.wikipedia.org/wiki/Remote_procedure_call
 [get]: ./0131.md
@@ -89,8 +110,12 @@ have sole responsibility and authority for maintaining the application state.
 [update]: ./0134.md
 [delete]: ./0135.md
 [custom methods]: ./0136.md
+[resource references]: ./0122.md#fields-representing-another-resource
+[output only]: ./0203.md#output-only
+
 
 ## Changelog
 
+- **2022-11-02**: Added a section restricting resource references.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -87,20 +87,19 @@ The relationship between resources, such as parent-child or
 [resource references][], **must** be representable via an acylic graph.
 
 A cyclic relationship between resources increases the complexity of managing
-resources significantly more complex. Consider a resource A and B that refer to
+resources. Consider resources A and B that refer to
 each other. The process to create said resources are:
 
 1. create resource A without a reference to B. Retrieve id for resource A.
 2. create resource B with a reference to A. Retrieve id for resource B.
 3. update resource A with the reference to B.
 
-The delete operation may also become more complex, due to reasoning about which resource must be dereferenced first for a successful deletion.
+The delete operation may also become more complex, due to reasoning about which
+resource must be dereferenced first for a successful deletion.
 
 This requirement does not apply to relationships that are expressed via
-[output only][] fields. Output only fields with cyclic references can be
-useful to help reduce the need to retrieve multiple resources to understand the relationship, and do not increase complexity in the management of resources as
-they do not require the user to specify the values during create, update, and
-delete operations.
+[output only][] fields, as they do not require the user to specify the values
+and in turn do not increase resource management complexity.
 
 [rest]: https://en.wikipedia.org/wiki/Representational_state_transfer
 [rpc]: https://en.wikipedia.org/wiki/Remote_procedure_call


### PR DESCRIPTION
Cyclic references can cause significant complexity in the management of resources. Adding specific guidance around both mutable and output only cyclic references to clarify when it is appropriate to do so.

NOTE: this is a part of GURP.