### PR TITLE
feat(AIP-4222): define path_template syntax

### DIFF
--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -167,28 +167,38 @@ that are interpreted by code generators during conversion to regular expressions
 or non-regular expression matcher implementations. The syntax for these symbols
 is as follows:
 
-- Segment delimiters:
-  - `/`: The traditional delimiter for resource names and HTTP paths.
-- Wildcards:
-  - `*`: Corresponds to 1 or more non-`/` symbols. The regex describing it is
-    `[^\/]+`. It **must** only appear between segment delimiters.
-  - `**`: Corresponds to 0 or more symbols or segments (so it can be empty).
-    Consumes segment delimiters and does not match unless the delimiter has
-    trailing content. The regular expression is `([:\/].*)?`. It **must** only
-    appear as the final segment.
-- `{}`: Named Segments, the contents of which are used as a value in the
-  key-value pair of the header value. These have one of the following forms:
-  - `{key}`: Where `key` is the name of the key to be used in the key-value pair
-    sent. Defaults to a format `**` for capturing the contents of the value to
-    be paired. While `{key=**}` is technicaly valid syntax, as `**` is the final
-    segment, one **should** use the simpler syntax of `{key}`.
-  - `{key=format}`: Where `format` is the format of the segment(s) (expressed in
-    this `path_template` syntax) to extract as the value paired with `key`.
-  - A Named Segment **must not** contain another named segment, meaning that the
-    interpretation of a Named Segment is not recursive.
-
-If the `path_template` contains a Complex Resource ID path segments, as defined
-in [AIP-4231][], the Generator **should** emit an error.
+- The only acceptable segment delimiter is `/`.
+  - The last symbol in a `path_template` **may** be a delimiter - it will be 
+    ignored.
+  - A segment **must not** represent a complex resource ID as described in
+    [AIP-4231][]. A Generator **should** emit an error in this case.
+- A segment **must** be of one of the following types:
+  - `*`: A single-segment wildcard. Corresponds to 1 or more non-`/` symbols.
+    The regex describing it is `[^\/]+`.
+    - A Single-segment wildcard typically represents a resource ID.
+  - `**`: A multi-segment wildcard. Corresponds to 0 or more symbols or segments
+    (so it can be empty). Consumes segment delimiters and does not match unless
+    the delimiter has trailing content. The regular expression is `([:\/].*)?`.
+    - A multi-segment wildcard **must** only appear as the final segment.
+  - `LITERAL`: A literal string. A literal can consist of any alphanumeric
+    symbol.
+    - A literal **must not** contain a symbol reserved in this syntax.
+    - Literal segments typically represent a resource collection ID or base
+      path.
+  - `{}`: A variable. This matches part of the path as specified by its
+    template.
+    - A variable template **must not** contain other variables. This syntax
+      is not recursive.
+    - A variable template can start with a `{key}`, where `key` is the name to
+      be used in the key-value pair of the header.
+    - A variable template **must** follow a key and `=` separator like so:
+      `{key=template}`.
+      - The `template` is the segment(s) (expressed in this `path_template`
+        syntax) to extract as the value paired with `key`.
+    - A variable of just `{key}` defaults to a template of `**` which matches
+      everything non-empty. 
+      - While `{key=**}` is technicaly valid syntax, as `**` is the final
+        segment, the simpler syntax of `{key}` **should** be used.
 
 ## Implicit Routing Headers (`google.api.http`)
 

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -175,12 +175,13 @@ is as follows:
   - `**`: Corresponds to 0 or more symbols or segments (so it can be empty).
     Consumes segment delimiters and does not match unless the delimiter has
     trailing content. The regular expression is `([:\/].*)?`. It **must** only
-    appear following the final segment delimiter.
+    appear as the final segment.
 - `{}`: Named Segments, the contents of which are used as a value in the
   key-value pair of the header value. These have one of the following forms:
   - `{key}`: Where `key` is the name of the key to be used in the key-value pair
     sent. Defaults to a format `**` for capturing the contents of the value to
