### PR TITLE
feat(121) clarifying one std method per resource

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -77,12 +77,13 @@ resource schema for that resource across all methods **must** be the same.
 where "None" indicates that the resource neither **is** nor **is contained** in
 the request or the response*
 
-A resource **must** support at minimum [Get][]: clients must be
+- A resource **must** support at minimum [Get][]: clients must be
 able to validate the state of resources after performing a mutation such
 as [Create][], [Update][], or [Delete][].
-
-A resource **must** also support [List][], except for [singleton resources][]
+- A resource **must** also support [List][], except for [singleton resources][]
 where more than one resource is not possible.
+- There **must** only be one of each standard method which refers to the
+  resource, to allow consumers to uniquely identify the appropriate method.
 
 **Note:** A custom method in resource-oriented design does _not_ entail
 defining a new or custom HTTP verb. Custom methods use traditional HTTP verbs
@@ -141,6 +142,7 @@ and in turn do not increase resource management complexity.
 
 ## Changelog
 
+- **2023-02-03**: Clarify one set of standard methods per resource.
 - **2023-01-21**: Explicitly require matching schema across standard methods.
 - **2022-12-19**: Added a section requiring Get and List.
 - **2022-11-02**: Added a section restricting resource references.

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -77,11 +77,11 @@ resource schema for that resource across all methods **must** be the same.
 where "None" indicates that the resource neither **is** nor **is contained** in
 the request or the response*
 
-- A resource **must** support at minimum [Get][]: clients must be
-able to validate the state of resources after performing a mutation such
-as [Create][], [Update][], or [Delete][].
+- A resource **must** support at minimum [Get][]: clients must be able to
+  validate the state of resources after performing a mutation such as [Create][],
+  [Update][], or [Delete][].
 - A resource **must** also support [List][], except for [singleton resources][]
-where more than one resource is not possible.
+  where more than one resource is not possible.
 - There **must** only be one of each standard method which refers to the
   resource, to allow consumers to uniquely identify the appropriate method.
 


### PR DESCRIPTION
Although implied, it was not stated that there can only be one standard method per resource.

Having multiple standard methods for a single resources can make it impossible for automated clients to reason about the appropriate call to operate on a resource. This impacts declarative clients heavily, which need to determine which mutation method is appropriate.