### PR TITLE
fix(AIP-131,AIP-132) make Get/List a must

### DIFF
--- a/aip/general/0131.md
+++ b/aip/general/0131.md
@@ -20,9 +20,8 @@ resource.
 
 ## Guidance
 
-APIs **should** generally provide a get method for resources unless it is not
-valuable for users to do so. The purpose of the get method is to return data
-from a single resource.
+APIs **must** provide a get method for resources. The purpose of the get method
+is to return data from a single resource.
 
 Get methods are specified using the following pattern:
 
@@ -98,6 +97,7 @@ NOT_FOUND errors][permission-denied].
 
 ## Changelog
 
+- **2023-03-17**: Align with AIP-122 and make Get a must.
 - **2022-11-04**: Aggregated error guidance to AIP-193.
 - **2022-06-02**: Changed suffix descriptions to eliminate superfluous "-".
 - **2020-06-08**: Added guidance on returning the full resource.

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -20,9 +20,9 @@ parameters), and return a list of responses matching that input.
 
 ## Guidance
 
-APIs **should** generally provide a `List` method for resources unless it is
-not valuable for users to do so. The purpose of the `List` method is to return
-data from a single, finite collection.
+APIs **must** provide a `List` method for resources unless the resource is a
+[singleton][]. The purpose of the `List` method is to return data from a single,
+finite collection.
 
 List methods are specified using the following pattern:
 
@@ -198,10 +198,12 @@ NOT_FOUND errors][permission-denied].
 [aip-203]: ./0203.md
 [errors]: ./0193.md
 [permission-denied]: ./0193.md#permission-denied
+[singleton]: ./156.md
 [soft delete]: ./0135.md#soft-delete
 
 ## Changelog
 
+- **2023-03-17**: Align with AIP-122 and make Get a must.
 - **2022-11-04**: Aggregated error guidance to AIP-193.
 - **2022-06-02**: Changed suffix descriptions to eliminate superfluous "-".
 - **2020-09-02**: Add link to the filtering AIP.


### PR DESCRIPTION
With #993, Get and List are required for resources as stated in AIP-121.

Fixe the guidance to match in the more specific AIPs.