### PR TITLE
feat: pagination should ignore deprecated field

### DIFF
--- a/aip/client-libraries/4233.md
+++ b/aip/client-libraries/4233.md
@@ -43,9 +43,9 @@ provide access to the individual fields on the response message, in the usual
 fashion.
 
 **Note:** If the response message has more than one non-primitive `repeated`
-field, the first one (in order of appearance in the file _and_ field number) is
-used. If the first field by order of appearance in the message and the first
-field by field number do not match, code generators that implement automatic
-pagination **should** fail with an error.
+field, the first one (in order of appearance in the file _and_ field number)
+that is not deprecated is used. If the first field by order of appearance in
+the message and the first field by field number do not match, code generators
+that implement automatic pagination **should** fail with an error.
 
 [aip-158]: ../0158.md


### PR DESCRIPTION
A response message of a "list-like" method's first non-primitive field may be deprecated and replaced by another field.  Example: https://github.com/googleapis/googleapis/blob/master/google/cloud/aiplatform/v1beta1/deployment_resource_pool_service.proto#L218

The current AIP-4233 says the deprecated field should still be used, examples:

- https://github.com/googleapis/python-aiplatform/blob/main/google/cloud/aiplatform_v1beta1/services/deployment_resource_pool_service/pagers.py#L241
- https://github.com/googleapis/google-cloud-go/blob/aiplatform/v1.37.0/aiplatform/apiv1beta1/deployment_resource_pool_client.go#L600

The proposed change requires the client libraries to ignore deprecated fields.