### PR TITLE
Fix link to AIP-203 in AIP-4223

### DIFF
--- a/aip/client-libraries/4223.md
+++ b/aip/client-libraries/4223.md
@@ -11,7 +11,7 @@ for any misconfigurations (e.g. missing required fields, attempting to update an
 immutable field) prior to executing a network call with the payload. Typically,
 documentation communicates the expectations of the service with regards to each
 request field, including any requirements on presence or format. The
-`google.api.field_behavior` annotation defined in [AIP-203][] is the
+`google.api.field_behavior` annotation defined in AIP-203 is the
 machine-readable format that services use to document behavior in relation to
 specific request fields.
 
@@ -40,5 +40,3 @@ lag between service and clients when the field behavior changes.
 Client libraries **may** implement client-side payload validation based on the
 `google.api.field_behavior` annotation only to the extent that it prevents
 local failures, such as crashes within the client library code itself.
-
-[AIP-203]: ../general/0203.md


### PR DESCRIPTION
https://google.aip.dev/client-libraries/4223

Currently leads to https://google.aip.dev/general/0203.md

<img width="612" alt="image" src="https://user-images.githubusercontent.com/1039756/209046378-fccaad02-4b72-4018-aabf-7d2c984a1911.png">
