### PR TITLE
fix: use the term uniformity instead of consistency

### DIFF
--- a/aip/general/0100.md
+++ b/aip/general/0100.md
@@ -330,7 +330,7 @@ Escalate according to [AIP-1][].
 
 ## Does my PA or team have any particular guidelines?
 
-The Cloud PA has specific guidelines to ensure additional consistency across
+The Cloud PA has specific guidelines to ensure additional uniformity across
 Cloud, and Cloud APIs have their own reviewer pool. Other teams may adopt
 similar (but not necessarily identical) rules and systems. Some teams that
 produce multiple APIs (for example, machine learning) may also have guidelines

--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -22,7 +22,7 @@ on the differences between the current landscape and the intended one.
 
 Furthermore, there are numerous popular DevOps tools, with more being
 introduced each year. Integrating hundreds of resource types with multiple
-tools requires strong consistency, so that integration can be automated.
+tools requires uniformity, so that integration can be automated.
 
 ## Guidance
 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -44,7 +44,7 @@ it creates ambiguity when converting between snake case and camel case.
 Similarly, fields **must not** contain leading, trailing, or adjacent
 underscores.
 
-### Consistency
+### Uniformity
 
 APIs **should** endeavor to use the same name for the same concept and
 different names for different concepts wherever possible. This includes names
@@ -82,7 +82,7 @@ is often appropriate in reporting scenarios (e.g. "nodes per instance" or
 
 ### Adjectives
 
-For consistency, field names that contain both a noun and an adjective
+For uniformity, field names that contain both a noun and an adjective
 **should** place the adjective _before_ the noun. For example:
 
 - `collected_items` (**not** `items_collected`)

--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -58,7 +58,7 @@ rpc WriteBook(WriteBookRequest) returns (google.longrunning.Operation) {
     define an empty message for the RPC metadata and use that.
 - APIs with messages that return `Operation` **must** implement the
   [`Operations`][lro] service. Individual APIs **must not** define their own
-  interfaces for long-running operations to avoid inconsistency.
+  interfaces for long-running operations to avoid non-uniformity.
 
 **Note:** User expectations can vary on what is considered "a significant
 amount of time" depending on what work is being done. A good rule of thumb is


### PR DESCRIPTION
The term "consistency" is overloaded, mixing the compliance of multiple things to a particular standard or convention, vs the computer science term with respect to data state across replicas.

Using the term "uniformity" conveys the same intention, and provides a clear delineation between the terms.

In some places "consistency" is a better term than uniformity, so not all instances were replaced.

Similarly, not replacing the term from any news articles as those are point-in-time artifacts.