### PR TITLE
feat(AIP-203): require field behavior

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -16,18 +16,19 @@ behavior (for example, to optimize client library signatures).
 
 ## Guidance
 
-APIs **should** use the `google.api.field_behavior` annotation to describe
-well-understood field behavior, such as a field's being required, immutable, or
-output only:
+APIs use the `google.api.field_behavior` annotation to describe well-understood
+field behavior, such as a field's being required or immutable.
 
 ```proto
 // The audio data to be recognized.
 RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
-Additionally, APIs **may** use the `OPTIONAL` value to describe none of the
-above. However, it is never mandatory to explicitly describe a field as
-optional.
+APIs **must** use the `google.api.field_behavior` annotation on every message
+field and have one of [`REQUIRED`][], [`IMMUTABLE`][], or [`OUTPUT_ONLY`][].
+
+Fields with no annotation are interpreted as `OPTIONAL`, but this is for
+backwards-compatility and this annotation **must not** be omitted.
 
 **Note:** The vocabulary given in this document is for _descriptive_ purposes
 only, and does not itself add any validation. The purpose is to consistently
@@ -162,11 +163,36 @@ the user's behalf.
 A resource with an unordered list **may** return the list in a stable order, or
 **may** return the list in a randomized, unstable order.
 
+## Rationale
+
+### Requiring field behavior
+
+The field behavior annotation explicitly states the intended behavior of the
+resource which enables better documentation. In addition, requiring the
+annotation forces the API author to explicitly consider the behavior during
+authoring of the API.
+
+Modifying field behavior after initial authoring results in
+backwards-incompatible changes in clients. For example, making an optional field
+required results in backwards-incompatible changes in the method signature of
+an RPC, or the require property for an [IaC][] client.
+
+## History
+
+In 2023-05, field behavior was made mandatory due to required and immutable
+field behavior annotations being missed often, resulting in poor quality
+clients that had to deal with backward-incompatible changes.
+
+The cost of clients and API users addressing breaking changes outweighed the
+cost of a one-line annotation per field during API authoring.
+
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md
+[IaC]: ./0009.md#iac
 
 ## Changelog
 
+- **2023-05-10**: Added guidance to require the annotation.
 - **2020-12-15**: Added guidance for `UNORDERED_LIST`.
 - **2020-05-27**: Clarify behavior when receiving an immutable field in an
   update.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -170,7 +170,7 @@ A resource with an unordered list **may** return the list in a stable order, or
 
 By including the field behavior annotation for each field, the overall behavior
 that the resource exhibits is more clearly defined. Clearly defined field
-behavior enables improved programmatic clients and improves user understanding.
+behavior improves programmatic clients and user understanding.
 
 Requiring the annotation also forces the API author to explicitly consider the
 behavior when initially authoring of the API.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -24,7 +24,7 @@ field behavior, such as a field being required or immutable.
 RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
-- APIs **must** use the `google.api.field_behavior` annotation on every message.
+- APIs **must** use the `google.api.field_behavior` annotation on every field.
 - If an option described in this AIP accurately describes the behavior of the
   field, it **must** be annotated on the field.
 

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -25,7 +25,7 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
 APIs **must** use the `google.api.field_behavior` annotation on every message
-field and have one of [`REQUIRED`][], [`OPTIONAL`][], or [`OUTPUT_ONLY`][].
+field and must include every relevant option in this AIP.
 
 Fields with no annotation are interpreted as `OPTIONAL` for
 backwards-compatility, but this annotation **must not** be omitted.
@@ -179,9 +179,10 @@ an RPC, or the require property for an [IaC][] client.
 
 ## History
 
-In 2023-05, field behavior was made mandatory due to required and immutable
-field behavior annotations being missed often, resulting in poor quality
-clients that had to deal with backward-incompatible changes.
+In 2023-05, field behavior was made mandatory due to field behavior which define
+client behavior (e.g. required, output_only, immutable) often being missed,
+resulting in poor quality clients that had to deal with backward-incompatible
+changes with a major version revision.
 
 The cost of clients and API users addressing breaking changes outweighed the
 cost of a one-line annotation per field during API authoring.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -25,7 +25,7 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
 - APIs **must** apply the `google.api.field_behavior` annotation on every field.
-- The annotation **must** include any [`google.api.FieldBehavior`][] values that
+- The annotation **must** include any [google.api.FieldBehavior][] values that
   accurately describe the behavior of the field.
   - `FIELD_BEHAVIOR_UNSPECIFIED` **must not** be used.
 
@@ -198,7 +198,7 @@ surpass the costs to clients and API users of not doing so.
 
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md
-[FieldBehavior]: https://github.com/googleapis/googleapis/blob/master/google/api/field_behavior.proto#L49
+[google.api.FieldBehavior]: https://github.com/googleapis/googleapis/blob/master/google/api/field_behavior.proto#L49
 [IaC]: ./0009.md#iac
 
 ## Changelog

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -25,10 +25,10 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
 APIs **must** use the `google.api.field_behavior` annotation on every message
-field and have one of [`REQUIRED`][], [`IMMUTABLE`][], or [`OUTPUT_ONLY`][].
+field and have one of [`REQUIRED`][], [`OPTIONAL`][], or [`OUTPUT_ONLY`][].
 
-Fields with no annotation are interpreted as `OPTIONAL`, but this is for
-backwards-compatility and this annotation **must not** be omitted.
+Fields with no annotation are interpreted as `OPTIONAL` for
+backwards-compatility, but this annotation **must not** be omitted.
 
 **Note:** The vocabulary given in this document is for _descriptive_ purposes
 only, and does not itself add any validation. The purpose is to consistently

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -17,22 +17,23 @@ behavior (for example, to optimize client library signatures).
 ## Guidance
 
 APIs use the `google.api.field_behavior` annotation to describe well-understood
-field behavior, such as a field's being required or immutable.
+field behavior, such as a field being required or immutable.
 
 ```proto
 // The audio data to be recognized.
 RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
