### PR TITLE
chore(ci): fix gh pages publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+
+permissions:
+  contents: write
+    
 jobs:
   github-pages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Based on discussion in https://github.com/JamesIves/github-pages-deploy-action/issues/1110 it seems we now need to explicitly declare which Actions will use `write` permissions. The `publish` Action uses `write` in order to publish to GH Pages.

It [recently failed](https://github.com/aip-dev/google.aip.dev/actions/runs/4108736125/jobs/7090941781) for seemingly the same reason as mentioned in the issue but has worked fine until now.

Let's add this just in case and worst-case we have explicitly defined permissions in this Action :)