### PR TITLE
[WIP] feat(AIP-122): require parent in resource name

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -52,6 +52,8 @@ the leading slash:
     [`OUTPUT_ONLY`](./0203.md#output-only) field behavior classification.
   - Resources **must not** expose tuples, self-links, or other forms of
     resource identification.
+  - Resources **must** include their parent's resource name in their resource
+    names.
   - All ID fields **should** be strings.
 
 **Note:** Resource names as described here are used within the scope of a
@@ -321,6 +323,20 @@ message Book {
   // Other fields...
 }
 ```
+
+## Rationale
+
+### Including the parent resource name in the resource name
+
+It is a common use case to first look up the parent resource, then perform an
+operation on a child. If the child does not incude the resource name of the
+parent, the consumer of the resource must choose from a set of non-optimal
+approaches to find the parent:
+
+1. Perform a read of the child resource, then look up a custom field on the
+   child to find the parent (assuming such a field exists).
+1. Require another field for their operation that specifies the parent of a
+   resource in addition to the child resource.
 
 ## Further reading
 


### PR DESCRIPTION
It is a common use case to first look up the parent resource, then perform an operation on a child. If the child does not incude the resource name of the parent, the consumer of the resource must choose from a set of non-optimal approaches to find the parent:

1. Perform a read of the child resource, then look up a custom field on the child to find the parent (assuming such a field exists).
1. Add another field where one specifies the parent of a resource in addition to the child resource.