### PR TITLE
fix(AIP-2510): add bold **should** resource ref

### DIFF
--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -73,7 +73,7 @@ Project identifiers also appear in [resource names][]. These resource
 names are used both to identify the resource itself and can refer to
 other resources ([example][]).
 
-When project identifiers are provided, the response should
+When project identifiers are provided, the response **should**
 include the identifier as it occurred in the request: if the project ID
 was provided it should be returned, and if the project number was
 provided, that is what should be in the response.
@@ -130,10 +130,10 @@ and if the value of `name` on such a request is,
 projects/my-project/books/les-miserables
 ```
 
-then the value of the field, `name`, returned for the `Book`, should match: the
-project ID and not the number should be returned. But, the value for the field,
-`shelf` should use the project number, as the create request had submitted a
-shelf with the project number in the resource name.
+then the value of the field, `name`, returned for the `Book`, **should** match:
+the project ID and not the number should be returned. But, the value for the
+field, `shelf` should use the project number, as the create request had
+submitted a shelf with the project number in the resource name.
 
 In other words, the following values should be returned:
 


### PR DESCRIPTION
The original PR missed the bolding to clarify it follows the RFC-2119 terminology.