### PR TITLE
feat(AIP-193): specify how to "change" messages.

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -87,9 +87,11 @@ variables](#dynamic-variables)".
 
 If your service's API design governing body decides that altering
 `Status.message` represents a backwards incompatible change, then
-`Status.message` **must not** change.
+`Status.message` **must not** change. Otherwise, `Status.message`
+**may** change.
 
 <a name="status-message-warning"></a>
+
 **Warning:** **Use extreme caution** when changing `Status.message`.
 API consumers often treat this error message as **part of the API
 contract**. Clients perform string matches on the text to differentiate

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -85,18 +85,13 @@ variables](#dynamic-variables)".
 
 #### Changing error messages
 
-If your service's API design governing body decides that altering
-`Status.message` represents a backwards incompatible change, then
-`Status.message` **must not** change. Otherwise, `Status.message`
-**may** change.
-
 <a name="status-message-warning"></a>
 
-**Warning:** **Use extreme caution** when changing `Status.message`.
-API consumers often treat this error message as **part of the API
-contract**. Clients perform string matches on the text to differentiate
-one error for another and even parse the error message to extract
-variables from dynamic segments.
+`Status.message` **may** change. However, **use extreme caution** when
+doing so.  API consumers often treat this error message as **part of the
+API contract**. Clients perform string matches on the text to
+differentiate one error for another and even parse the error message to
+extract variables from dynamic segments.
 
 There is a safer alternative. The service can chose to include an error
 message by adding [`google.rpc.LocalizedMessage`][LocalizedMessage] to

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -64,11 +64,11 @@ a [`PreconditionFailure`][PreconditionFailure].
 
 ### Error messages
 
-For each error, the service **must** populate the `message` field on [`google.rpc.Status`][Status]. The goals of this error message are the following:
+For each error, the service **must** populate the `message` field on [`google.rpc.Status`][Status]. This error messages
 
-- It is developer-facing, human-readable, and in the application's
+- is developer-facing, human-readable, and in the application's
   native language
-- Both explain the error and offer an actionable resolution to it
+- both explains the error and offer an actionable resolution to it
   ([citation](https://cloud.google.com/apis/design/errors#error_model))
 
 **Note:** Sometimes, services elect to publish debug error message in
@@ -86,26 +86,26 @@ Changes to `message` on `Status` **must not** change it if your
 service's API design governing body decides that to do so represents a
 breaking change and **should not** change it the text contains dyanmic
 data and `ErrorInfo` was absent at the time of launch. See, "[Dynamic
-variables](#dynamic-variables).
+variables](#dynamic-variables)".
 
 **Warning:** **Use extreme caution** when changing `message` on
 `Status`. API consumers often treat the root-level error message as part
 of the API contract. They perform string matches on the text to
 differentiate one error for another. If there are dynamic segments in
-the error message clients will often parse the text to extract these
+the error message, clients will often parse the text to extract these
 variables.
 
 A second error message **may** by included by adding
-[`google.rpc.LocalizedMessage`][LocalizedMessage] in
+[`google.rpc.LocalizedMessage`][LocalizedMessage] to
 [`details`](#details) by populating its `message` field. When including
 `LocalizedMessage`, both the `locale` and `message` fields **must** be
 populated.
 
 When adding a new error messsage with `LocalizedMessage`, `ErrorInfo`
-**must** be introduced before or concurrently. If there are dyanmic
-segments found in messages, these variables must be included in the
-`metadata` field on `ErrorInfo`, a `map<string, string>`. See, "[Dynamic
-variables](#dynamic-variables)".
+**must** be introduced either before or concurrently. If there are
+dynamic segments found in messages, these variables must be included in
+the `metadata` field on `ErrorInfo`, a `map<string, string>`. See,
+"[Dynamic variables](#dynamic-variables)".
 
 Consider adding the *second error message* with `LocalizedMessage` for
 the folowing reasons:

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -64,49 +64,69 @@ a [`PreconditionFailure`][PreconditionFailure].
 
 ### Error messages
 
-The [`google.rpc.Status`][Status] error payload **should** contain two
-error messages.
+For each error, the service **must** populate the `message` field on [`google.rpc.Status`][Status]. The goals of this error message are the following:
 
-1. The payload **must** contain an error message in the `message` field
-   found at the root of [`Status`][Status].
-1. The payload **should** contain
-   [`google.rpc.LocalizedMessage`][LocalizedMessage] in `details` on
-   `Status`. This is the location of the second error message.
-
-The error message on `Status` should,
-
-- Be developer-facing, human-readable, and in English
-- Both expalin the error and offer an actionable resolution to it
+- It is developer-facing, human-readable, and in the application's
+  native language
+- Both explain the error and offer an actionable resolution to it
   ([citation](https://cloud.google.com/apis/design/errors#error_model))
 
-Once launched the value of `message` at the root-level of `Status`
-**must not** change for the error payload to be backwards compatible.
+**Note:** Sometimes, services elect to publish debug error message in
+English rather than the application's native language so that messages
+are more easily universally searchable in common online knowledge bases.
 
-When including `LocalizedMessage`, both the `locale` and `message`
-fields **must** be present.
+For new errors, the payload **must** include `ErrorInfo` and any
+variables found in dynamic segments of the error message **must** be
+represented in `metadata`. See, "[Dynamic
+variables](#dynamic-variables)".
 
 #### Changing error messages
 
-A new, additional error message **may** be added because the error
-message at the root of the payload **must not** change once launched.
-This second error messages allows for continuous, iterative
-improvement. It is potentially displayed directly to end users by
-client application.
+Changes to `message` adhere to the rules below. `message` on `Status`,
+
+- **must not** change it if your service's governing API design body
+  decides that to do so represents a breaking change.
+- **should not** change it the text contains dyanmic data and
+  `ErrorInfo` was absent at the time of launch. See, "[Dynamic
+  variables](#dynamic-variables).
+
+**Warning:** **Use extreme caution** when changing `message` on
+`Status`. API consumers often treat the root-level error message as part
+of the API contract. They perform string matches on the text to
+differentiate one error for another. If there are dynamic segments in
+the error message clients will often parse the text to extract these
+variables.
+
+A second error message **may** by included by adding
+[`google.rpc.LocalizedMessage`][LocalizedMessage] in
+[`details`](#details) by populating its `message` field. When including
+`LocalizedMessage`, both the `locale` and `message` fields **must** be
+populated.
 
 When adding a new error messsage with `LocalizedMessage`, `ErrorInfo`
 **must** be introduced before or concurrently. If there are dyanmic
-variables found in the message, these variables must be included in the
+segments found in messages, these variables must be included in the
 `metadata` field on `ErrorInfo`, a `map<string, string>`. See, "[Dynamic
 variables](#dynamic-variables)".
 
-**Warning:** If `LocalizedMessage` is released without `ErrorInfo` even
-the new error message **must not** change. To do so, would be backwards
-incompatible, effectively locking all error messages in the payload.
+Consider adding the *second error message* with `LocalizedMessage` for
+the folowing reasons:
 
-If the service is location aware, the value of `locale` **should**
-change.  See, "[Localization](#localization)". Otherwise, the field
-**may** contain the service's default locale, e.g.  "en-US", as its
-value, always, allowing the opportunity to add localization later.
+- To localize. See, "[Localization](#localization)".
+- If business requirements dictate that the message displayed to end
+  users is different than the "debug message" (found in `message` on
+  `Status`).
+- The business expects to release ongoing, iterative error message
+  improvements. This especially applies if dynamic segments are expected
+  to be relocated (within the text) or new variables to be added.
+
+**Note:** If the service is localized, the value of `locale` **must**
+change. See, "[Localization](#localization)". Otherwise, the field
+**must** always contain the service's default locale, e.g. "en-US".
+
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo` even
+the new error message **may** be considered a non-backwards compatible
+change. This would effectively lock all error messages in the payload.
 
 #### Dynamic variables
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -82,13 +82,11 @@ variables](#dynamic-variables)".
 
 #### Changing error messages
 
-Changes to `message` adhere to the rules below. `message` on `Status`,
-
-- **must not** change it if your service's governing API design body
-  decides that to do so represents a breaking change.
-- **should not** change it the text contains dyanmic data and
-  `ErrorInfo` was absent at the time of launch. See, "[Dynamic
-  variables](#dynamic-variables).
+Changes to `message` on `Status` **must not** change it if your
+service's API design governing body decides that to do so represents a
+breaking change and **should not** change it the text contains dyanmic
+data and `ErrorInfo` was absent at the time of launch. See, "[Dynamic
+variables](#dynamic-variables).
 
 **Warning:** **Use extreme caution** when changing `message` on
 `Status`. API consumers often treat the root-level error message as part

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -77,7 +77,7 @@ For each error, the service **must** populate the `message` field on
 language so that messages are easily searchable in common knowledge
 bases, such as StackOverflow&trade;.
 
-When introducing a new error, a failure scenario that did not previously
+When introducing an error that represents a failure scenario that did not previously
 occur for the service, the payload **must** include `ErrorInfo` and any
 variables found in dynamic segments of the error message **must** be
 present in `ErrorInfo.metadata`. See, "[Dynamic

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -84,7 +84,7 @@ variables](#dynamic-variables)".
 
 Changes to `message` on `Status` **must not** change it if your
 service's API design governing body decides that to do so represents a
-breaking change and **should not** change it the text contains dyanmic
+breaking change and **should not** change it the text contains dynamic
 data and `ErrorInfo` was absent at the time of launch. See, "[Dynamic
 variables](#dynamic-variables)".
 
@@ -112,13 +112,13 @@ the same concerns regarding clients misusing textual error messages
 apply.
 
 Consider adding the *second error message* with `LocalizedMessage` for
-the folowing reasons:
+the following reasons:
 
 - To localize or if you plan to localize. See,
   "[Localization](#localization)".
 - If requirements dictate that the message displayed to end users is
   different than the "debug message" (found in `message` on `Status`).
-- Onngoing, iterative error message improvements are expected,
+- Ongoing, iterative error message improvements are expected,
   especially if dynamic segments are to be relocated (within the text)
   or new variables added.
 
@@ -132,13 +132,13 @@ The best, actionable error messages include dynamic segments. These
 variable parts of the message are specific to a particular request.
 Consider the following example:
 
-> The Book, "The Great Gatsby", is unvailable at the Library, "Garfield
+> The Book, "The Great Gatsby", is unavailable at the Library, "Garfield
 > East". It is expected to be available again on 2199-05-13.
 
-**Note:** The preceeding error message is made actionable by the
-context, both that orignates from the request, the title of the Book and
-the name of the Library, and by the information that is known only by
-the service, i.e. the expected return date of the Book.
+The preceding error message is made actionable by the context, both that
+originates from the request, the title of the Book and the name of the
+Library, and by the information that is known only by the service, i.e.
+the expected return date of the Book.
 
 All dynamic variables found in error messages **must** also appear in
 the `map<string, string>` field, `metadata` (found on the *required*
@@ -154,7 +154,7 @@ expectedReturnDate: "2199-05-13"
 Dynamic variables that do not appear in an error message **may** also be
 included in `metadata` to provide additional information to the client
 to be used programmatically. Keys **must** be expressed as lower
-camel-clase.
+camel-case.
 
 Once present in `metadata`, keys **must** continue to be included in the
 map for the error payload to be backwards compatible.

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -70,7 +70,7 @@ error messages.
 1. The payload **must** contain an error message in the `message` field
    found at the root of [`Status`][Status].
 1. The payload **should** contain
-   [`google.rpc.LocalizedMessage`][LocalizedMessage], in `details` on
+   [`google.rpc.LocalizedMessage`][LocalizedMessage] in `details` on
    `Status`. This is the location of the second error message.
 
 The error message on `Status` should,
@@ -79,8 +79,8 @@ The error message on `Status` should,
 - Both expalin the error and offer an actionable resolution to it
   ([citation](https://cloud.google.com/apis/design/errors#error_model))
 
-Once launched the value of `message` found at the root-level of `Status`
-**must not** change for the error response to be backwards compatible.
+Once launched the value of `message` at the root-level of `Status`
+**must not** change for the error payload to be backwards compatible.
 
 When including `LocalizedMessage`, both the `locale` and `message`
 fields **must** be present.
@@ -106,7 +106,7 @@ incompatible, effectively locking all error messages in the payload.
 If the service is location aware, the value of `locale` **should**
 change.  See, "[Localization](#localization)". Otherwise, the field
 **may** contain the service's default locale, e.g.  "en-US", as its
-value always, allowing the opportunity to add localization later.
+value, always, allowing the opportunity to add localization later.
 
 #### Dynamic variables
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -67,7 +67,7 @@ a [`PreconditionFailure`][PreconditionFailure].
 The [`google.rpc.Status`][Status] error payload houses error messages in
 two places. There is the field, `message`, at the root of the payload,
 and there also is another `message` field on
-[`google.rpc.LocalizedMessge`][LocalizedMessage]. `Status` **must**
+[`google.rpc.LocalizedMessage`][LocalizedMessage]. `Status` **must**
 always have a value for `message`. It should,
 
 - Be developer-facing, human-readable, and in English

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -107,9 +107,9 @@ dynamic segments found in messages, these variables **must** be included
 in the `metadata` field on `ErrorInfo`, a `map<string, string>`. See,
 "[Dynamic variables](#dynamic-variables)".
 
-**Warning:** If `LocalizedMessage` is released without `ErrorInfo` even
-the new error message **may** be considered a non-backwards compatible
-change. This would effectively lock all error messages in the payload.
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo`
+the same concerns regarding clients misusing textual error messages
+apply.
 
 Consider adding the *second error message* with `LocalizedMessage` for
 the folowing reasons:

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -213,9 +213,9 @@ it is difficult to disambiguate one error from another across an entire
 [API Service][API Service].
 
 Also, error messages often contain dynamic segments that express
-variable information, so that there is machine readable component for
-*every* error response that enables clients to use such information
-programmatically.
+variable information, so that there needs to be machine readable
+component of *every* error response that enables clients to use such
+information programmatically.
 
 ### LocalizedMessage
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -101,7 +101,7 @@ A second error message **may** by included by adding
 `LocalizedMessage`, both the `locale` and `message` fields **must** be
 populated.
 
-When adding a new error messsage with `LocalizedMessage`, `ErrorInfo`
+When adding a new error message via `LocalizedMessage`, `ErrorInfo`
 **must** be introduced either before or at the same time. If there are
 dynamic segments found in messages, these variables must be included in
 the `metadata` field on `ErrorInfo`, a `map<string, string>`. See,
@@ -122,7 +122,7 @@ the folowing reasons:
   especially if dynamic segments are to be relocated (within the text)
   or new variables added.
 
-**Note:** If the service is localized, the value of `locale` **must**
+If the service is localized, the value of `locale` **must**
 change. See, "[Localization](#localization)". Otherwise, the field
 **must** always contain the service's default locale, e.g. "en-US".
 
@@ -143,7 +143,7 @@ the service, i.e. the expected return date of the Book.
 All dynamic variables found in error messages **must** also appear in
 the `map<string, string>` field, `metadata` (found on the *required*
 `ErrorInfo`).  For example, the `metadata` map for the sample error
-message above **must** include *at least* the following key/value pairs:
+message above will include *at least* the following key/value pairs:
 
 ```yaml
 bookTitle: "The Great Gatsby"
@@ -153,7 +153,8 @@ expectedReturnDate: "2199-05-13"
 
 Dynamic variables that do not appear in an error message **may** also be
 included in `metadata` to provide additional information to the client
-to be used programmatically.
+to be used programmatically. Keys **must** be expressed as lower
+camel-clase.
 
 Once present in `metadata`, keys **must** continue to be included in the
 map for the error payload to be backwards compatible.
@@ -203,16 +204,6 @@ needs to be a machine readable component of *every* error response that
 enables clients to pull such information programatically--without
 parsing the string error message. For these reasons, `ErrorInfo` is
 required for *every* error response.
-
-The field, `message`, on `Status` is immutable because clients **may**
-rely upon it to disambiguate errors. For example, client software may
-leverage a string contains or regexp match on the error message string
-itself to determine the difference between one error with `status`,
-`PRECONDTION_FAILURE`, from another.
-
-`LocalizedMessage` serves two purposes, to allow for error message
-improvements and for true localization.  In either case, adding it
-allows for localization to be introduced at any time.
 
 ## Further reading
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -80,8 +80,7 @@ Once launched the value of `message` found at the root-level of `Status`
 Each error response, **should** include `LocalizedMessage`. Both the
 `locale` and `message` fields **must** be populated.  `LocalizedMessage`
 **must** be included to change existing error messages such that the
-change is backwards compatible, in most cases.  See, "[Changing error
-messages](#changing-error-messages)".
+change is backwards compatible, in most cases.
 
 #### Changing error messages
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -213,9 +213,9 @@ it is difficult to disambiguate one error from another across an entire
 [API Service][API Service].
 
 Also, error messages often contain dynamic segments that express
-variable information, so that there needs to be machine readable
-component of *every* error response that enables clients to use such
-information programmatically.
+variable information, so there needs to be machine readable component of
+*every* error response that enables clients to use such information
+programmatically.
 
 ### LocalizedMessage
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -64,7 +64,7 @@ a [`PreconditionFailure`][PreconditionFailure].
 
 ### Error messages
 
-For each error, the service **must** populate the `message` field on [`google.rpc.Status`][Status]. This error messages
+For each error, the service **must** populate the `message` field on [`google.rpc.Status`][Status]. This error message,
 
 - is developer-facing, human-readable, and in the application's
   native language

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -62,11 +62,94 @@ a [`PreconditionFailure`][PreconditionFailure].
 **Note:** `ErrorInfo` represents a special case. There **must** be exactly one
 `ErrorInfo`. It is required.
 
-### Localization
+### Error messages
 
-Error messages **must** be in English. If a localized error message is also
-required, the service **should** use [`google.rpc.LocalizedMessage`][details]
-in the `details` field.
+The [`google.rpc.Status`][Status] error payload houses error messages in
+two places. There is the field, `message`, at the root of the payload,
+and there also is another `message` field on
+[`google.rpc.LocalizedMessge`][LocalizedMessage]. `Status` **must**
+always have a value for `message`. It should,
+
+- Be developer-facing, human-readable, and in English
+- Both expalin the error and offer an actionable resolution to it
+  ([citation](https://cloud.google.com/apis/design/errors#error_model))
+
+Once launched the value of `message` found at the root-level of `Status`
+**must not** change for the error response to be backwards compatible.
+
+Each error response, **should** include `LocalizedMessage`. Both the
+`locale` and `message` fields **must** be populated.  `LocalizedMessage`
+**must** be included to change existing error messages such that the
+change is backwards compatible, in most cases.  See, "[Changing error
+messages](#changing-error-messages)".
+
+#### Dynamic variables
+
+The best, actionable error messages include dynamic segments. These
+variable parts of the message are specific to a particular request.
+Consider the following example:
+
+> The Book, "The Great Gatsby", is unvailable at the Library, "Garfield
+> East". It is expected to be available again on 2199-05-13.
+
+**Note:** The preceeding error message is made actionable by the
+context, both that orignates in the request, the title of the Book and
+the name of the Library, and by the information that is included, known
+only by the system, i.e. the expected return date of the Book.
+
+All dynamic variables found in error messages **must** also appear in
+the `map<string, string>` field, `metadata`, found on the *required*
+error details payload, `ErrorInfo`.  For example the `metadata` map for
+the example error message above **must** include *at least* the
+following key/value pairs:
+
+```yaml
+bookTitle: "The Great Gatsby"
+library: "Garfield East"
+expectedDate: "2199-05-13"
+```
+
+Dynamic variables that do not appear in an error message **may** also be
+included in `metadata` to provide additional information to the client
+to be used programmatically.
+
+Once present in `metadata`, keys **must** continue to be included in the
+map for the error response to be backwards compatible.
+
+#### Changing error messages
+
+An new, additional error message **may** be added. To so, include
+[`LocalizedMessage`][LocalizedMessage] in the payload so that the error
+payload includes a second, improved message. The purpose of this change
+might be to add a message that a client application might display
+directly to end users.
+
+The field, `locale`, **must** be populated but **may** always contain
+the value of the service's default locale, e.g.  "en-US". While this
+means that the this additional error messages is not, in fact,
+localized, it provides the service owner with the opportunity to do so
+later.  Alternatively, the value of `locale` **may** change if the
+service is location aware. See, "[Localization](#localization)".
+
+When adding a new error messsage, `ErrorInfo` **should** be introduced
+before `LocalizedMessage` or at the same time. If there are dyanmic
+variables found in the message, `ErrorInfo` **must** be introduced.
+Similarly, this **must** occurr at the same time as or before
+`LocalizedMessage` is released, and `metadata` **must** include all
+dynamic variables in the error message.
+
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo` and
+with an error message that includes dynamic segments, the error message
+**must not** be changed. To so, would be considered a backwards
+incompatible change, effectively locking all error messages in the
+payload.
+
+#### Localization
+
+The error message, found in the payload on `Status`, **must** be in
+English. If a localized error message is also required, the service
+**should** use [`google.rpc.LocalizedMessage`][LocalizedMessage] in the
+`details` field.
 
 ### Partial errors
 
@@ -107,6 +190,17 @@ enables clients to pull such information programatically--without
 parsing the string error message. For these reasons, `ErrorInfo` is
 required for *every* error response.
 
+The field, `message`, on `Status` is immutable because client **may**
+rely upon it to disambiguate errors. For example, client software may
+leverage a string contains or regexp match on the string error message
+itself to determine the difference of one error with `status`,
+`PRECONDTION_FAILURE`, from another.
+
+`LocalizedMessage` serves two purposes, to allow for error message
+improvements and for true localization.  Regardless of the reaon for
+adding it, doing so allows for localization to be introduced at any
+time.
+
 ## Further reading
 
 - For which error codes to retry, see [AIP-194](https://aip.dev/194).
@@ -115,6 +209,7 @@ required for *every* error response.
 
 ## Changelog
 
+- **2023-05-12**: Specify requirements for changing error messages.
 - **2023-05-10**: Require [`ErrorInfo`][ErrorInfo] for all error
   responses.
 - **2023-05-04**: Require uniqueness by message type for error details.
@@ -133,6 +228,7 @@ required for *every* error response.
 [ErrorInfo]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L27-L76
 [PreconditionFailure]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L139-L166
 [BadRequest]: https://github.com/googleapis/googleapis/blob/477a59d764428136ba1d857a9633c0d231de6efa/google/rpc/error_details.proto#L168-L218
+[LocalizedMessage]: https://github.com/googleapis/googleapis/blob/e9897ed945336e2dc967b439ac7b4be6d2c62640/google/rpc/error_details.proto#L275-L285
 [grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 [Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 [Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -128,7 +128,7 @@ present the service's default locale, e.g. "en-US".
 When adding an error message via `LocalizedMessage`, `ErrorInfo`
 **must** be introduced either before or at the same time. If there are
 dynamic segments found in the text, the values of these variables
-**must** be included `ErrorInfo.metadata`.  See, "[Dynamic
+**must** be included in `ErrorInfo.metadata`.  See, "[Dynamic
 variables](#dynamic-variables)".
 
 **Warning:** If `LocalizedMessage` is released without `ErrorInfo`, the

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -102,29 +102,29 @@ A second error message **may** by included by adding
 populated.
 
 When adding a new error messsage with `LocalizedMessage`, `ErrorInfo`
-**must** be introduced either before or concurrently. If there are
+**must** be introduced either before or at the same time. If there are
 dynamic segments found in messages, these variables must be included in
 the `metadata` field on `ErrorInfo`, a `map<string, string>`. See,
 "[Dynamic variables](#dynamic-variables)".
 
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo` even
+the new error message **may** be considered a non-backwards compatible
+change. This would effectively lock all error messages in the payload.
+
 Consider adding the *second error message* with `LocalizedMessage` for
 the folowing reasons:
 
-- To localize. See, "[Localization](#localization)".
-- If business requirements dictate that the message displayed to end
-  users is different than the "debug message" (found in `message` on
-  `Status`).
-- The business expects to release ongoing, iterative error message
-  improvements. This especially applies if dynamic segments are expected
-  to be relocated (within the text) or new variables to be added.
+- To localize or if you plan to localize. See,
+  "[Localization](#localization)".
+- If requirements dictate that the message displayed to end users is
+  different than the "debug message" (found in `message` on `Status`).
+- Onngoing, iterative error message improvements are expected,
+  especially if dynamic segments are to be relocated (within the text)
+  or new variables added.
 
 **Note:** If the service is localized, the value of `locale` **must**
 change. See, "[Localization](#localization)". Otherwise, the field
 **must** always contain the service's default locale, e.g. "en-US".
-
-**Warning:** If `LocalizedMessage` is released without `ErrorInfo` even
-the new error message **may** be considered a non-backwards compatible
-change. This would effectively lock all error messages in the payload.
 
 #### Dynamic variables
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -64,11 +64,16 @@ a [`PreconditionFailure`][PreconditionFailure].
 
 ### Error messages
 
-The [`google.rpc.Status`][Status] error payload houses error messages in
-two places. There is the field, `message`, at the root of the payload,
-and there also is another `message` field on
-[`google.rpc.LocalizedMessage`][LocalizedMessage]. `Status` **must**
-always have a value for `message`. It should,
+The [`google.rpc.Status`][Status] error payload **should** contain two
+error messages.
+
+1. The payload **must** contain an error message in the `message` field
+   found at the root of [`Status`][Status].
+1. The payload **should** contain
+   [`google.rpc.LocalizedMessage`][LocalizedMessage], in `details` on
+   `Status`. This is the location of the second error message.
+
+The error message on `Status` should,
 
 - Be developer-facing, human-readable, and in English
 - Both expalin the error and offer an actionable resolution to it
@@ -77,37 +82,31 @@ always have a value for `message`. It should,
 Once launched the value of `message` found at the root-level of `Status`
 **must not** change for the error response to be backwards compatible.
 
-Each error response, **should** include `LocalizedMessage`. Both the
-`locale` and `message` fields **must** be populated.  `LocalizedMessage`
-**must** be included to change existing error messages such that the
-change is backwards compatible, in most cases.
+When including `LocalizedMessage`, both the `locale` and `message`
+fields **must** be present.
 
 #### Changing error messages
 
-Because the error message at the root of the payload **must not** change
-after it is launched, a new, additional error message **may** be added.
-The purpose of this change might be to add a message that a client
-application could display directly to end users. To do so, include
-[`LocalizedMessage`][LocalizedMessage] in the payload to enable the
-error payload to include a second, improved message.
+A new, additional error message **may** be added because the error
+message at the root of the payload **must not** change once launched.
+This second error messages allows for continuous, iterative
+improvement. It is potentially displayed directly to end users by
+client application.
 
-The field, `locale`, **must** be populated but **may** always contain
-the value of the service's default locale, e.g.  "en-US". While this
-means that the this additional error messages is not, in fact,
-localized, it provides the service owner with the opportunity to do so
-later.  Alternatively, the value of `locale` **may** change if the
-service is location aware. See, "[Localization](#localization)".
+When adding a new error messsage with `LocalizedMessage`, `ErrorInfo`
+**must** be introduced before or concurrently. If there are dyanmic
+variables found in the message, these variables must be included in the
+`metadata` field on `ErrorInfo`, a `map<string, string>`. See, "[Dynamic
+variables](#dynamic-variables)".
 
-When adding a new error messsage using `LocalizedMessage`, `ErrorInfo`
-**must** be introduced either before or at the same time. If there are
-dyanmic variables found in the message, the `ErrorInfo` field,
-`metadata`, **must** include all of these variables. (See, "[Dynamic
-variables](#dynamic-variables".)
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo` even
+the new error message **must not** change. To do so, would be backwards
+incompatible, effectively locking all error messages in the payload.
 
-**Warning:** If `LocalizedMessage` is released without `ErrorInfo` and
-with an error message that includes dynamic segments, the error message
-**must not** be changed. To do so, would be backwards incompatible,
-effectively locking all error messages in the payload.
+If the service is location aware, the value of `locale` **should**
+change.  See, "[Localization](#localization)". Otherwise, the field
+**may** contain the service's default locale, e.g.  "en-US", as its
+value always, allowing the opportunity to add localization later.
 
 #### Dynamic variables
 
@@ -120,14 +119,13 @@ Consider the following example:
 
 **Note:** The preceeding error message is made actionable by the
 context, both that orignates from the request, the title of the Book and
-the name of the Library, and by the information that is  known only by
+the name of the Library, and by the information that is known only by
 the service, i.e. the expected return date of the Book.
 
 All dynamic variables found in error messages **must** also appear in
-the `map<string, string>` field, `metadata`, found on the *required*
-error details payload, `ErrorInfo`.  For example, the `metadata` map for
-the sample error message above **must** include *at least* the following
-key/value pairs:
+the `map<string, string>` field, `metadata` (found on the *required*
+`ErrorInfo`).  For example, the `metadata` map for the sample error
+message above **must** include *at least* the following key/value pairs:
 
 ```yaml
 bookTitle: "The Great Gatsby"
@@ -140,7 +138,7 @@ included in `metadata` to provide additional information to the client
 to be used programmatically.
 
 Once present in `metadata`, keys **must** continue to be included in the
-map for the error response to be backwards compatible.
+map for the error payload to be backwards compatible.
 
 #### Localization
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -32,6 +32,37 @@ Error messages **should** be brief but actionable. Any extra information
 necessary, you **should** provide a link where a reader can get more
 information or ask questions to help resolve the issue.
 
+
+A JSON representation of an error response might look like the
+following:
+
+```json
+{
+  "error": {
+    "code": 429,
+    "message": "The zone 'us-east-1' does not have enough resources available to fulfill the request.  Try a different zone, or try again later.",
+    "status": "RESOURCE_EXHAUSTED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "STOCKOUT",
+        "domain": "compute.googleapis.com",
+        "metadata": {
+          "zone": "us-east1-a",
+          "vmType": "e2-medium",
+          "attachment": "local-ssd=3,nvidia-t4=2"
+         }
+       },
+       {
+        "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
+        "locale": "en-US",
+        "message": "A e2-medium with local-ssd=3,nvidia-t4=2 is currently unavailable in the us-east1-a zone.\nCapacity changes frequently, so try your request in a different zone, with a different VM hardware configuration, or at a later time. For more information, see troubleshooting documentation."
+       }
+    ]
+  }
+}
+```
+
 ### Details
 
 Google defines a set of [standard detail payloads][details] for error details,

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -222,7 +222,7 @@ allows for localization to be introduced at any time.
 
 ## Changelog
 
-- **2023-05-12**: Specify requirements for changing error messages.
+- **2023-05-16**: Specify requirements for changing error messages.
 - **2023-05-10**: Require [`ErrorInfo`][ErrorInfo] for all error
   responses.
 - **2023-05-04**: Require uniqueness by message type for error details.

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -68,25 +68,28 @@ For each error, the service **must** populate the `message` field on [`google.rp
 
 - is developer-facing, human-readable, and in the application's
   native language
-- both explains the error and offer an actionable resolution to it
+- both explains the error and offers an actionable resolution to it
   ([citation](https://cloud.google.com/apis/design/errors#error_model))
 
 **Note:** Sometimes, services elect to publish debug error message in
 English rather than the application's native language so that messages
 are more easily universally searchable in common online knowledge bases.
 
-For new errors, the payload **must** include `ErrorInfo` and any
+When introducing a new error, a failure scenario that did not previously
+occur for the service, the payload **must** include `ErrorInfo` and any
 variables found in dynamic segments of the error message **must** be
 represented in `metadata`. See, "[Dynamic
 variables](#dynamic-variables)".
 
 #### Changing error messages
 
-Changes to `message` on `Status` **must not** change it if your
-service's API design governing body decides that to do so represents a
-breaking change and **should not** change it the text contains dynamic
-data and `ErrorInfo` was absent at the time of launch. See, "[Dynamic
-variables](#dynamic-variables)".
+If your service's API design governing body decides that changes to
+`Status.message` represent backwards incompatible change, then
+`Status.message` **must not** be changed.
+
+If the error message in `Status.message` contains dynamic segments, and
+`ErrorInfo` was absent at the time of launch, then `Status.message`
+**should not** change. See, "[Dynamic variables](#dynamic-variables)".
 
 **Warning:** **Use extreme caution** when changing `message` on
 `Status`. API consumers often treat the root-level error message as part

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -64,69 +64,77 @@ a [`PreconditionFailure`][PreconditionFailure].
 
 ### Error messages
 
-For each error, the service **must** populate the `message` field on [`google.rpc.Status`][Status]. This error message,
+For each error, the service **must** populate the `message` field on
+[`google.rpc.Status`][Status]. This error message,
 
-- is developer-facing, human-readable, and in the application's
-  native language
+- is a developer-facing, human-readable "debug message"
+- is presented in the service's native language
 - both explains the error and offers an actionable resolution to it
   ([citation](https://cloud.google.com/apis/design/errors#error_model))
 
-**Note:** Sometimes, services elect to publish debug error message in
-English rather than the application's native language so that messages
-are more easily universally searchable in common online knowledge bases.
+**Note:** Sometimes a service might elect to always present
+`Status.message` in English rather than the application's native
+language so that messages are easily searchable in common knowledge
+bases, such as StackOverflow&trade;.
 
 When introducing a new error, a failure scenario that did not previously
 occur for the service, the payload **must** include `ErrorInfo` and any
 variables found in dynamic segments of the error message **must** be
-represented in `metadata`. See, "[Dynamic
+present in `ErrorInfo.metadata`. See, "[Dynamic
 variables](#dynamic-variables)".
 
 #### Changing error messages
 
-If your service's API design governing body decides that a change to
-`Status.message` represent a backwards incompatible change, then
-`Status.message` **must not** be changed.
+If your service's API design governing body decides that altering
+`Status.message` represents a backwards incompatible change, then
+`Status.message` **must not** change.
 
-If the error message in `Status.message` contains dynamic segments, and
-`ErrorInfo` was absent at the time of launch, then `Status.message`
-**should not** change. See, "[Dynamic variables](#dynamic-variables)".
+If the error message in `Status.message` contains dynamic segments (see
+"[Dynamic variables](#dynamic-variables)"), and `ErrorInfo` was absent
+at the time of launch, then `Status.message` **should not** change.
 
-**Warning:** **Use extreme caution** when changing `Status.message`. API
-consumers often treat this error message as part of the API contract.
-They perform string matches on the text to differentiate one error for
-another. Also, if there are dynamic segments in the error message,
-clients will often parse the text to extract these variables.
+**Warning:** **Use extreme caution** when changing `Status.message`.
+API consumers often treat this error message as **part of the API
+contract**. Clients perform string matches on the text to differentiate
+one error for another and even parse the error message to extract
+variables from dynamic segments.
 
-A second error message **may** by included by adding
-[`google.rpc.LocalizedMessage`][LocalizedMessage] to
-[`details`](#details) by populating its `message` field. When including
-`LocalizedMessage`, both the `locale` and `message` fields **must** be
-populated.
+There is a safer alternative. The service can chose to include an error
+message by adding [`google.rpc.LocalizedMessage`][LocalizedMessage] to
+[`Status.details`][Status details].
 
-When adding a new error message via `LocalizedMessage`, `ErrorInfo`
+The error message presented in `LocalizedMessage.message` **may** be the
+same as `Status.message` or it **may** be an alternate message.
+
+Reasons to present the same error message in both locations include the
+following:
+
+- It affords clients the ability to find a canonical error message in a
+  single location, `LocalizedMessaage.message`.
+- The service plans to localize either immediately or in the near
+  future.  See, "[Localization](#localization)".
+
+Reasons to present an error message in `LocalizedMessage.message` that
+differs from `Status.message` include the following:
+
+- The service requires an end-user facing error message that differs
+  from the "debug message".
+- Ongoing, iterative error message improvements are expected.
+
+When including `LocalizedMessage`, both fields, `locale` and `message`,
+**must** be populated.  If the service is to be localized, the value of
+`locale` **must** change dynamically. See,
+"[Localization](#localization)". Otherwise, the service **must** present
+the service's default locale, e.g. "en-US", always.
+
+When adding an error message via `LocalizedMessage`, `ErrorInfo`
 **must** be introduced either before or at the same time. If there are
-dynamic segments found in messages, these variables **must** be included
-in the `metadata` field on `ErrorInfo`, a `map<string, string>`. See,
-"[Dynamic variables](#dynamic-variables)".
+dynamic segments found in the text, the values of these variables
+**must** be included in the `map<string, string>`, `ErrorInfo.metadata`.
+See, "[Dynamic variables](#dynamic-variables)".
 
-**Warning:** If `LocalizedMessage` is released without `ErrorInfo`
-the same concerns regarding clients misusing textual error messages
-apply.
-
-Consider adding the *second error message* with `LocalizedMessage` for
-the following reasons:
-
-- To localize or if you plan to localize. See,
-  "[Localization](#localization)".
-- If requirements dictate that the message displayed to end users is
-  different than the "debug message" (found in `message` on `Status`).
-- Ongoing, iterative error message improvements are expected,
-  especially if dynamic segments are to be relocated (within the text)
-  or new variables added.
-
-If the service is localized, the value of `locale` **must**
-change. See, "[Localization](#localization)". Otherwise, the field
-**must** always contain the service's default locale, e.g. "en-US".
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo`, the
+same concerns regarding client misuse of textual error messages apply.
 
 #### Dynamic variables
 
@@ -142,10 +150,11 @@ originates from the request, the title of the Book and the name of the
 Library, and by the information that is known only by the service, i.e.
 the expected return date of the Book.
 
-All dynamic variables found in error messages **must** also appear in
-the `map<string, string>` field, `metadata` (found on the *required*
-`ErrorInfo`).  For example, the `metadata` map for the sample error
-message above will include *at least* the following key/value pairs:
+All dynamic variables found in error messages **must** also be present
+in the `map<string, string>`, `ErrorInfo.metadata` (found on the
+*required* `ErrorInfo`).  For example, the `metadata` map for the sample
+error message above will include *at least* the following key/value
+pairs:
 
 ```yaml
 bookTitle: "The Great Gatsby"
@@ -163,10 +172,10 @@ map for the error payload to be backwards compatible.
 
 #### Localization
 
-The error message, found in the payload on `Status`, **must** be in
-English. If a localized error message is also required, the service
-**should** use [`google.rpc.LocalizedMessage`][LocalizedMessage] in the
-`details` field.
+The value of `Status.message` **should** be presented in the service's
+native language. If a localized error message is required, the service
+**must** include [`google.rpc.LocalizedMessage`][LocalizedMessage] in
+`Status.details`.
 
 ### Partial errors
 
@@ -196,16 +205,28 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 ## Rationale
 
-`ErrorInfo` is required because it further identifies an error. The
-`Status` field, with under 20 [allowed values][Code], is rarely enough
-to disambiguate one error from another accross an entire API Service.
-Error messages often contain dynamic segments that express values, such
-as project numbers or locations, and these values are often read from
-the string message using brittle extraction methods, like RegExp. There
-needs to be a machine readable component of *every* error response that
-enables clients to pull such information programatically--without
-parsing the string error message. For these reasons, `ErrorInfo` is
-required for *every* error response.
+### Requiring ErrorInfo
+
+`ErrorInfo` is required because it further identifies an error. With
+only approximately twenty [available values][Code] for `Status.status`,
+it is almost always impossible to disambiguate one error from another
+across am entire [API Service][API Service].
+
+Error messages often contain dynamic segments that express variable
+information. These values are often parsed from the text using brittle
+extraction methods, like RegExp. To alleviate this risk, these values
+need to be included in the `map<string, string>` `ErrorInfo.metatdata`
+so that there is machine readable component for *every* error response
+that enables clients to use such information programmatically.
+
+### LocalizedMessage
+
+`LocalizedMessage` was selected as the location to present alternate
+error messages. This is desirable when clients need to display a crafted
+error message directly to end users. `LocalizedMessage` can be used with
+a static `locale`. This may seem misleading, but it allows the service
+to eventually localize without having to duplicate or move the error
+message, which would be a backwards incompatible change.
 
 ## Further reading
 
@@ -215,7 +236,9 @@ required for *every* error response.
 
 ## Changelog
 
-- **2023-05-16**: Specify requirements for changing error messages.
+- **2023-05-17**: Change the recommended language for `Status.message`
+  to be the service's native language rather than English.
+- **2023-05-17**: Specify requirements for changing error messages.
 - **2023-05-10**: Require [`ErrorInfo`][ErrorInfo] for all error
   responses.
 - **2023-05-04**: Require uniqueness by message type for error details.
@@ -238,5 +261,7 @@ required for *every* error response.
 [grpc status code documentation]: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 [Code]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 [Status]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
+[Status details]: https://github.com/googleapis/googleapis/blob/aeae5ea2b01ece6c0cee046ae84b881cdc62b95d/google/rpc/status.proto#L46-L48
 [long-running operations]: ./0151.md
+[API Service]: https://cloud.google.com/apis/design/glossary#api_service
 <!-- prettier-ignore-end -->

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -42,7 +42,7 @@ following:
 {
   "error": {
     "code": 429,
-    "message": "The zone 'us-east-1' does not have enough resources available to fulfill the request.  Try a different zone, or try again later.",
+    "message": "The zone 'us-east-1' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
     "status": "RESOURCE_EXHAUSTED",
     "details": [
       {

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -103,8 +103,8 @@ populated.
 
 When adding a new error message via `LocalizedMessage`, `ErrorInfo`
 **must** be introduced either before or at the same time. If there are
-dynamic segments found in messages, these variables must be included in
-the `metadata` field on `ErrorInfo`, a `map<string, string>`. See,
+dynamic segments found in messages, these variables **must** be included
+in the `metadata` field on `ErrorInfo`, a `map<string, string>`. See,
 "[Dynamic variables](#dynamic-variables)".
 
 **Warning:** If `LocalizedMessage` is released without `ErrorInfo` even

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -186,16 +186,15 @@ enables clients to pull such information programatically--without
 parsing the string error message. For these reasons, `ErrorInfo` is
 required for *every* error response.
 
-The field, `message`, on `Status` is immutable because client **may**
+The field, `message`, on `Status` is immutable because clients **may**
 rely upon it to disambiguate errors. For example, client software may
-leverage a string contains or regexp match on the string error message
-itself to determine the difference of one error with `status`,
+leverage a string contains or regexp match on the error message string
+itself to determine the difference between one error with `status`,
 `PRECONDTION_FAILURE`, from another.
 
 `LocalizedMessage` serves two purposes, to allow for error message
-improvements and for true localization.  Regardless of the reaon for
-adding it, doing so allows for localization to be introduced at any
-time.
+improvements and for true localization.  In either case, adding it
+allows for localization to be introduced at any time.
 
 ## Further reading
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -77,10 +77,10 @@ For each error, the service **must** populate the `message` field on
 language so that messages are easily searchable in common knowledge
 bases, such as StackOverflow&trade;.
 
-When introducing an error that represents a failure scenario that did not previously
-occur for the service, the payload **must** include `ErrorInfo` and any
-variables found in dynamic segments of the error message **must** be
-present in `ErrorInfo.metadata`. See, "[Dynamic
+When introducing an error that represents a failure scenario that did
+not previously occur for the service, the payload **must** include
+`ErrorInfo` and any variables found in dynamic segments of the error
+message **must** be present in `ErrorInfo.metadata`. See, "[Dynamic
 variables](#dynamic-variables)".
 
 #### Changing error messages

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -83,20 +83,19 @@ variables](#dynamic-variables)".
 
 #### Changing error messages
 
-If your service's API design governing body decides that changes to
-`Status.message` represent backwards incompatible change, then
+If your service's API design governing body decides that a change to
+`Status.message` represent a backwards incompatible change, then
 `Status.message` **must not** be changed.
 
 If the error message in `Status.message` contains dynamic segments, and
 `ErrorInfo` was absent at the time of launch, then `Status.message`
 **should not** change. See, "[Dynamic variables](#dynamic-variables)".
 
-**Warning:** **Use extreme caution** when changing `message` on
-`Status`. API consumers often treat the root-level error message as part
-of the API contract. They perform string matches on the text to
-differentiate one error for another. If there are dynamic segments in
-the error message, clients will often parse the text to extract these
-variables.
+**Warning:** **Use extreme caution** when changing `Status.message`. API
+consumers often treat this error message as part of the API contract.
+They perform string matches on the text to differentiate one error for
+another. Also, if there are dynamic segments in the error message,
+clients will often parse the text to extract these variables.
 
 A second error message **may** by included by adding
 [`google.rpc.LocalizedMessage`][LocalizedMessage] to

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -36,6 +36,8 @@ information or ask questions to help resolve the issue.
 A JSON representation of an error response might look like the
 following:
 
+<a name="sample"></a>
+
 ```json
 {
   "error": {

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -83,6 +83,33 @@ Each error response, **should** include `LocalizedMessage`. Both the
 change is backwards compatible, in most cases.  See, "[Changing error
 messages](#changing-error-messages)".
 
+#### Changing error messages
+
+Because the error message at the root of the payload **must not** change
+after it is launched, a new, additional error message **may** be added.
+The purpose of this change might be to add a message that a client
+application could display directly to end users. To do so, include
+[`LocalizedMessage`][LocalizedMessage] in the payload to enable the
+error payload to include a second, improved message.
+
+The field, `locale`, **must** be populated but **may** always contain
+the value of the service's default locale, e.g.  "en-US". While this
+means that the this additional error messages is not, in fact,
+localized, it provides the service owner with the opportunity to do so
+later.  Alternatively, the value of `locale` **may** change if the
+service is location aware. See, "[Localization](#localization)".
+
+When adding a new error messsage using `LocalizedMessage`, `ErrorInfo`
+**must** be introduced either before or at the same time. If there are
+dyanmic variables found in the message, the `ErrorInfo` field,
+`metadata`, **must** include all of these variables. (See, "[Dynamic
+variables](#dynamic-variables".)
+
+**Warning:** If `LocalizedMessage` is released without `ErrorInfo` and
+with an error message that includes dynamic segments, the error message
+**must not** be changed. To do so, would be backwards incompatible,
+effectively locking all error messages in the payload.
+
 #### Dynamic variables
 
 The best, actionable error messages include dynamic segments. These
@@ -93,20 +120,20 @@ Consider the following example:
 > East". It is expected to be available again on 2199-05-13.
 
 **Note:** The preceeding error message is made actionable by the
-context, both that orignates in the request, the title of the Book and
-the name of the Library, and by the information that is included, known
-only by the system, i.e. the expected return date of the Book.
+context, both that orignates from the request, the title of the Book and
+the name of the Library, and by the information that is  known only by
+the service, i.e. the expected return date of the Book.
 
 All dynamic variables found in error messages **must** also appear in
 the `map<string, string>` field, `metadata`, found on the *required*
-error details payload, `ErrorInfo`.  For example the `metadata` map for
-the example error message above **must** include *at least* the
-following key/value pairs:
+error details payload, `ErrorInfo`.  For example, the `metadata` map for
+the sample error message above **must** include *at least* the following
+key/value pairs:
 
 ```yaml
 bookTitle: "The Great Gatsby"
 library: "Garfield East"
-expectedDate: "2199-05-13"
+expectedReturnDate: "2199-05-13"
 ```
 
 Dynamic variables that do not appear in an error message **may** also be
@@ -115,34 +142,6 @@ to be used programmatically.
 
 Once present in `metadata`, keys **must** continue to be included in the
 map for the error response to be backwards compatible.
-
-#### Changing error messages
-
-An new, additional error message **may** be added. To so, include
-[`LocalizedMessage`][LocalizedMessage] in the payload so that the error
-payload includes a second, improved message. The purpose of this change
-might be to add a message that a client application might display
-directly to end users.
-
-The field, `locale`, **must** be populated but **may** always contain
-the value of the service's default locale, e.g.  "en-US". While this
-means that the this additional error messages is not, in fact,
-localized, it provides the service owner with the opportunity to do so
-later.  Alternatively, the value of `locale` **may** change if the
-service is location aware. See, "[Localization](#localization)".
-
-When adding a new error messsage, `ErrorInfo` **should** be introduced
-before `LocalizedMessage` or at the same time. If there are dyanmic
-variables found in the message, `ErrorInfo` **must** be introduced.
-Similarly, this **must** occurr at the same time as or before
-`LocalizedMessage` is released, and `metadata` **must** include all
-dynamic variables in the error message.
-
-**Warning:** If `LocalizedMessage` is released without `ErrorInfo` and
-with an error message that includes dynamic segments, the error message
-**must not** be changed. To so, would be considered a backwards
-incompatible change, effectively locking all error messages in the
-payload.
 
 #### Localization
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -72,7 +72,7 @@ For each error, the service **must** populate the `message` field on
 - both explains the error and offers an actionable resolution to it
   ([citation](https://cloud.google.com/apis/design/errors#error_model))
 
-**Note:** Sometimes a service might elect to always present
+**Note:** Sometimes a service will elect to always present
 `Status.message` in English rather than the application's native
 language so that messages are easily searchable in common knowledge
 bases, such as StackOverflow&trade;.
@@ -89,10 +89,7 @@ If your service's API design governing body decides that altering
 `Status.message` represents a backwards incompatible change, then
 `Status.message` **must not** change.
 
-If the error message in `Status.message` contains dynamic segments (see
-"[Dynamic variables](#dynamic-variables)"), and `ErrorInfo` was absent
-at the time of launch, then `Status.message` **should not** change.
-
+<a name="status-message-warning"></a>
 **Warning:** **Use extreme caution** when changing `Status.message`.
 API consumers often treat this error message as **part of the API
 contract**. Clients perform string matches on the text to differentiate
@@ -109,10 +106,11 @@ same as `Status.message` or it **may** be an alternate message.
 Reasons to present the same error message in both locations include the
 following:
 
-- It affords clients the ability to find a canonical error message in a
-  single location, `LocalizedMessaage.message`.
 - The service plans to localize either immediately or in the near
   future.  See, "[Localization](#localization)".
+- It affords clients the ability to find an error message consistently
+  in one location, `LocalizedMessaage.message`, across all methods of
+  the API Service.
 
 Reasons to present an error message in `LocalizedMessage.message` that
 differs from `Status.message` include the following:
@@ -124,17 +122,18 @@ differs from `Status.message` include the following:
 When including `LocalizedMessage`, both fields, `locale` and `message`,
 **must** be populated.  If the service is to be localized, the value of
 `locale` **must** change dynamically. See,
-"[Localization](#localization)". Otherwise, the service **must** present
-the service's default locale, e.g. "en-US", always.
+"[Localization](#localization)". Otherwise, `locale` **must** always
+present the service's default locale, e.g. "en-US".
 
 When adding an error message via `LocalizedMessage`, `ErrorInfo`
 **must** be introduced either before or at the same time. If there are
 dynamic segments found in the text, the values of these variables
-**must** be included in the `map<string, string>`, `ErrorInfo.metadata`.
-See, "[Dynamic variables](#dynamic-variables)".
+**must** be included `ErrorInfo.metadata`.  See, "[Dynamic
+variables](#dynamic-variables)".
 
 **Warning:** If `LocalizedMessage` is released without `ErrorInfo`, the
-same concerns regarding client misuse of textual error messages apply.
+same [concerns](#status-message-warning) regarding client misuse of
+textual error messages apply.
 
 #### Dynamic variables
 
@@ -164,11 +163,12 @@ expectedReturnDate: "2199-05-13"
 
 Dynamic variables that do not appear in an error message **may** also be
 included in `metadata` to provide additional information to the client
-to be used programmatically. Keys **must** be expressed as lower
-camel-case.
+to be used programmatically.
 
 Once present in `metadata`, keys **must** continue to be included in the
-map for the error payload to be backwards compatible.
+map for the error payload to be backwards compatible, even if the value
+for a particular key is empty. Keys **must** be expressed as lower
+camel-case.
 
 #### Localization
 
@@ -209,15 +209,13 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404).
 
 `ErrorInfo` is required because it further identifies an error. With
 only approximately twenty [available values][Code] for `Status.status`,
-it is almost always impossible to disambiguate one error from another
-across am entire [API Service][API Service].
+it is difficult to disambiguate one error from another across an entire
+[API Service][API Service].
 
-Error messages often contain dynamic segments that express variable
-information. These values are often parsed from the text using brittle
-extraction methods, like RegExp. To alleviate this risk, these values
-need to be included in the `map<string, string>` `ErrorInfo.metatdata`
-so that there is machine readable component for *every* error response
-that enables clients to use such information programmatically.
+Also, error messages often contain dynamic segments that express
+variable information, so that there is machine readable component for
+*every* error response that enables clients to use such information
+programmatically.
 
 ### LocalizedMessage
 


### PR DESCRIPTION
Introduces the concept that `LocalizedMessage` can be used to include a second error message aside from the debug message on `Status`. This message can be updated ongoingly. Further, explains how to use the `metadata` `map<string, string>` on `ErrorInfo` for dynamic variables found in error messages and otherwise.

Fixes: #1096