### PR TITLE
fix(AIP-132): mention Lists across multiple collections

### DIFF
--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -22,7 +22,7 @@ parameters), and return a list of responses matching that input.
 
 APIs **must** provide a `List` method for resources unless the resource is a
 [singleton][]. The purpose of the `List` method is to return data from a finite
-collection (generally singular unless the operations supports [reading across
+collection (generally singular unless the operation supports [reading across
 collections][]).
 
 List methods are specified using the following pattern:

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -21,8 +21,9 @@ parameters), and return a list of responses matching that input.
 ## Guidance
 
 APIs **must** provide a `List` method for resources unless the resource is a
-[singleton][]. The purpose of the `List` method is to return data from a single,
-finite collection.
+[singleton][]. The purpose of the `List` method is to return data from a finite
+collection (generally singular unless the operations supports [reading across
+collections][]).
 
 List methods are specified using the following pattern:
 
@@ -198,11 +199,13 @@ NOT_FOUND errors][permission-denied].
 [aip-203]: ./0203.md
 [errors]: ./0193.md
 [permission-denied]: ./0193.md#permission-denied
-[singleton]: ./156.md
+[reading across collections]: ./0159.md
+[singleton]: ./0156.md
 [soft delete]: ./0135.md#soft-delete
 
 ## Changelog
 
+- **2023-03-22**: Fix guidance wording to mention AIP-159.
 - **2023-03-17**: Align with AIP-122 and make Get a must.
 - **2022-11-04**: Aggregated error guidance to AIP-193.
 - **2022-06-02**: Changed suffix descriptions to eliminate superfluous "-".


### PR DESCRIPTION
As a follow-up to #1043, fixing wording that implies that only a single finite collection is allowed to allow more than one in the case of AIP-159.