### PR TITLE
feat(AIP-8): add requirement for counterexamples

### DIFF
--- a/aip/general/0008.md
+++ b/aip/general/0008.md
@@ -169,7 +169,7 @@ When using these terms in AIPs, they **must** be lower-case and **bold**. These
 terms **should not** be used in other ways.
 
 If "SHOULD" or "SHOULD NOT" are used, they **must** include valid examples of
-where the guidance can be ignored.
+where other concerns may override the guidance.
 
 **Important:** If rationale is used, it exists to provide background and a more
 complete understanding, but **must not** contain guidance (and RFC-2119 terms

--- a/aip/general/0008.md
+++ b/aip/general/0008.md
@@ -168,9 +168,12 @@ described in [RFC 2119][].
 When using these terms in AIPs, they **must** be lower-case and **bold**. These
 terms **should not** be used in other ways.
 
-**Important:** If an appendix is used, it exists to provide background and a
-more complete understanding, but **must not** contain guidance (and RFC-2119
-terms **must not** be used).
+If "SHOULD" or "SHOULD NOT" are used, they **must** include valid examples of
+where the guidance can be ignored.
+
+**Important:** If rationale is used, it exists to provide background and a more
+complete understanding, but **must not** contain guidance (and RFC-2119 terms
+**must not** be used).
 
 ### Code examples
 


### PR DESCRIPTION
should / should not guidance in the AIPs is vague, and leaves
the exercise of determining whether the guidance should be ignored
completely up to the reader.

Adding clear examples will help clarify the scenarios where it
makes sense to ignore the guidance.