### PR TITLE
AIP-136: formally discourage use of standard verbs

### DIFF
--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -2,7 +2,7 @@
 id: 136
 state: approved
 created: 2019-01-25
-updated: 2022-06-02
+updated: 2023-03-02
 placement:
   category: operations
   order: 100
@@ -42,6 +42,8 @@ services. The bullets below apply in all three cases.
 
 - The name of the method **should** be a verb followed by a noun.
   - The name **must not** contain prepositions ("for", "with", etc.).
+  - The verb **should not** contain any of the standard method verbs ([Get][],
+    [List][], [Create][], [Update][], [Delete][]).
 - The HTTP method for custom methods **should** usually be `POST`, unless the
   custom method maps more strongly to another HTTP verb.
   - Custom methods that serve as an alternative to get or list methods (such as
@@ -117,8 +119,15 @@ An exception to this is for rarely-used, fundamentally imperative operations,
 such as a `Move` or `Rename` operation, for which there would not be an
 expectation of declarative support.
 
+[get]: ./0131.md
+[list]: ./0132.md
+[create]: ./0133.md
+[update]: ./0134.md
+[delete]: ./0135.md
+
 ## Changelog
 
+- **2023-03-02:** Explicitly discourage use of standard method verbs.
 - **2022-06-02:** Changed suffix descriptions to eliminate superfluous "-".
 - **2020-10-06:** Added declarative-friendly guidance.
 - **2019-08-01:** Changed the examples from "shelves" to "publishers", to

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -42,7 +42,7 @@ services. The bullets below apply in all three cases.
 
 - The name of the method **should** be a verb followed by a noun.
   - The name **must not** contain prepositions ("for", "with", etc.).
-  - The verb **should not** contain any of the standard method verbs ([Get][],
+  - The verb in the name **should not** contain any of the standard method verbs ([Get][],
     [List][], [Create][], [Update][], [Delete][]).
 - The HTTP method for custom methods **should** usually be `POST`, unless the
   custom method maps more strongly to another HTTP verb.


### PR DESCRIPTION
A comparative reading of guidance from AIP-121 and AIP-136 indicates that use of standard method verbs in a custom method is strongly discouraged, but the guidance is not formalized.

Guidance uses 'should not' rather than 'must not' to avoid rendering any existing APIs non-compliant, and to account for legitimate use cases of standard verbs in non-standard methods such as AIP-162's Delete{Resource}Revision and List{Resource}Revisions methods.