### PR TITLE
FIX(AIP-158): Added optional keyword in page_(size|token) fields

### DIFF
--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -36,14 +36,14 @@ message ListBooksRequest {
   // this value.
   // If unspecified, at most 50 books will be returned.
   // The maximum value is 1000; values above 1000 will be coerced to 1000.
-  int32 page_size = 2;
+  optional int32 page_size = 2;
 
   // A page token, received from a previous `ListBooks` call.
   // Provide this to retrieve the subsequent page.
   //
   // When paginating, all other parameters provided to `ListBooks` must match
   // the call that provided the page token.
-  string page_token = 3;
+  optional string page_token = 3;
 }
 
 // The response structure from listing books.
@@ -172,6 +172,7 @@ paginate) is reasonable for initially-small collections.
 
 ## Changelog
 
+- **2023-04-24**: Added optional keyword in page_(size|token) fields
 - **2020-05-13**: Added guidance for skipping results.
 - **2020-08-24**: Clarified that responses are not streaming responses.
 - **2020-06-24**: Clarified that page size is always optional for users.


### PR DESCRIPTION
> The page_size / page_token field must not be required.

Does this mean that page_(size|token) is optional?