### PR TITLE
feat(AIP-121) require the same resource schema

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -61,9 +61,21 @@ exposes a large number of resources with a small number of methods on each
 resource. The methods can be either the standard methods ([Get][], [List][],
 [Create][], [Update][], [Delete][]), or [custom methods][].
 
-If a request and response in a standard method contains the resource (such as
-the request of [Create][] or the response of [Get][]), the schema (proto
-message) for the resource **must** be identical.
+If the request to or the response from a standard method (or a custom method in
+the same *service*) **is** the resource or **contains** the resource, the
+resource schema for that resource across all methods **must** be the same.
+
+| Standard method | Request               | Response        |
+| --------------- | --------------------- | --------------- |
+| Create          | Contains the resource | Is the resource |
+| Get             | None                  | Is the resource |
+| Update          | Contains the resource | Is the resource |
+| Delete          | None                  | None            |
+| List            | None                  | Is the resource |
+
+*The table above describes each standard method's relationship to the resource,
+where "None" indicates that the resource neither **is** nor **is contained** in
+the request or the response*
 
 A resource **must** support at minimum [Get][]: clients must be
 able to validate the state of resources after performing a mutation such

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -61,6 +61,10 @@ exposes a large number of resources with a small number of methods on each
 resource. The methods can be either the standard methods ([Get][], [List][],
 [Create][], [Update][], [Delete][]), or [custom methods][].
 
+If a request and response in a standard method contains the resource (such as
+the request of [Create][] or the response of [Get][]), the schema (proto
+message) for the resource **must** be identical.
+
 A resource **must** support at minimum [Get][]: clients must be
 able to validate the state of resources after performing a mutation such
 as [Create][], [Update][], or [Delete][].
@@ -125,6 +129,7 @@ and in turn do not increase resource management complexity.
 
 ## Changelog
 
+- **2023-01-21**: Explicitly require matching schema across standard methods.
 - **2022-12-19**: Added a section requiring Get and List.
 - **2022-11-02**: Added a section restricting resource references.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to


### PR DESCRIPTION
In order for clients to rely on modeling their interfaces via resources, the schemas of the resources must match.

Without matching schema, consumers must make inferences about the mapping of a field across operations, making it an error-prone, manual effort.