### PR TITLE
feat(AIP-123) clarify type name guidance

### DIFF
--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -28,15 +28,19 @@ In the guidance below, we use the following terms:
   This usually (but not necessarily) matches the hostname that users use to
   call the service. Example: `pubsub.googleapis.com`. This is equivalent to an
   [API Group][] in Kubernetes.
-- **Type:** This is the name used for the type within the API. This usually
-  (but not necessarily) matches the name of the protobuf message. This is
-  equivalent to an [Object][] in Kubernetes.
+- **Type:** This is the name used for the type within the API. This *should*
+  match the name of the protobuf message. This is equivalent to an [Object][] in
+  Kubernetes.
 
 ## Guidance
 
 APIs **must** define a resource type for each resource in the API, according to
-the following pattern: `{Service Name}/{Type}`. The type name **must** be
-singular and use PascalCase (UpperCamelCase).
+the following pattern: `{Service Name}/{Type}`. The type name **must**:
+
+- Start with an uppercase letter.
+- Only contain alphanumeric characters.
+- Be of the singular form of the noun.
+- Use PascalCase (UpperCamelCase).
 
 ### Examples
 
@@ -98,6 +102,7 @@ resource:
 
 ## Changelog
 
+- **2023-01-28**: Clarifying guidance for the resource type name.
 - **2022-10-28**: Added pattern variable format guidance.
 - **2020-05-14**: Added pattern uniqueness.
 - **2019-12-05**: Added guidance on patterns.


### PR DESCRIPTION
The guidance around the name of the resource type had a few gaps.

- It's often problematic for parses to lead type names with a number. Some languages may not support a class with a leading type name, and the protobuf guidance suggests a leading capital: https://developers.google.com/protocol-buffers/docs/style#message_and_field_names.
- Adding clarification around the alphanumeric range to avoid problematic punctuation, yet another issue for language-specific parsers, etc.
- Converting fairly loose language around resource types usually matching proto names to a *should*: in practice a should is identical guidance in that the convention should be followed unless there is good
  reason not to.