### PR TITLE
Prohibit ASCII art in proto documentation

### DIFF
--- a/aip/general/0192.md
+++ b/aip/general/0192.md
@@ -84,6 +84,12 @@ Comments **should** use `code font` for field or method names and for literals
 
 Raw HTML **must not** be used.
 
+"ASCII art" attempts to present a diagram within the protos **must not** be
+used. The Markdown within the protos is consumed by a large number of renderers,
+and any ASCII art is very unlikely to be well-presented by all of them. If
+a diagram is useful in order to understand the API, include a link to a
+documentation page containing the diagram as an image.
+
 ### Cross-references
 
 Comments **may** "link" to another component (service, method, message, field,


### PR DESCRIPTION
(I could easily be persuaded to make this a "should not", but it really is a bad idea.)