-    be paired.
+    be paired. While `{key=**}` is technicaly valid syntax, as `**` is the final
+    segment, one **should** use the simpler syntax of `{key}`.
   - `{key=format}`: Where `format` is the format of the segment(s) (expressed in
     this `path_template` syntax) to extract as the value paired with `key`.
   - A Named Segment **must not** contain another named segment, meaning that the

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -154,6 +154,31 @@ If none of the routing parameters matched their respective fields, the routing h
 Much like URL parameters, if there is more than one key-value pair to be sent, the `&`
 character is used as the separator.
 
+### `path_template` syntax
+
+As seen in the above examples, the `path_template` can use a variety of symbols
+that are interpreted by code generators during conversion to regular expression.
+The syntax for these symbols is as follows:
+
+- Wildcards:
+  - `*`: Corresponds to 1 or more non-`/` symbols. The regex describing it is
+    `[^/]+`.
+  - `**`: Corresponds to 0 or more symbols or segments (so it can be empty). The
+    regex is `.*`.
+- `{}`: Named segments, the contents of which are used as a value in the
+  key-value pair of the header value. These have one of the following forms:
+  - `{key}`: Where `key` is the name of the key to be used in the key-value pair
+    sent. Defaults to a format `**` for capturing the contents of the value to
+    be paired.
+  - `{key=format}`: Where `format` is the format of the segment(s) (expressed in
+    this `path_template` syntax) to extract as the value paired with `key`.
+
+If the `path_template` contains a Multivariate Resource ID segment, as defined
+in [AIP-4231][], the Generator **should** emit an error.
+
+Any other symbol **must** be treated as the literal symbol, and escaped as
+necessary when converting to regular expression.
+
 ## Implicit Routing Headers (`google.api.http`)
 
 **Note:** For an RPC annotated with the [`google.api.routing`][routing] annotation,
@@ -206,8 +231,10 @@ character is used as the separator.
 [http]: https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
 [routing]: https://github.com/googleapis/googleapis/blob/master/google/api/routing.proto
 [rfc 6570 §3.2.2]: https://tools.ietf.org/html/rfc6570#section-3.2.2
+[AIP-4231]: ./4231.md#complex-resource-id-path-segments
 
 ## Changelog
