### PR TITLE
s/ACCESS_ACCESS_KEY_ID/AWS_ACCESS_KEY_ID/

### DIFF
--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -248,7 +248,7 @@ The auth libraries and applications **must** follow the steps below:
   to determine the current AWS region. The API returns the zone name, e.g.
   `us-east-1d`. The region should be determined by stripping the last
   character, e.g. `us-east-1`.
-- Check the environment variables `ACCESS_ACCESS_KEY_ID`,
+- Check the environment variables `AWS_ACCESS_KEY_ID`,
   `AWS_SECRET_ACCESS_KEY` and the optional `AWS_SESSION_TOKEN` for the AWS
   security credentials. If found, skip using the AWS metadata server to
   determine these values.


### PR DESCRIPTION
The correct environment variable seems to be `AWS_ACCESS_KEY_ID`:

https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_environment.html https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html