### PR TITLE
Require annotation of the resource type

### DIFF
--- a/aip/general/0131.md
+++ b/aip/general/0131.md
@@ -71,7 +71,7 @@ message GetBookRequest {
 
 - A resource name field **must** be included. It **should** be called `name`.
   - The field **should** be [annotated as required][aip-203].
-  - The field **should** identify the [resource type][aip-123] that it
+  - The field **must** identify the [resource type][aip-123] that it
     references.
 - The comment for the `name` field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -86,7 +86,7 @@ message ListBooksRequest {
 - A `parent` field **must** be included unless the resource being listed is a
   top-level resource. It **should** be called `parent`.
   - The field **should** be [annotated as required][aip-203].
-  - The field **should** identify the [resource type][aip-123] of the resource
+  - The field **must** identify the [resource type][aip-123] of the resource
     being listed.
 - The `page_size` and `page_token` fields, which support pagination, **must**
   be specified on all list request messages. For more information, see

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -85,7 +85,7 @@ message CreateBookRequest {
 - A `parent` field **must** be included unless the resource being created is a
   top-level resource. It **should** be called `parent`.
   - The field **should** be [annotated as required][aip-203].
-  - The field **should** identify the [resource type][aip-123] of the resource
+  - The field **must** identify the [resource type][aip-123] of the resource
     being created.
 - The resource field **must** be included and **must** map to the POST body.
 - The request message **must not** contain any other required fields and

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -87,6 +87,8 @@ message UpdateBookRequest {
   - The field **should** be [annotated as required][aip-203].
   - A `name` field **must** be included in the resource message. It **should**
     be called `name`.
+  - The field **must** identify the [resource type][aip-123] of the resource
+    being updated.
 - If partial resource update is supported, a field mask **must** be included.
   It **must** be of type `google.protobuf.FieldMask`, and it **should** be
   called `update_mask`.

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -76,7 +76,7 @@ message DeleteBookRequest {
 
 - A `name` field **must** be included. It **should** be called `name`.
   - The field **should** be [annotated as required][aip-203].
-  - The field **should** identify the [resource type][aip-123] that it
+  - The field **must** identify the [resource type][aip-123] that it
     references.
 - The comment for the field **should** document the resource pattern.
 - The request message **must not** contain any other required fields, and


### PR DESCRIPTION
We need to clearly identify resources in standard CRUDL operations. This is done using the resource type annotation specified in AIP 123. Right now, annotating the resources is optional, "should". I also didn't find that mentioned for Update. Is there a reason we can't require these annotations for all standard resource-management methods?