### PR TITLE
feat(AIP-193): require ErrorInfo

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -44,8 +44,13 @@ strings **may** change over time; however, if an error message does not have a
 machine-readable identifier _in addition to_ the `code` field, changing the
 error message **must** be considered a backwards-incompatible change.
 
-**Note:** The [`ErrorInfo`][ErrorInfo] message is the recommended way to send a
-machine-readable identifier.
+### ErrorInfo
+
+The [`ErrorInfo`][ErrorInfo] message is the required way to send a
+machine-readable identifier. All error responses **must** include an
+`ErrorInfo` payload in the `details` field. Variable information
+**should** be included in the `metadata` field on `ErrorInfo` and
+**must** be included if it appears within an error message.
 
 #### Uniqueness
 
@@ -86,13 +91,29 @@ if the resource or parent exists.
 If the user does have proper permission, but the requested resource or parent
 does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
+## Rationale
+
+`ErrorInfo` is required because it further identifies an error. The
+`Status` field, with under 20 [allowed values][Code], is rarley enough
+to diambiguate one error from another accross an entire API Service.
+Error messages often contain dynamic segments that express values, such
+as project numbers or locations, and these values are too often read
+from the string message using brittle extraction methods, like RegExp.
+There needs to be a machine readable component of *every* error response
+that enables clients to pull such information programatically--without
+parsing the string error message. For these reasons, `ErrorInfo` is
+required for *every* error response.
+
 ## Further reading
 
 - For which error codes to retry, see [AIP-194](https://aip.dev/194).
-- For how to retry errors in client libraries, see [AIP-4221](https://aip.dev/client-libraries/4221).
+- For how to retry errors in client libraries, see
+  [AIP-4221](https://aip.dev/client-libraries/4221).
 
 ## Changelog
 
+- **2023-05-04**: Require [`ErrorInfo`][ErrorInfo] for all error
+  responses.
 - **2023-05-04**: Require uniqueness by message type for error details.
 - **2022-11-04**: Added guidance around PERMISSION_DENIED errors previously
   found in other AIPs.

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -101,7 +101,7 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 to disambiguate one error from another accross an entire API Service.
 Error messages often contain dynamic segments that express values, such
 as project numbers or locations, and these values are often read from
-the string message using brittle extraction methods, like RegExp.  There
+the string message using brittle extraction methods, like RegExp. There
 needs to be a machine readable component of *every* error response that
 enables clients to pull such information programatically--without
 parsing the string error message. For these reasons, `ErrorInfo` is

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -100,10 +100,10 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 `Status` field, with under 20 [allowed values][Code], is rarely enough
 to disambiguate one error from another accross an entire API Service.
 Error messages often contain dynamic segments that express values, such
-as project numbers or locations, and these values are too often read
-from the string message using brittle extraction methods, like RegExp.
-There needs to be a machine readable component of *every* error response
-that enables clients to pull such information programatically--without
+as project numbers or locations, and these values are often read from
+the string message using brittle extraction methods, like RegExp.  There
+needs to be a machine readable component of *every* error response that
+enables clients to pull such information programatically--without
 parsing the string error message. For these reasons, `ErrorInfo` is
 required for *every* error response.
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -44,7 +44,7 @@ strings **may** change over time; however, if an error message does not have a
 machine-readable identifier _in addition to_ the `code` field, changing the
 error message **must** be considered a backwards-incompatible change.
 
-### ErrorInfo
+#### ErrorInfo
 
 The [`ErrorInfo`][ErrorInfo] message is the required way to send a
 machine-readable identifier. All error responses **must** include an
@@ -55,9 +55,12 @@ machine-readable identifier. All error responses **must** include an
 #### Uniqueness
 
 Each type of detail payload **must** be included at most once. For
-example, there **must not** be more than one `ErrorInfo` message in the
-`details` field, but there **may** be an `ErrorInfo` and a
-[`PreconditionFailure`][PreconditionFailure].
+example, there **must not** be more than one [`BadRequest`][BadRequest]
+message in the `details` field, but there **may** be a `BadRequest` and
+a [`PreconditionFailure`][PreconditionFailure].
+
+**Note:** `ErrorInfo` represents a special case. There **must** be exactly one
+`ErrorInfo`. It is required.
 
 ### Localization
 
@@ -94,8 +97,8 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 ## Rationale
 
 `ErrorInfo` is required because it further identifies an error. The
-`Status` field, with under 20 [allowed values][Code], is rarley enough
-to diambiguate one error from another accross an entire API Service.
+`Status` field, with under 20 [allowed values][Code], is rarely enough
+to disambiguate one error from another accross an entire API Service.
 Error messages often contain dynamic segments that express values, such
 as project numbers or locations, and these values are too often read
 from the string message using brittle extraction methods, like RegExp.
@@ -112,7 +115,7 @@ required for *every* error response.
 
 ## Changelog
 
-- **2023-05-04**: Require [`ErrorInfo`][ErrorInfo] for all error
+- **2023-05-10**: Require [`ErrorInfo`][ErrorInfo] for all error
   responses.
 - **2023-05-04**: Require uniqueness by message type for error details.
 - **2022-11-04**: Added guidance around PERMISSION_DENIED errors previously
@@ -129,6 +132,7 @@ required for *every* error response.
 [details]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
 [ErrorInfo]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L27-L76
 [PreconditionFailure]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L139-L166
+[BadRequest]: https://github.com/googleapis/googleapis/blob/477a59d764428136ba1d857a9633c0d231de6efa/google/rpc/error_details.proto#L168-L218
 [grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 [Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 [Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto


### PR DESCRIPTION
This change makes `ErrorInfo` a required component of each error's details. It adds rationale for the change as well.

Fixes: #1088