### PR TITLE
fix(AIP-191): include proto3 syntax requirement

### DIFF
--- a/aip/general/0191.md
+++ b/aip/general/0191.md
@@ -20,6 +20,10 @@ such as those used throughout Google. While the spirit of this guidance applies
 to APIs defined using other specification languages or formats, some of the
 particular recommendations might be irrelevant.
 
+### Syntax
+
+APIs defined in protocol buffers **must** use `proto3` syntax.
+
 ### Single package
 
 APIs defined in protocol buffers **must** define each individual API in a
@@ -125,5 +129,6 @@ that language. When releasing protos, be sure that omissions are intentional.
 
 ## Changelog
 
+- **2023-02-24**: Added guidance on protobuf syntax.
 - **2022-10-18**: Added guidance on Ruby/PHP/C# options.
 - **2019-11-18**: Added guidance on the packaging annotations.


### PR DESCRIPTION
The linter [has been enforcing this](https://linter.aip.dev/191/proto-version) from the beginning and it is a requirement for all new Google APIs.

Fixes #1023 