### PR TITLE
feat(AIP-121): require Get for mutable resources

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -61,6 +61,10 @@ exposes a large number of resources with a small number of methods on each
 resource. The methods can be either the standard methods ([Get][], [List][],
 [Create][], [Update][], [Delete][]), or [custom methods][].
 
+A resource that supports a [Create][], [Update][], or [Delete][] must also
+support [Get][] to enable the user to validate the success of their operation
+outside of the operation completion.
+
 **Note:** A custom method in resource-oriented design does _not_ entail
 defining a new or custom HTTP verb. Custom methods use traditional HTTP verbs
 (usually `POST`) and define the custom verb in the URI.
@@ -117,6 +121,8 @@ and in turn do not increase resource management complexity.
 
 ## Changelog
 
+- **2022-12-19**: Added a section requiring a Get if Create,Update, or Delete
+  are supported.
 - **2022-11-02**: Added a section restricting resource references.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -61,8 +61,9 @@ exposes a large number of resources with a small number of methods on each
 resource. The methods can be either the standard methods ([Get][], [List][],
 [Create][], [Update][], [Delete][]), or [custom methods][].
 
-A resource that supports a [Create][], [Update][], or [Delete][] **must** also
-support [Get][] to enable a client to validate the state of the resource.
+A resource **must** support at minimum [Get][] and [List][]: clients must be
+able to validate the state of resources after performing a mutation such
+as [Create][], [Update][], or [Delete][].
 
 **Note:** A custom method in resource-oriented design does _not_ entail
 defining a new or custom HTTP verb. Custom methods use traditional HTTP verbs
@@ -120,8 +121,7 @@ and in turn do not increase resource management complexity.
 
 ## Changelog
 
-- **2022-12-19**: Added a section requiring Get if Create, Update, or Delete
-  are supported.
+- **2022-12-19**: Added a section requiring Get and List.
 - **2022-11-02**: Added a section restricting resource references.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -61,9 +61,12 @@ exposes a large number of resources with a small number of methods on each
 resource. The methods can be either the standard methods ([Get][], [List][],
 [Create][], [Update][], [Delete][]), or [custom methods][].
 
-A resource **must** support at minimum [Get][] and [List][]: clients must be
+A resource **must** support at minimum [Get][]: clients must be
 able to validate the state of resources after performing a mutation such
 as [Create][], [Update][], or [Delete][].
+
+A resource **must** also support [List][], except for [singleton resources][]
+where more than one resource is not possible.
 
 **Note:** A custom method in resource-oriented design does _not_ entail
 defining a new or custom HTTP verb. Custom methods use traditional HTTP verbs
@@ -117,6 +120,7 @@ and in turn do not increase resource management complexity.
 [directed acyclic graph]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 [resource references]: ./0122.md#fields-representing-another-resource
 [output only]: ./0203.md#output-only
+[singleton resources]: ./0156.md
 
 
 ## Changelog

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -61,9 +61,8 @@ exposes a large number of resources with a small number of methods on each
 resource. The methods can be either the standard methods ([Get][], [List][],
 [Create][], [Update][], [Delete][]), or [custom methods][].
 
-A resource that supports a [Create][], [Update][], or [Delete][] must also
-support [Get][] to enable the user to validate the success of their operation
-outside of the operation completion.
+A resource that supports a [Create][], [Update][], or [Delete][] **must** also
+support [Get][] to enable a client to validate the state of the resource.
 
 **Note:** A custom method in resource-oriented design does _not_ entail
 defining a new or custom HTTP verb. Custom methods use traditional HTTP verbs
@@ -121,7 +120,7 @@ and in turn do not increase resource management complexity.
 
 ## Changelog
 
-- **2022-12-19**: Added a section requiring a Get if Create,Update, or Delete
+- **2022-12-19**: Added a section requiring Get if Create, Update, or Delete
   are supported.
 - **2022-11-02**: Added a section restricting resource references.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to


### PR DESCRIPTION
Resources that do not support Get but support mutable operations make customers unable to validate the
state of their resources for long-term synchronization use cases like drift detection or state management.

See https://github.com/pulumi/pulumi-google-native/issues/47 for an example of the issue.