+- **2023-04-13**: Include `path_template` syntax.
 - **2022-07-13**: Updated to include the new `google.api.routing` annotation.
 - **2020-04-21**: Explicitly parse path variables missing a trailing segment.
 - **2019-11-27**: Include `additional_bindings` as a request parameter source.

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -50,9 +50,18 @@ rpc CreateTopic(CreateTopicRequest) {
 }
 ```
 
-The field specified in `field` **must** be a field of type `string` and **must**
-have a path-like value format, resembling a resource name or a HTTP path
-segment. Parsing arbitrary `string` fields is not supported.
+The value of the field `field` **must** be one of the following:
+1. a name of a field in the top-level of the request message
+1. a dot-separated path of field names leading to a field in a sub-message of
+the request message e.g. `"book.author.name"` where `book` is a message field in
+the request message, `author` is a message field in the `book` message, and
+`name` is a `string` field in the `author` message
+
+The _actual field_ specified in the field `field` **must** have the following
+characteristics:
+- it is type `string`
+- it has a path-like value format, resembling a resource name or a HTTP path
+segment
 
 **Note:** An empty `google.api.routing` annotation is acceptable. It means that no
 routing headers should be generated for the RPC, when they otherwise would be

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -164,41 +164,42 @@ character is used as the separator.
 
 As seen in the above examples, the `path_template` can use a variety of symbols
 that are interpreted by code generators during conversion to regular expressions
-or non-regular expression matcher implementations. The syntax for these symbols
+or non-regular expression matcher implementations. The `path_template` consists
+of segments delimited by the segment delimiter. The syntax for `path_template`
 is as follows:
 
 - The only acceptable segment delimiter is `/`.
   - The last symbol in a `path_template` **may** be a delimiter - it will be 
     ignored.
-  - A segment **must not** represent a complex resource ID as described in
-    [AIP-4231][]. A Generator **should** emit an error in this case.
 - A segment **must** be of one of the following types:
   - `*`: A single-segment wildcard. Corresponds to 1 or more non-`/` symbols.
     The regex describing it is `[^\/]+`.
     - A Single-segment wildcard typically represents a resource ID.
   - `**`: A multi-segment wildcard. Corresponds to 0 or more symbols or segments
     (so it can be empty). Consumes segment delimiters and does not match unless
-    the delimiter has trailing content. The regular expression is `([:\/].*)?`.
+    the delimiter has trailing content. The regex describing it is `([:\/].*)?`.
     - A multi-segment wildcard **must** only appear as the final segment.
-  - `LITERAL`: A literal string. A literal can consist of any alphanumeric
-    symbol.
-    - A literal **must not** contain a symbol reserved in this syntax.
+  - `LITERAL`: A literal segment. A literal segment can contain any
+    alphanumeric symbol.
+    - A literal segment **must not** contain a symbol reserved in this syntax.
     - Literal segments typically represent a resource collection ID or base
       path.
-  - `{}`: A variable. This matches part of the path as specified by its
+  - `{}`: A variable segment. This matches part of the path as specified by its
     template.
-    - A variable template **must not** contain other variables. This syntax
-      is not recursive.
-    - A variable template can start with a `{key}`, where `key` is the name to
+    - A variable segment **must not** contain other variable segments. This
+      syntax is not recursive.
+    - A variable segment can start with a `{key}`, where `key` is the name to
       be used in the key-value pair of the header.
-    - A variable template **must** follow a key and `=` separator like so:
+    - A variable segment **must** follow a key and `=` separator like so:
       `{key=template}`.
       - The `template` is the segment(s) (expressed in this `path_template`
         syntax) to extract as the value paired with `key`.
-    - A variable of just `{key}` defaults to a template of `**` which matches
-      everything non-empty. 
-      - While `{key=**}` is technicaly valid syntax, as `**` is the final
-        segment, the simpler syntax of `{key}` **should** be used.
+    - A variable segment of just `{key}` defaults to a template of `*` which
+      matches everything non-empty. 
+      - While `{key=*}` is technicaly valid syntax, the simpler syntax of
+        `{key}` **should** be used.
+- A segment **must not** represent a complex resource ID as described in
+  [AIP-4231][]. A Generator **should** emit an error in this case.
 
 ## Implicit Routing Headers (`google.api.http`)
 

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -183,7 +183,7 @@ is as follows:
     ignored.
 - A segment **must** be of one of the following types:
   - `*`: A single-segment wildcard. Corresponds to 1 or more non-`/` symbols.
-    The regex describing it is `[^\/]+`.
+    The regex describing it is `[^/]+`.
     - A Single-segment wildcard typically represents a resource ID.
   - `**`: A multi-segment wildcard. Corresponds to 0 or more segments. 
     - A multi-segment wildcard **must** only appear as the final segment or
@@ -193,7 +193,7 @@ is as follows:
       consumed while matching so a `path_template` like `foo/**` matches all of
       the following: `foo`, `foo/`, `foo/bar/baz`.
     - In a multi-segment `path_template`, when used as the last segment the
-      regex describing it is `([:\/].*)?`.
+      regex describing it is `([:/].*)?`.
     - When used as the entire `path_template`, the regex describing it is `.*`.
     - Segment delimiters are consumed while matching, including any preceding
       delimiter.

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -157,8 +157,9 @@ character is used as the separator.
 ### `path_template` syntax
 
 As seen in the above examples, the `path_template` can use a variety of symbols
-that are interpreted by code generators during conversion to regular expression.
-The syntax for these symbols is as follows:
+that are interpreted by code generators during conversion to regular expressions
+or non-regular expression matcher implementations. The syntax for these symbols
+is as follows:
 
 - Wildcards:
   - `*`: Corresponds to 1 or more non-`/` symbols. The regex describing it is
@@ -172,8 +173,10 @@ The syntax for these symbols is as follows:
     be paired.
   - `{key=format}`: Where `format` is the format of the segment(s) (expressed in
     this `path_template` syntax) to extract as the value paired with `key`.
+    A Named segment must not contain another named segment i.e. interpretation
+    of a named segment is not recursive.
 
-If the `path_template` contains a Multivariate Resource ID segment, as defined
+If the `path_template` contains a Complex Resource ID path segments, as defined
 in [AIP-4231][], the Generator **should** emit an error.
 
 Any other symbol **must** be treated as the literal symbol, and escaped as

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -60,8 +60,9 @@ the request message, `author` is a message field in the `book` message, and
 The _actual field_ specified in the field `field` **must** have the following
 characteristics:
 - it is type `string`
-- it has a path-like value format, resembling a resource name or a HTTP path
-segment
+- it either has a path-like value format resembling a resource name or contains
+  an unstructured value that would be appropriate as an individual path segment
+  e.g. a `project_id`. 
 
 **Note:** An empty `google.api.routing` annotation is acceptable. It means that no
 routing headers should be generated for the RPC, when they otherwise would be
@@ -184,10 +185,18 @@ is as follows:
   - `*`: A single-segment wildcard. Corresponds to 1 or more non-`/` symbols.
     The regex describing it is `[^\/]+`.
     - A Single-segment wildcard typically represents a resource ID.
-  - `**`: A multi-segment wildcard. Corresponds to 0 or more symbols or segments
-    (so it can be empty). Consumes segment delimiters and does not match unless
-    the delimiter has trailing content. The regex describing it is `([:\/].*)?`.
-    - A multi-segment wildcard **must** only appear as the final segment.
+  - `**`: A multi-segment wildcard. Corresponds to 0 or more segments. 
+    - A multi-segment wildcard **must** only appear as the final segment or
+      make up the entire `path_template`.
+    - In a multi-segment `path_template`, a multi-segment wildcard **must**
+      appear immediately following a segment delimiter. This delimiter is
+      consumed while matching so a `path_template` like `foo/**` matches all of
+      the following: `foo`, `foo/`, `foo/bar/baz`.
+    - In a multi-segment `path_template`, when used as the last segment the
+      regex describing it is `([:\/].*)?`.
+    - When used as the entire `path_template`, the regex describing it is `.*`.
+    - Segment delimiters are consumed while matching, including any preceding
+      delimiter.
   - `LITERAL`: A literal segment. A literal segment can contain any
     alphanumeric symbol.
     - A literal segment **must not** contain a symbol reserved in this syntax.
@@ -201,7 +210,7 @@ is as follows:
       - `{key=template}`, where the `template` is the segment(s) (expressed in
         this `path_template` syntax) to extract as the value paired with `key`
     - A variable segment of just `{key}` defaults to a template of `*` which
-      matches everything non-empty. 
+      matches 1 or more non-`/` symbols.
       - While `{key=*}` is technicaly valid syntax, the simpler syntax of
         `{key}` **should** be used.
     - A variable segment **must not** contain other variable segments. This

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -186,18 +186,17 @@ is as follows:
       path.
   - `{}`: A variable segment. This matches part of the path as specified by its
     template.
-    - A variable segment **must not** contain other variable segments. This
-      syntax is not recursive.
-    - A variable segment can start with a `{key}`, where `key` is the name to
-      be used in the key-value pair of the header.
-    - A variable segment **must** follow a key and `=` separator like so:
-      `{key=template}`.
-      - The `template` is the segment(s) (expressed in this `path_template`
-        syntax) to extract as the value paired with `key`.
+    - A variable segment can be either of the following:
+      - `{key}`, where `key` is the name to be used in the key-value pair of the
+        header
+      - `{key=template}`, where the `template` is the segment(s) (expressed in
+        this `path_template` syntax) to extract as the value paired with `key`
     - A variable segment of just `{key}` defaults to a template of `*` which
       matches everything non-empty. 
       - While `{key=*}` is technicaly valid syntax, the simpler syntax of
         `{key}` **should** be used.
+    - A variable segment **must not** contain other variable segments. This
+      syntax is not recursive.
 - A segment **must not** represent a complex resource ID as described in
   [AIP-4231][]. A Generator **should** emit an error in this case.
 

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -50,6 +50,10 @@ rpc CreateTopic(CreateTopicRequest) {
 }
 ```
 
+The field specified in `field` **must** be a field of type `string` and **must**
+have a path-like value format, resembling a resource name or a HTTP path
+segment. Parsing arbitrary `string` fields is not supported.
+
 **Note:** An empty `google.api.routing` annotation is acceptable. It means that no
 routing headers should be generated for the RPC, when they otherwise would be
 e.g. implicitly from the `google.api.http` annotation.
@@ -89,7 +93,9 @@ routing_parameters {
   path_template: "{parent=**}"
 }
 ```
-NB: an omitted `path_template` field does not indicate that key-value pairs with empty values can be sent. It's merely a shorthand.
+
+**Note:** An omitted `path_template` field does not indicate that key-value
+pairs with empty values can be sent. It's merely a shorthand.
 
 When the user supplies an instance of `CreateTopicRequest` to the method, the
 client library **must** match all the routing parameters in the order specified
@@ -162,32 +168,26 @@ or non-regular expression matcher implementations. The syntax for these symbols
 is as follows:
 
 - Segment delimiters:
-  `path_template`:
   - `/`: The traditional delimiter for resource names and HTTP paths.
-  - `:`: Often, but not exclusively, used to separate a path segment from a
-    custom method name segment.
 - Wildcards:
   - `*`: Corresponds to 1 or more non-`/` symbols. The regex describing it is
-    `[^\/]+`.
+    `[^\/]+`. It **must** only appear between segment delimiters.
   - `**`: Corresponds to 0 or more symbols or segments (so it can be empty).
     Consumes segment delimiters and does not match unless the delimiter has
-    trailing content. The regular expression is `([:\/].*)?`.
-  - All wildcards **must** be preceded by an acceptable delimiter.
-- `{}`: Named segments, the contents of which are used as a value in the
+    trailing content. The regular expression is `([:\/].*)?`. It **must** only
+    appear following the final segment delimiter.
+- `{}`: Named Segments, the contents of which are used as a value in the
   key-value pair of the header value. These have one of the following forms:
   - `{key}`: Where `key` is the name of the key to be used in the key-value pair
     sent. Defaults to a format `**` for capturing the contents of the value to
     be paired.
   - `{key=format}`: Where `format` is the format of the segment(s) (expressed in
     this `path_template` syntax) to extract as the value paired with `key`.
-    A Named segment must not contain another named segment i.e. interpretation
-    of a named segment is not recursive.
+  - A Named Segment **must not** contain another named segment, meaning that the
+    interpretation of a Named Segment is not recursive.
 
 If the `path_template` contains a Complex Resource ID path segments, as defined
 in [AIP-4231][], the Generator **should** emit an error.
-
-Any other symbol **must** be treated as the literal symbol, and escaped as
-necessary when converting to regular expression.
 
 ## Implicit Routing Headers (`google.api.http`)
 

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -161,11 +161,18 @@ that are interpreted by code generators during conversion to regular expressions
 or non-regular expression matcher implementations. The syntax for these symbols
 is as follows:
 
+- Segment delimiters:
+  `path_template`:
+  - `/`: The traditional delimiter for resource names and HTTP paths.
+  - `:`: Often, but not exclusively, used to separate a path segment from a
+    custom method name segment.
 - Wildcards:
   - `*`: Corresponds to 1 or more non-`/` symbols. The regex describing it is
-    `[^/]+`.
-  - `**`: Corresponds to 0 or more symbols or segments (so it can be empty). The
-    regex is `.*`.
+    `[^\/]+`.
+  - `**`: Corresponds to 0 or more symbols or segments (so it can be empty).
+    Consumes segment delimiters and does not match unless the delimiter has
+    trailing content. The regular expression is `([:\/].*)?`.
+  - All wildcards **must** be preceded by an acceptable delimiter.
 - `{}`: Named segments, the contents of which are used as a value in the
   key-value pair of the header value. These have one of the following forms:
   - `{key}`: Where `key` is the name of the key to be used in the key-value pair

--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -273,7 +273,7 @@ character is used as the separator.
 [AIP-4231]: ./4231.md#complex-resource-id-path-segments
 
 ## Changelog
-- **2023-04-13**: Include `path_template` syntax.
+- **2023-07-07**: Include `path_template` syntax.
 - **2022-07-13**: Updated to include the new `google.api.routing` annotation.
 - **2020-04-21**: Explicitly parse path variables missing a trailing segment.
 - **2019-11-27**: Include `additional_bindings` as a request parameter source.


### PR DESCRIPTION
Define the exact syntax of the `path_template` field as it would be interpreted by code generators during expansion/parsing. Added a stipulation about the types of fields that can be specified as the `field` to be parsed.

Most of the language was lifted from the original design doc.