### PR TITLE
chore: field names must not be verbs.

### DIFF
--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -100,7 +100,7 @@ what is so, not what to do.
 - `disabled` (**not** `disable`)
 
 In contrast, method names, whether standard or custom, change facets of
-resources and are be named as verbs.
+resources and are named as verbs.
 
 ### Booleans
 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -90,28 +90,17 @@ For uniformity, field names that contain both a noun and an adjective
 
 ### Verbs
 
-Field names **must not** be expressed to reflect an intent or action.
-That is, they **must not** be expressed as verbs. Rather, the field name
-should express the condition of that aspect of the resource as defined
-by the value of the field in question.
-
-When performing a mutation, the field value is set to the desired
-*final* value of that property. When performing a read, the field value
-is returned as the *current* value of that property. As such, the name
-should always be *a noun or an adjective* as it describes what is so,
-not what to do.
+Field names **must not** be named to reflect an intent or action. They
+**must not** be verbs. Rather, because the field defines the *desired
+value* for mutations, e.g. Create and Update, and the *current value*
+for reads, e.g.  Get and List, the name **must** be a noun. It defines
+what is so, not what to do.
 
 - `collected_items` (**not** `collect_items`)
-- `imported_objects` (**not** `import_objects`)
+- `disabled` (**not** `disable`)
 
-Alternatively, method names, whether standard or custom, express intent
-to change the condition of resources and **should** be named as verbs,
-accordingly.
-
-**Note:** Fields named as verbs may suggest that there should be a
-complementary, corresponding field that is a noun or adjective, one to
-set a value and the other to get the value, respectively. This is highly
-discouraged, as it is suboptimal for declarative client use cases.
+In contrast, method names, whether standard or custom, change facets of
+resources and are be named as verbs.
 
 ### Booleans
 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -88,6 +88,31 @@ For uniformity, field names that contain both a noun and an adjective
 - `collected_items` (**not** `items_collected`)
 - `imported_objects` (**not** `objects_imported`)
 
+### Verbs
+
+Field names **must not** be expressed to reflect an intent or action.
+That is, they **must not** be expressed as verbs. Rather, the field name
+should express the condition of that aspect of the resource as defined
+by the value of the field in question.
+
+When performing a mutation, the field value is set to the desired
+*final* value of that property. When performing a read, the field value
+is returned as the *current* value of that property. As such, the name
+should always be *a noun or an adjective* as it describes what is so,
+not what to do.
+
+- `collected_items` (**not** `collect_items`)
+- `imported_objects` (**not** `import_objects`)
+
+Alternatively, method names, whether standard or custom, express intent
+to change the condition of resources and **should** be named as verbs,
+accordingly.
+
+**Note:** Fields named as verbs may suggest that there should be a
+complementary, corresponding field that is a noun or adjective, one to
+set a value and the other to get the value, respectively. This is highly
+discouraged, as it is suboptimal for declarative client use cases.
+
 ### Booleans
 
 Boolean fields **should** omit the prefix "is". For example:
@@ -142,6 +167,7 @@ field **should not** have a uniqueness requirement.
 
 ## Changelog
 
+- **2023-04-25**: Field names **must not** be expressed as verbs.
 - **2021-07-12**: Normalized display name guidance to "should".
 - **2021-04-07**: Added base64 and bytes guidance.
 - **2021-03-05**: Added prohibition on leading, trailing, or adjacent


### PR DESCRIPTION
Add guidance that field names must not be expressed in the context of imperatives or actions, as verbs.

Fixes: #1077