### PR TITLE
Clarify service name vs endpoints

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -17,7 +17,7 @@ resources.
 
 ## Guidance
 
-All resource names defined by an API **must** be unique and unambiguous within that API. (See
+All resource names defined by an API **must** be unique within that API. (See
 the section on [full resource names](#full-resource-names) below for more
 information on referring to resources across APIs.)
 

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -48,7 +48,7 @@ the leading slash:
     `book_id`). This field **must** apply the
     [`OUTPUT_ONLY`](./0203.md#output-only) field behavior classification.
   - Resources **may** expose a separate, system-generated unique ID field
-    (`uid`). This field **must** apply the
+    [(`uid`)](./0148.md#uid). This field **must** apply the
     [`OUTPUT_ONLY`](./0203.md#output-only) field behavior classification.
   - Resources **must not** expose tuples, self-links, or other forms of
     resource identification.
@@ -153,8 +153,8 @@ are used in contexts where the owning API is clear (for example,
 
 However, sometimes it is necessary for services to refer to resources in an
 arbitrary API. In this situation, the service **should** use the _full resource
-name_, a schemeless URI with the owning API's (logical) service name, followed by the
-relative resource name:
+name_, a schemeless URI with the owning [API's service name](./0009.md#api-service-name),
+followed by the relative resource name:
 
 ```
 //library.googleapis.com/publishers/123/books/les-miserables
@@ -169,7 +169,8 @@ resources in multiple APIs where ambiguity is possible.
 
 The full resource name is a schemeless URI, but slightly distinct from the full
 URIs we use to access a resource. The latter includes the protocol
-(HTTPS), the API version, and the specific service endpoint to target:
+(HTTPS), the API version, and the specific [service endpoint](./0009.md#api-service-endpoint)
+to target:
 
 ```
 https://library.googleapis.com/v1/publishers/123/books/les-miserables
@@ -182,7 +183,7 @@ surface may change between major versions, multiple major versions of the same
 API are expected to use the same underlying data.
 
 **Note:** The correlation between the full resource name and the service's
-endpoint (DNS name) is by convention. In particular, one service is able to have multiple
+endpoint is by convention. In particular, one service is able to have multiple
 endpoints (example use cases include regionalization, MTLS, and private access),
 and the full resource name does not change between these.
 
@@ -329,6 +330,8 @@ message Book {
 
 ## Changelog
 
+- **2023-03-24**: Correction: full resource name contains the service name rather
+  than the service endpoint
 - **2023-03-17**: Add `OUTPUT_ONLY` guidance for resource ID fields.
 - **2020-10-06**: Added declarative-friendly guidance, and tightened character
   set restrictions.

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -17,7 +17,7 @@ resources.
 
 ## Guidance
 
-All resource names defined by an API **must** be unique within that API. (See
+All resource names defined by an API **must** be unique and unambiguous within that API. (See
 the section on [full resource names](#full-resource-names) below for more
 information on referring to resources across APIs.)
 
@@ -153,7 +153,7 @@ are used in contexts where the owning API is clear (for example,
 
 However, sometimes it is necessary for services to refer to resources in an
 arbitrary API. In this situation, the service **should** use the _full resource
-name_, a schemeless URI with the owning API's service endpoint, followed by the
+name_, a schemeless URI with the owning API's (logical) service name, followed by the
 relative resource name:
 
 ```
@@ -168,8 +168,8 @@ resources in multiple APIs where ambiguity is possible.
 ### Resource URIs
 
 The full resource name is a schemeless URI, but slightly distinct from the full
-URIs we use to access a resource. The latter adds two components: the protocol
-(HTTPS) and the API version:
+URIs we use to access a resource. The latter includes the protocol
+(HTTPS), the API version, and the specific service endpoint to target:
 
 ```
 https://library.googleapis.com/v1/publishers/123/books/les-miserables
@@ -182,9 +182,9 @@ surface may change between major versions, multiple major versions of the same
 API are expected to use the same underlying data.
 
 **Note:** The correlation between the full resource name and the service's
-hostname is by convention. In particular, one service is able to have multiple
-hostnames (example use cases include regionalization or staging environments),
-and the full resource does not change between these.
+endpoint (DNS name) is by convention. In particular, one service is able to have multiple
+endpoints (example use cases include regionalization, MTLS, and private access),
+and the full resource name does not change between these.
 
 ### Fields representing resource names
 


### PR DESCRIPTION
Now that there are more regional service endpoints, the distinction between service names and service endpoints has become more important. The location must be in the resource name not just in the endpoint.