### PR TITLE
fix(AIP-157): prefix top-level enum values

### DIFF
--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -49,10 +49,10 @@ enum BookView {
 
   // Include basic metadata about the book, but not the full contents.
   // This is the default value (for both ListBooks and GetBook).
-  BASIC = 1;
+  BOOK_VIEW_BASIC = 1;
 
   // Include everything.
-  FULL = 2;
+  BOOK_VIEW_FULL = 2;
 }
 ```
 
@@ -66,7 +66,8 @@ enum BookView {
   - For Get RPCs, the effective default value **should** be either `BASIC` or
     `FULL`.
 - The enum **should** be defined at the top level of the proto file (as it is
-  likely to be needed in multiple requests, e.g. both `Get` and `List`).
+  likely to be needed in multiple requests, e.g. both `Get` and `List`). See
+  [AIP-126][] for more guidance on top-level enumerations.
 - APIs **may** add fields to a given view over time. APIs **must not** remove a
   field from a given view (this is a breaking change).
 
@@ -87,3 +88,4 @@ enum BookView {
 
 [0]: https://cloud.google.com/apis/docs/system-parameters
 [1]: https://grpc.io/docs/what-is-grpc/core-concepts/#metadata
+[AIP-126]: ./0126.md

--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -82,6 +82,7 @@ enum BookView {
 
 ## Changelog
 
+- **2023-05-09**: Fix top-level enum example and link to AIP-126.
 - **2022-03-14:** Updated guidance on default value and how to specify a read mask.
 - **2021-10-06:** Updated the guidance with system parameters.
 - **2021-03-04:** Added guidance for conflicting view enums.


### PR DESCRIPTION
This fixes the example `View` enum to use prefixed values since it is also recommended that the enum definition is top level. According to AIP-126, top-level enum values **should** be prefixed to avoid collisions in generated code.