### PR TITLE
FIX(AIP-4223): fix local failures link

### DIFF
--- a/aip/client-libraries/4223.md
+++ b/aip/client-libraries/4223.md
@@ -19,7 +19,7 @@ specific request fields.
 
 Client libraries **must not** implement client-side payload validation based
 on the `google.api.field_behavior` annotation, except to prevent
-[local failures](4223.md#local-failures).
+[local failures](#local-failures).
 
 The reason for this is that the `google.api.field_behavior` annotation is
 primarily a machine-readable form of _documentation_, and **not** a


### PR DESCRIPTION
Currently forwards to 404: https://google.aip.dev/client-libraries/4223.md#local-failures