### PR TITLE
chore: complete publication of `read_mask` deprecation in AIP-161

### DIFF
--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -32,7 +32,7 @@ Field masks **should not** be specified in the [request](./0157.md#read-masks-as
   - If the field mask parameter is omitted, it **must** default to `"*"`, unless otherwise documented.
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.
-  
+
 **Note:** Changing the default value of the field mask parameter is a [breaking change](../0180.md#semantic-changes).
 
 ### View enumeration

--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -21,11 +21,14 @@ without waiting for UI or client updates.
 
 ## Guidance
 
-Update methods (AIP-134) **must** include an `update_mask` field, and Get and
-List methods **may** include a `read_mask` field. These are collectively called
-"field masks", and they use the `google.protobuf.FieldMask` type.
+Update methods (AIP-134) **must** include an `update_mask` field. These
+are called "field masks", and they use the `google.protobuf.FieldMask`
+type.
 
 Field masks **must** always be relative to the resource:
+
+**Warning:** Read masks as a single field on the request message, for
+example: `google.protobuf.FieldMask read_mask` are **DEPRECATED**.
 
 ```proto
 message UpdateBookRequest {


### PR DESCRIPTION
`read_mask` as a field is deprecated.