### PR TITLE
fix(AIP-127) clarify should not of "**" path

### DIFF
--- a/aip/general/0127.md
+++ b/aip/general/0127.md
@@ -78,8 +78,10 @@ message CreateBookRequest {
   - URIs **may** use nested fields for their variable names. (Additionally,
     AIP-134 mandates this for `Update` requests.)
   - URIs **must** use the `*` character to represent ID components, which
-    matches all URI-safe characters except for `/`. URIs **may** use `**` as
-    the final segment of a URI if matching `/` is required.
+    matches all URI-safe characters except for `/`.
+  - URIs **must not** use `**`, except in the final segment of the URI.
+  - URIs **should not** use `**` as the final segment of a URI unless doing so
+    for backwards-compatibility reasons ([AIP-122][]).
 - The `body` key defines which single top-level field in the request will be
   sent as the HTTP body. If the body is `*`, then this indicates that the
   request object itself is the HTTP body. The request body is encoded as JSON
@@ -129,6 +131,7 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
 
 ## Changelog
 
+- **2023-02-03**: Clarify guidance of usage of "**" to *should not*.
 - **2022-08-18**: Added the comment that query string parameter names are
   in camelCase.
 - **2021-01-06**: Added clarification around `body` and nested fields.


### PR DESCRIPTION
AIP-122 already states that resources *should not* use the "/" in the path. AIP-127 includes this as the more flexible *may*, which is not consistent.