### PR TITLE
feat(AIP-128): remove unused guidance

### DIFF
--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -107,4 +107,5 @@ is a comprehensive reference to declarative-friendly guidance in other AIPs:
 - Resources **must** include certain standard fields: see AIP-148.
 - Resources **must** have an `etag` field: see AIP-154.
 - Resources **should** provide change validation: see AIP-163.
-- If a resource cannot be recreated with a previously used id, and it is feasible to support soft-delete, it **must** support soft delete: see AIP-164.
+- Resources **should not** implement soft-delete. If the id cannot be re-used,
+  the resource **must** implement soft-delete and the undelete RPC: see AIP-164

--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -102,11 +102,9 @@ interfaces, due to the focus on automation on top of these resources. This list
 is a comprehensive reference to declarative-friendly guidance in other AIPs:
 
 - Resources **must** use user-settable resource IDs: see AIP-133.
-- Resources **must** permit "create or update": see AIP-134.
-- Resources **should** permit "delete if existing": see AIP-135.
 - Resources **should not** employ custom methods: see AIP-136.
 - Resources **must** use the `Update` method for repeated fields: see AIP-144.
 - Resources **must** include certain standard fields: see AIP-148.
 - Resources **must** have an `etag` field: see AIP-154.
-- Resources **must** provide change validation: see AIP-163.
-- Resources **should** support soft delete: see AIP-164.
+- Resources **should** provide change validation: see AIP-163.
+- If a resource cannot be recreated with a previously used id, and it is feasible to support soft-delete, it **must** support soft delete: see AIP-164.

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -209,9 +209,6 @@ The user **must** have the update permissions to call `Update` even with
 `allow_missing` set to `true`. For customers that want to prevent users from
 creating resources using the update method, IAM conditions **should** be used.
 
-**Note:** Declarative-friendly resources ([AIP-128][]) **must** expose the
-`bool allow_missing` field.
-
 ### Etags
 
 An API may sometimes need to allow users to send update requests which are

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -112,9 +112,6 @@ rpc DeleteBook(DeleteBookRequest) returns (google.longrunning.Operation) {
 - Both the `response_type` and `metadata_type` fields **must** be specified
   (even if they are `google.protobuf.Empty`).
 
-**Note:** Declarative-friendly resources (AIP-128) **should** use long-running
-delete.
-
 ### Cascading delete
 
 Sometimes, it may be necessary for users to be able to delete a resource as


### PR DESCRIPTION
There is guidance in AIP-128 that is currently not relied on by any declarative surface.

This is not a comprehensive remove of all unused behavior, but it does remove guidance this generally unhelpful.

Specifically:

Delete if existing is not necessary: error codes exist to indicate if a resource has already been deleted, and can be used by declarative surfaces instead.

Change validation is not strictly required for declarative surfaces: it can be conditionally used if available. 

For soft deletes: this must only be used in the case where the resource cannot re-use the same id. Generally it is a simpler workflow to simple recreate the resource rather than undelete.