### PR TITLE
fix(AIP-122): extra ID fields output_only

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -45,9 +45,9 @@ the leading slash:
     in Normalization Form C (see [AIP-210][]).
 - Resources **must** expose a `name` field that contains its resource name.
   - Resources **may** provide the resource ID as a separate field (e.g.
-    `book_id`).
+    `book_id`). This field **must** be [`OUTPUT_ONLY`](./0203.md#output-only).
   - Resources **may** expose a separate, system-generated unique ID field
-    (`uid`).
+    (`uid`). This field **must** be [`OUTPUT_ONLY`](./0203.md#output-only).
   - Resources **must not** expose tuples, self-links, or other forms of
     resource identification.
   - All ID fields **should** be strings.

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -45,9 +45,11 @@ the leading slash:
     in Normalization Form C (see [AIP-210][]).
 - Resources **must** expose a `name` field that contains its resource name.
   - Resources **may** provide the resource ID as a separate field (e.g.
-    `book_id`). This field **must** be [`OUTPUT_ONLY`](./0203.md#output-only).
+    `book_id`). This field **must** apply the
+    [`OUTPUT_ONLY`](./0203.md#output-only) field behavior classification.
   - Resources **may** expose a separate, system-generated unique ID field
-    (`uid`). This field **must** be [`OUTPUT_ONLY`](./0203.md#output-only).
+    (`uid`). This field **must** apply the
+    [`OUTPUT_ONLY`](./0203.md#output-only) field behavior classification.
   - Resources **must not** expose tuples, self-links, or other forms of
     resource identification.
   - All ID fields **should** be strings.
@@ -327,6 +329,7 @@ message Book {
 
 ## Changelog
 
+- **2023-03-17**: Add `OUTPUT_ONLY` guidance for resource ID fields.
 - **2020-10-06**: Added declarative-friendly guidance, and tightened character
   set restrictions.
 - **2020-10-05**: Clarified when full resource names are used.


### PR DESCRIPTION
This adds a **must** requirement to the `{resource}_id` and `uid` fields on a resource regarding their `field_behavior`. Specifically, these fields **must** be `OUTPUT_ONLY` as described in AIP-203.

Fixes #1038 