### PR TITLE
feat: require unique error details messages

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -47,11 +47,18 @@ error message **must** be considered a backwards-incompatible change.
 **Note:** The [`ErrorInfo`][ErrorInfo] message is the recommended way to send a
 machine-readable identifier.
 
+#### Uniqueness
+
+Each type of detail payload **must** be included only once. For example,
+there **must not** not be more than one `ErrorInfo` message in the
+`details` field, but there **may** be an `ErrorInfo` and a
+[`PreconditionFailure`][PreconditionFailure].
+
 ### Localization
 
 Error messages **must** be in English. If a localized error message is also
 required, the service **should** use [`google.rpc.LocalizedMessage`][details]
-as the `details` field.
+in the `details` field.
 
 ### Partial errors
 
@@ -86,6 +93,7 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Changelog
 
+- **2023-05-04**: Require uniqueness by message type for error details.
 - **2022-11-04**: Added guidance around PERMISSION_DENIED errors previously
   found in other AIPs.
 - **2022-08-12**: Reworded/Simplified intro to add clarity to the intent.
@@ -98,7 +106,8 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 <!-- prettier-ignore-start -->
 [aip-4221]: ../client-libraries/4221.md
 [details]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
-[ErrorInfo]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L51
+[ErrorInfo]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L27-L76
+[PreconditionFailure]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L139-L166
 [grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 [Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 [Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -49,8 +49,8 @@ machine-readable identifier.
 
 #### Uniqueness
 
-Each type of detail payload **must** be included only once. For example,
-there **must not** be more than one `ErrorInfo` message in the
+Each type of detail payload **must** be included at most once. For
+example, there **must not** be more than one `ErrorInfo` message in the
 `details` field, but there **may** be an `ErrorInfo` and a
 [`PreconditionFailure`][PreconditionFailure].
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -50,7 +50,7 @@ machine-readable identifier.
 #### Uniqueness
 
 Each type of detail payload **must** be included only once. For example,
-there **must not** not be more than one `ErrorInfo` message in the
+there **must not** be more than one `ErrorInfo` message in the
 `details` field, but there **may** be an `ErrorInfo` and a
 [`PreconditionFailure`][PreconditionFailure].
 


### PR DESCRIPTION
AIP-193 expresses that for a certain message type, it must be unique in "details" on Status after the PR. That is there can be only one message of a certain type as an error detail.

Fixes: #1086