-APIs **must** use the `google.api.field_behavior` annotation on every message
-field and must include every relevant option in this AIP.
+- APIs **must** use the `google.api.field_behavior` annotation on every message.
+- If an option described in this AIP accurately describes the behavior of the
+  field, it **must** be annotated on the field.
 
 Fields with no annotation are interpreted as `OPTIONAL` for
-backwards-compatility, but this annotation **must not** be omitted.
+backwards-compatility. Nontheless, this annotation **must not** be omitted.
 
 **Note:** The vocabulary given in this document is for _descriptive_ purposes
 only, and does not itself add any validation. The purpose is to consistently
-document this behavior for users.
+document this behavior for clients.
 
 ## Vocabulary
 
@@ -167,25 +168,28 @@ A resource with an unordered list **may** return the list in a stable order, or
 
 ### Requiring field behavior
 
-The field behavior annotation explicitly states the intended behavior of the
-resource which enables better documentation. In addition, requiring the
-annotation forces the API author to explicitly consider the behavior during
-authoring of the API.
+By including the field behavior annotation for each field, the overall behavior
+that the resource exhibits is more clearly defined. Clearly defined field
+behavior enables improved programmatic clients and improves user understanding.
+
+Requiring the annotation also forces the API author to explicitly consider the
+behavior when initially authoring of the API.
 
 Modifying field behavior after initial authoring results in
 backwards-incompatible changes in clients. For example, making an optional field
-required results in backwards-incompatible changes in the method signature of
-an RPC, or the require property for an [IaC][] client.
+required, results in backwards-incompatible changes in the method signature of
+an RPC or a resource in an [IaC][] client.
 
 ## History
 
-In 2023-05, field behavior was made mandatory due to field behavior which define
-client behavior (e.g. required, output_only, immutable) often being missed,
-resulting in poor quality clients that had to deal with backward-incompatible
-changes with a major version revision.
+In 2023-05 field_behavior was made mandatory. Prior to this change, the
+annotation was often omitted. Its values, e.g. REQUIRED, OUTPUT_ONLY, and
+IMMUTABLE, are relied upon to produce high quality clients. Further, when the
+value is added after the fact or changes, within a major version, it is
+backwards-incompatible, which is likely to break clients.
 
-The cost of clients and API users addressing breaking changes outweighed the
-cost of a one-line annotation per field during API authoring.
+The benefits of requiring field_behavior, at the time that the API is authored,
+surpass the costs to clients and API users of not doing so.
 
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -24,9 +24,14 @@ field behavior, such as a field being required or immutable.
 RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
-- APIs **must** use the `google.api.field_behavior` annotation on every field.
-- If an option described in this AIP accurately describes the behavior of the
-  field, it **must** be annotated on the field.
+- APIs **must** apply the `google.api.field_behavior` annotation on every field.
+- The annotation **must** include any [`google.api.FieldBehavior`][] values that
+  accurately describe the behavior of the field.
+  - `FIELD_BEHAVIOR_UNSPECIFIED` **must not** be used.
+
+**Warning:** Although `field_behavior` does not impact proto-level behavior,
+many clients (e.g. CLIs and SDKs) rely on them to generate code. Thoroughly
+review and consider which values are relevant when adding a new field.
 
 Fields with no annotation are interpreted as `OPTIONAL` for
 backwards-compatility. Nontheless, this annotation **must not** be omitted.
@@ -193,6 +198,7 @@ surpass the costs to clients and API users of not doing so.
 
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md
+[FieldBehavior]: https://github.com/googleapis/googleapis/blob/master/google/api/field_behavior.proto#L49
 [IaC]: ./0009.md#iac
 
 ## Changelog


### PR DESCRIPTION
To reduce the likelihood of missed field behavior annotations,
require it for all message feilds.

further rationale is explained in the change of AIP-203.