### PR TITLE
fix(AIP-2510): fix resource id name

### DIFF
--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -127,7 +127,7 @@ message GetBookRequest {
 and if the value of `name` on such a request is,
 
 ```
-projects/my-project/libraries/67890/books/les-miserables
+projects/my-project/books/les-miserables
 ```
 
 then the value of the field, `name`, returned for the `Book`, should match: the


### PR DESCRIPTION
Fix the the value of `name` on get request to use the defined format by removing unwanted segment