### PR TITLE
fix(AIP-158): page_(size|token) cannot be required

### DIFF
--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -59,6 +59,7 @@ message ListBooksResponse {
 
 - Request messages for collections **should** define an `int32 page_size`
   field, allowing users to specify the maximum number of results to return.
+  - The `page_size` field **must not** be required.
   - If the user does not specify `page_size` (or specifies `0`), the API
     chooses an appropriate default, which the API **should** document. The API
     **must not** return an error.
@@ -70,6 +71,7 @@ message ListBooksResponse {
     zero results), even if not at the end of the collection.
 - Request messages for collections **should** define a `string page_token`
   field, allowing users to advance to the next page in the collection.
+  - The `page_token` field **must not** be required.
   - If the user changes the `page_size` in a request for subsequent pages, the
     service **must** honor the new page size.
   - The user is expected to keep all other arguments to the RPC the same; if


### PR DESCRIPTION
The `page_size` and `page_token` fields must not be required. The `page_token` especially cannot be required as the first request to start an "iterator" of resources will not have a `page_token`.

This was just discovered in an [existing proto](https://github.com/googleapis/googleapis/blob/2028ca57b34456f9194f5c1f5ed5b50ea9b5df99/google/cloud/vmmigration/v1/vmmigration.proto#L3336) and will be linted by https://github.com/googleapis/api-linter/issues/1065.