### PR TITLE
feat(AIP-122) add guidance to prefer easy plurals

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -76,6 +76,8 @@ form of the noun used for the resource. (For example, a collection of
     and plural terms are the same ("moose"), the non-pluralized (singular) form
     is correct. Collection segments **must not** "coin" words by adding "s" in
     such cases (e.g, avoid "infos").
+- Collection identifiers **should** be terms that can be pluralized by adding
+  an "s" to the end.
 
 #### Nested collections
 
@@ -327,6 +329,7 @@ message Book {
 
 ## Changelog
 
+- **2022-11-18**: Add guidance to prefer easily pluralizable terms.
 - **2020-10-06**: Added declarative-friendly guidance, and tightened character
   set restrictions.
 - **2020-10-05**: Clarified when full resource names are used.


### PR DESCRIPTION
When referring to an API collection, it's common to need to refer to the collection in both the plural and singular.

Plural and singular and English can be inconsistent in it's conversion: some words have different endings (butterflies vs butterfly), while others are the same word (moose).

If most terms did have a straightforward conversion across singular and plural, it would reduce the need for a user's awareness of the English language, as well as enable some heuristic that could be applied for automation.