### PR TITLE
Remove a duplicated `Changelog` section

### DIFF
--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -205,10 +205,6 @@ NOT_FOUND errors][permission-denied].
 
 ## Changelog
 
-- **2022-11-04**: Aggregated error guidance to AIP-193.
-
-## Changelog
-
 - **2022-11-04**: Referencing aggregated error guidance in AIP-193, similar to other CRUDL AIPs.
 - **2022-06-02**: Changed suffix descriptions to eliminate superfluous "-".
 - **2020-10-06**: Added declarative-friendly guidance.


### PR DESCRIPTION
Looks like it was added accidentally in https://github.com/aip-dev/google.aip.dev/pull/977/files