### PR TITLE
Update the resource revisions guide using nested collections.

### DIFF
--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -27,94 +27,79 @@ to the version of an API as a whole.
 
 APIs **may** store a revision history for a resource if it is useful to users.
 
-APIs implementing resources with a revision history **must** provide a
-`revision_id` field on the resource:
+APIs implementing resources with a revision history **should** abstract resource revisions as nested collection of the resource. The
+resource revision type **should** inherit from the parent resource and has a field being the parent resource type.
 
 ```proto
-message Book {
-  // The name of the book.
-  string name = 1;
+message BookRevision {
+   // The name of the book revision.
+   string name = 1;
 
-  // Other fields…
-
-  // The revision ID of the book.
-  // A new revision is committed whenever the book is changed in any way.
-  // The format is an 8-character hexadecimal string.
-  string revision_id = 5 [
-    (google.api.field_behavior) = IMMUTABLE,
-    (google.api.field_behavior) = OUTPUT_ONLY];
+   // The snapshot of the book
+   Book book = 2 [(google.api.field_behavior) = IMMUTABLE];
 
   // The timestamp that the revision was created.
-  google.protobuf.Timestamp revision_create_time = 6
+  google.protobuf.Timestamp create_time = 3
     [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // tags set on the resource revisions by service or user.
+  repeated string tags = 4;
+  [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 ```
 
-- The resource **must** contain a `revision_id` field, which **should** be a
-  string and contain a short, automatically-generated random string. A good
-  rule of thumb is the last eight characters of a [UUID version 4 (random)](UUID4).
-  - The `revision_id` field **must** document when new revisions are created
-    (see [committing revisions](#committing-revisions) below).
-  - The `revision_id` field **should** document the format of revision IDs.
-- The resource **must** contain a `revision_create_time` field, which
+- The resource revision **must** contain a field representing the snapshot of the parent resource.
+- The resource revision **must** contain a `create_time` field, which
   **should** be a `google.protobuf.Timestamp` (see [AIP-142][]).
-
-**Note:** A randomly generated string is preferred over other methods, such as
-an auto-incrementing integer, because there is often a need to delete or revert
-revisions, and a randomly generated string holds up better in those situations.
+- The resource revision **may** contain a repeated field `tags` to represent tags that was set on the resource revision.
 
 ### Referencing revisions
 
-When it is necessary to refer to a specific revision of a resource, APIs
-**must** use the following syntax: `{resource_name}@{revision_id}`. For
-example:
+When referring to specific revision of a resource, APIs must use the following syntax
+`{resource_name}/revisions/{revision_id}`. For example:
 
-    publishers/123/books/les-miserables@c7cfa2a8
-
-**Note:** The `@` character is selected because it is the only character
-permitted by [RFC 1738 §2.2][] for special meaning within a URI scheme that is
-not already used elsewhere.
-
-APIs **should** generally accept a resource reference at a particular revision
-in any place where they ordinarily accept the resource name. However, they
-**must not** accept a revision in situations that mutate the resource, and
-should error with `INVALID_ARGUMENT` if one is given.
-
-**Important:** APIs **must not** require a revision ID, and **must** default to
-the current revision if one is not provided, except in methods specifically
-dealing with the revision history (such as rollback) where failing to require
-it would not make sense (or lead to dangerous mistakes).
+publishers/123/books/les-miserables/revisions/c7cfa2a8
 
 ### Getting a revision
 
-APIs implementing resource revisions **should** accept a resource name with a
-revision ID in the standard `Get` method ([AIP-131][]):
+APIs implementing resource revisions in the standard `Get` method ([AIP-131][]):
 
 ```proto
-message GetBookRequest {
-  // The name of the book.
+// Gets the details of a book revision.
+rpc GetBookRevision(GetBookRevisionRequest) returns (BookRevision) {
+  option (google.api.http) = {
+    get: "/v1/{name=publishers/*/books/*/revisions/*}"
+  };
+}
+
+message GetBookRevisionRequest {
+  // The name of the book revision.
   //   Example: publishers/123/books/les-miserables
   //
   // In order to retrieve a previous revision of the book, also provide
   // the revision ID.
-  //   Example: publishers/123/books/les-miserables@c7cfa2a8
+  //   Example: publishers/123/books/les-miserables/revisions/c7cfa2a8
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "library.googleapis.com/Book"
+      type: "library.googleapis.com/BookRevision"
     }];
 }
 ```
 
-If the user passes a revision ID that does not exist, the API **must** fail
-with a `NOT_FOUND` error.
+If the user passes a revision ID that does not exist, the API must fail with a `NOT_FOUND` error.
 
-APIs **must** return a `name` value corresponding to what the user sent. If the
-user sent a name with no revision ID, the returned `name` string **must not**
-include the revision ID either. Similarly, if the user sent a name with a
-revision ID, the returned `name` string **must** explicitly include it.
+The returned resource revision `should` be a different resource type from the parent resource type.
 
 ### Tagging revisions
+
+There are two types of tags: Server defined and user specified.
+
+Service may support `current`, `latest`, `oldest`, etc as preserved keyword tags.
+
+GET /v1/publishers/{publisher}/books/{book}/revisions/{preserved_keyword}
+
+Note that `publishers/{publisher}/books/{book}/revisions/latest` and `publishers/{publisher}/books/{book}` can differ. The latest revision may differ from the current status of the resource.
 
 APIs implementing resource revisions **may** provide a mechanism for users to
 tag a specific revision with a user provided name by implementing a "Tag
@@ -123,7 +108,7 @@ Revision" custom method:
 ```proto
 rpc TagBookRevision(TagBookRevisionRequest) returns (Book) {
   option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*}:tagRevision"
+    post: "/v1/{name=publishers/*/books/*/revisions/*}:tagRevision"
     body: "*"
   };
 }
@@ -131,11 +116,11 @@ rpc TagBookRevision(TagBookRevisionRequest) returns (Book) {
 
 ```proto
 message TagBookRevisionRequest {
-  // The name of the book to be tagged, including the revision ID.
+  // The name of the book revision to be tagged.
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "library.googleapis.com/Book"
+      type: "library.googleapis.com/BookRevision"
     }];
 
   // The tag to apply.
@@ -143,8 +128,7 @@ message TagBookRevisionRequest {
   string tag = 2 [(google.api.field_behavior) = REQUIRED];
 }
 ```
-
-- The `name` field **should** require an explicit revision ID to be provided.
+- The `name` field **should** require an explicit resource revision to be provided.
   - The field **should** be [annotated as required][aip-203].
   - The field **should** identify the [resource type][aip-123] that it
     references.
@@ -160,18 +144,15 @@ message TagBookRevisionRequest {
   succeed and the tag updated to point to the new requested revision ID. This
   allows users to write code against specific tags (e.g. `published`) and the
   revision can change in the background with no code change.
-
 ### Listing revisions
 
-APIs implementing resource revisions **should** provide a custom method for
-listing the revision history for a resource, with a structure similar to
-standard `List` methods ([AIP-132][]):
+APIs implementing resource revisions `should` provide a standard List method for listing the revision history for a resource
 
 ```proto
 rpc ListBookRevisions(ListBookRevisionsRequest)
     returns (ListBookRevisionsResponse) {
   option (google.api.http) = {
-    get: "/v1/{name=publishers/*/books/*}:listRevisions"
+    get: "/v1/{parent=publishers/*/books/*}/revisions"
   };
 }
 ```
@@ -179,7 +160,7 @@ rpc ListBookRevisions(ListBookRevisionsRequest)
 ```proto
 message ListBookRevisionsRequest {
   // The name of the book to list revisions for.
-  string name = 1 [
+  string parent = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
       type: "library.googleapis.com/Book"
@@ -195,7 +176,7 @@ message ListBookRevisionsRequest {
 
 message ListBookRevisionsResponse {
   // The revisions of the book.
-  repeated Book books = 1;
+  repeated BookRevision books = 1;
 
   // A token that can be sent as `page_token` to retrieve the next page.
   // If this field is omitted, there are no subsequent pages.
@@ -203,23 +184,7 @@ message ListBookRevisionsResponse {
 }
 ```
 
-While revision listing methods are mostly similar to standard `List` methods
-([AIP-132][]), the following important differences apply:
-
-- The first field in the request message **must** be called `name` rather than
-  `parent` (this is listing revisions for a specific book, not a collection of
-  books).
-- The URI **must** end with `:listRevisions`.
-- Revisions **must** be ordered in reverse chronological order. An `order_by`
-  field **should not** be provided.
-- The returned resources **must** include an explicit revision ID in the
-  resource's `name` field.
-  - If providing the full resource is expensive or infeasible, the revision
-    object **may** only populate the `string name`, `string revision_id`, and
-    `google.protobuf.Timestamp revision_create_time` fields instead. The
-    `string name` field **must** include the resource name and an explicit
-    revision ID, which can be used for an explicit `Get` request. The API
-    **must** document that it will do this.
+- Revisions must be ordered in reverse chronological order. An `order_by` field **should not** be provided in the list request.
 
 ### Child resources
 
@@ -234,17 +199,12 @@ there are two potential variants:
 If a child resource is a child of a single revision, the child resource's name
 **must** always explicitly include the parent's revision ID:
 
-    publishers/123/books/les-miserables@c7cfa2a8/pages/42
-
-In `List` requests for such resources, the service **should** default to the
-latest revision of the parent if the user does not specify one, but **must**
-explicitly include the parent's revision ID in the `name` field of resources in
-the response.
+    publishers/123/books/les-miserables/revisions/c7cfa2a8/pages/42
 
 If necessary, APIs **may** explicitly support listing child resources across
-parent revisions by accepting the `@-` syntax. For example:
+parent revisions by accepting the `-` syntax. For example:
 
-    GET /v1/publishers/123/books/les-miserables@-/pages
+    GET /v1/publishers/123/books/les-miserables/revisions/-/pages
 
 APIs **should not** include multiple levels of resources with revisions, as
 this quickly becomes difficult to reason about.
@@ -258,13 +218,13 @@ when to commit a new revision, such as:
 - Commit a new revision when something important happens
 - Commit a new revision when the user specifically asks
 
-APIs **may** use any of these strategies. APIs that want to commit a revision
-on user request **should** handle this with a `Commit` custom method:
+APIs **may** use any of these strategies. APIs that want to commit a revision on user request should
+handle this with a custom method on the resource:
 
 ```proto
-rpc CommitBook(CommitBookRequest) returns (Book) {
+rpc CommitBookRevision(CommitBookRevisionRequest) returns (BookRevision) {
   option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*}:commit"
+    post: "/v1/{name=publishers/*/books/*}:commitRevision"
     body: "*"
   };
 }
@@ -279,12 +239,11 @@ message CommitBookRequest {
 ```
 
 - The method **must** use the `POST` HTTP verb.
-- The method **should** return the resource, and the resource name **must**
-  include the revision ID.
+- The method **should** return a long running operation or resource revision.
 - The request message **must** include the `name` field.
-  - The field **should** be [annotated as required][aip-203].
-  - The field **should** identify the [resource type][aip-123] that it
-    references.
+- The `revision_id` of the resource revision **should** be a
+  string and contain a short, automatically-generated random string. A good
+  rule of thumb is the last eight characters of a [UUID version 4 (random)](UUID4).
 
 ### Rollback
 
@@ -293,7 +252,7 @@ back to a given revision. APIs **should** handle this with a `Rollback` custom
 method:
 
 ```proto
-rpc RollbackBook(RollbackBookRequest) returns (Book) {
+rpc RollbackBook(RollbackBookRequest) returns (BookRevision) {
   option (google.api.http) = {
     post: "/v1/{name=publishers/*/books/*}:rollback"
     body: "*"
@@ -302,8 +261,7 @@ rpc RollbackBook(RollbackBookRequest) returns (Book) {
 ```
 
 - The method **must** use the `POST` HTTP verb.
-- The method **should** return the resource, and the resource name **must**
-  include the revision ID.
+- The method **should** return a long running operation or resource revision.
 
 ```proto
 message RollbackBookRequest {
@@ -342,14 +300,13 @@ ranges of time.
 Revisions are sometimes expensive to store, and there are valid use cases to
 want to remove one or more revisions from a resource's revision history.
 
-APIs **may** define a method to delete revisions, with a structure similar to
-`Delete` ([AIP-135][]) methods:
+APIs **may** define a standard `Delete` ([AIP-135][]) method to delete resource revisions
 
 ```proto
 rpc DeleteBookRevision(DeleteBookRevisionRequest)
-    returns (Book) {
+    returns (google.protobuf.Empty) {
   option (google.api.http) = {
-    delete: "/v1/{name=publishers/*/books/*}:deleteRevision"
+    delete: "/v1/{name=publishers/*/books/*/revisions/*}"
   };
 }
 ```
@@ -359,50 +316,22 @@ message DeleteBookRevisionRequest {
   // The name of the book revision to be deleted, with a revision ID explicitly
   // included.
   //
-  // Example: publishers/123/books/les-miserables@c7cfa2a8
+  // Example: publishers/123/books/les-miserables/revisions/c7cfa2a8
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
     (google.api.resource_reference) = {
-      type: "library.googleapis.com/Book"
+      type: "library.googleapis.com/BookRevision"
     }];
 }
 ```
 
-- The request message **must** have a `name` field to identify the resource
-  revision being deleted.
-  - The explicit revision ID **must** be required (the method **must** fail
-    with `INVALID_ARGUMENT` if it is not provided, and **must not** default to
-    the latest revision).
-  - The field **should** be [annotated as required][aip-203].
-  - The field **should** identify the [resource type][aip-123] that it
-    references.
-- The API **must not** overload the `DeleteBook` method to serve both purposes
-  (this could lead to dangerous or confusing mistakes).
-- If the resource supports soft delete, then revisions of that resource
-  **should** also support soft delete.
-- The method **must not** cause the _resource_ to be deleted.
-  - Because a resource **should not** exist with zero revisions, the method
-    **must** fail with `FAILED_PRECONDITION` if the user attempts to delete the
-    only revision.
-- The response message **must** be the resource itself. There is no
-  `DeleteBookRevisionResponse`.
-  - The response **should** include the fully-populated resource unless it is
-    infeasible to do so.
-
-### Character Collision
-
-Most resource names have a restrictive set of characters, but some are very
-open. For example, Google Cloud Storage allows the `@` character in filenames,
-which are part of the resource name, and therefore uses the `#` character to
-indicate a revision.
-
-APIs **should** avoid permitting the `@` character in resource names, and if
-APIs that do permit it need to support resources with revisions, they
-**should** pick an appropriate separator depending on how and where the API is
-used, and **must** clearly document it.
+- Resource revisions **should** be automatically deleted on parent resource deletion.
+- If resource revisions meant to have longer lifespan than the parent resource, resource and resource revision
+should be side by side resource collections.
 
 ## Changelog
 
+- **2023-05-23**: Added a new AIP version of resource revisions.
 - **2021-04-27**: Added guidance on returning the resource from Delete Revision.
 
 [aip-123]: ./0123.md
@@ -411,5 +340,4 @@ used, and **must** clearly document it.
 [aip-135]: ./0135.md
 [aip-142]: ./0142.md
 [aip-203]: ./0203.md
-[rfc 1738 §2.2]: https://tools.ietf.org/html/rfc1738
 [UUID4]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)

--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -28,7 +28,7 @@ to the version of an API as a whole.
 APIs **may** store a revision history for a resource if it is useful to users.
 
 APIs implementing resources with a revision history **should** abstract resource revisions as nested collection of the resource. The
-resource revision type **should** inherit from the parent resource and has a field being the parent resource type.
+resource revision type **must** inherit from the parent resource and has a field being the parent resource type.
 
 ```proto
 message BookRevision {
@@ -50,10 +50,16 @@ message BookRevision {
 
 - The resource revision **must** contain a field representing the snapshot of the parent resource.
 - The resource revision **must** contain a `create_time` field, which
-  **should** be a `google.protobuf.Timestamp` (see [AIP-142][]).
+  **must** be a `google.protobuf.Timestamp` (see [AIP-142][]).
 - The resource revision **may** contain a repeated field `tags` to represent tags that was set on the resource revision.
 
-### Referencing revisions
+### When resource revisions are useful
+
+- When it is valuable to expose older versions of a resource via an API. This can avoid the overhead of the cusotmers having to write their own API to store and enable retrieval of revisions.
+- Oher resources depend on different revisions of a resource.
+- There is a need to visualize the change of a resource over time.
+
+### Resource names for revisions
 
 When referring to specific revision of a resource, APIs must use the following syntax
 `{resource_name}/revisions/{revision_id}`. For example:
@@ -62,44 +68,25 @@ publishers/123/books/les-miserables/revisions/c7cfa2a8
 
 ### Getting a revision
 
-APIs implementing resource revisions in the standard `Get` method ([AIP-131][]):
-
-```proto
-// Gets the details of a book revision.
-rpc GetBookRevision(GetBookRevisionRequest) returns (BookRevision) {
-  option (google.api.http) = {
-    get: "/v1/{name=publishers/*/books/*/revisions/*}"
-  };
-}
-
-message GetBookRevisionRequest {
-  // The name of the book revision.
-  //   Example: publishers/123/books/les-miserables
-  //
-  // In order to retrieve a previous revision of the book, also provide
-  // the revision ID.
-  //   Example: publishers/123/books/les-miserables/revisions/c7cfa2a8
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type: "library.googleapis.com/BookRevision"
-    }];
-}
-```
-
-If the user passes a revision ID that does not exist, the API must fail with a `NOT_FOUND` error.
-
-The returned resource revision `should` be a different resource type from the parent resource type.
+Services `should` implement the standard `Get` method ([AIP-131][])
 
 ### Tagging revisions
 
-There are two types of tags: Server defined and user specified.
+There are two types of tags: server defined and user specified.
 
-Service may support `current`, `latest`, `oldest`, etc as preserved keyword tags.
+#### Server defined
 
-GET /v1/publishers/{publisher}/books/{book}/revisions/{preserved_keyword}
+Services **may** reserve specific tags to be server-defined (e.g. `current`, `latest`), which are read-only and managed by the service.
 
-Note that `publishers/{publisher}/books/{book}/revisions/latest` and `publishers/{publisher}/books/{book}` can differ. The latest revision may differ from the current status of the resource.
+- `latest` represents the most recent created revision. The content of `publishers/{publisher}/books/{book}/revisions/latest` and `publishers/{publisher}/books/{book}` can differ. Because the latest revision may be different from the current state of the resource.
+
+```
+GET /v1/publishers/{publisher}/books/{book}/revisions/{reserved_keyword}
+```
+
+#### User Specified
+
+User specified tags are tags provided by the user when tagging specific resource revision.
 
 APIs implementing resource revisions **may** provide a mechanism for users to
 tag a specific revision with a user provided name by implementing a "Tag
@@ -108,7 +95,7 @@ Revision" custom method:
 ```proto
 rpc TagBookRevision(TagBookRevisionRequest) returns (Book) {
   option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*/revisions/*}:tagRevision"
+    post: "/v1/{name=publishers/*/books/*/revisions/*}:tag"
     body: "*"
   };
 }
@@ -136,55 +123,18 @@ message TagBookRevisionRequest {
   - Additionally, tags **should** restrict letters to lower-case.
 - Once a revision is tagged, the API **must** support using the tag in place of
   the revision ID in `name` fields.
-  - If the user sends a tag, the API **must** return the tag in the resource's
-    `name` field, but the revision ID in the resource's `revision_id` field.
-  - If the user sends a revision ID, the API **must** return the revision ID in
-    both the `name` field and the `revision_id` field.
+  - If the user sends a tag or revision ID, the API **must** return the revision ID in the resource's
+    `name` field.
 - If the user calls the `Tag` method with an existing tag, the request **must**
   succeed and the tag updated to point to the new requested revision ID. This
   allows users to write code against specific tags (e.g. `published`) and the
   revision can change in the background with no code change.
 ### Listing revisions
 
-APIs implementing resource revisions `should` provide a standard List method for listing the revision history for a resource
+Services `should` implement the standard `List` method ([AIP-132][])
 
-```proto
-rpc ListBookRevisions(ListBookRevisionsRequest)
-    returns (ListBookRevisionsResponse) {
-  option (google.api.http) = {
-    get: "/v1/{parent=publishers/*/books/*}/revisions"
-  };
-}
-```
 
-```proto
-message ListBookRevisionsRequest {
-  // The name of the book to list revisions for.
-  string parent = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type: "library.googleapis.com/Book"
-    }];
-
-  // The maximum number of revisions to return per page.
-  int32 page_size = 2;
-
-  // The page token, received from a previous ListBookRevisions call.
-  // Provide this to retrieve the subsequent page.
-  string page_token = 3;
-}
-
-message ListBookRevisionsResponse {
-  // The revisions of the book.
-  repeated BookRevision books = 1;
-
-  // A token that can be sent as `page_token` to retrieve the next page.
-  // If this field is omitted, there are no subsequent pages.
-  string next_page_token = 2;
-}
-```
-
-- Revisions must be ordered in reverse chronological order. An `order_by` field **should not** be provided in the list request.
+- By default, revisions in the list response **must** be ordered in reverse chronological order. User can supply `order_by` to override the default behavior.
 
 ### Child resources
 
@@ -235,15 +185,17 @@ message CommitBookRequest {
     (google.api.resource_reference) = {
       type: "library.googleapis.com/Book"
     }];
+  string tag = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 ```
 
 - The method **must** use the `POST` HTTP verb.
 - The method **should** return a long running operation or resource revision.
 - The request message **must** include the `name` field.
-- The `revision_id` of the resource revision **should** be a
+- The resource ID of the resource revision **should** be a
   string and contain a short, automatically-generated random string. A good
   rule of thumb is the last eight characters of a [UUID version 4 (random)](UUID4).
+- `tag` field is optional. If provided, revision created will have the tag set.
 
 ### Rollback
 
@@ -302,36 +254,37 @@ want to remove one or more revisions from a resource's revision history.
 
 APIs **may** define a standard `Delete` ([AIP-135][]) method to delete resource revisions
 
-```proto
-rpc DeleteBookRevision(DeleteBookRevisionRequest)
-    returns (google.protobuf.Empty) {
-  option (google.api.http) = {
-    delete: "/v1/{name=publishers/*/books/*/revisions/*}"
-  };
-}
-```
-
-```proto
-message DeleteBookRevisionRequest {
-  // The name of the book revision to be deleted, with a revision ID explicitly
-  // included.
-  //
-  // Example: publishers/123/books/les-miserables/revisions/c7cfa2a8
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type: "library.googleapis.com/BookRevision"
-    }];
-}
-```
-
 - Resource revisions **should** be automatically deleted on parent resource deletion.
 - If resource revisions meant to have longer lifespan than the parent resource, resource and resource revision
 should be side by side resource collections.
 
+## Rationale
+
+### Deprecate the @-based approach
+
+Historically, Resource revision was recommended to be referenced by `{resource_id}@{revision_id}`.
+
+It has several disadvantages:
+
+-  List revisions is a custom method (:listRevisions) on the resource collection
+-  Delete revision is a custom method on the resource collection
+-  Not visible in api discovery doc
+-  Resource ID cannot use `@`
+
+### Abstract revisions as nested collection
+
+Revisions being resources under nested collection make revisions a first class citizen. 
+
+- Revisions can offer standard get, list, and delete methods.
+- Revision has its own separate message type and inherits from the parent resource type. It retains the flexibility of extending new fields to revision resources.
+
+## History
+
+In 2023-06, revisions are abstracted as nested resource. Prior to this, revisions are more like extension of an existing resource by using `@` symbol. List and delete revisions are custom method on the resource collection. Getting revision shares the same method with get resource.
+
 ## Changelog
 
-- **2023-05-23**: Added a new AIP version of resource revisions.
+- **2023-06-21**: Added a new AIP version of resource revisions.
 - **2021-04-27**: Added guidance on returning the resource from Delete Revision.
 
 [aip-123]: ./0123.md

--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -27,8 +27,16 @@ to the version of an API as a whole.
 
 APIs **may** store a revision history for a resource if it is useful to users.
 
-APIs implementing resources with a revision history **should** abstract resource revisions as nested collection of the resource. The
-resource revision type **must** inherit from the parent resource and has a field being the parent resource type.
+APIs implementing resources with a revision history **should** abstract resource
+revisions as nested collection of the resource. Sometimes, the revisions 
+collection can be a top level collection, exception includes:
+
+- If resource revisions are meant to have longer lifespan than the parent 
+resource. In other words, resource revisions exist after the resource deletion.
+
+The resource revision type
+**must** inherit from the parent resource and has a field being the parent
+resource type.
 
 ```proto
 message BookRevision {
@@ -48,45 +56,95 @@ message BookRevision {
 }
 ```
 
-- The resource revision **must** contain a field representing the snapshot of the parent resource.
+- The resource revision **must** contain a field representing the snapshot of
+  the parent resource.
 - The resource revision **must** contain a `create_time` field, which
   **must** be a `google.protobuf.Timestamp` (see [AIP-142][]).
-- The resource revision **may** contain a repeated field `tags` to represent tags that was set on the resource revision.
+- The resource revision **may** contain a repeated field `tags` to represent
+  tags that was set on the resource revision.
 
 ### When resource revisions are useful
 
-- When it is valuable to expose older versions of a resource via an API. This can avoid the overhead of the cusotmers having to write their own API to store and enable retrieval of revisions.
-- Oher resources depend on different revisions of a resource.
+- When it is valuable to expose older versions of a resource via an API. This
+  can avoid the overhead of the customers having to write their own API to store
+  and enable retrieval of revisions.
+- Other resources depend on different revisions of a resource.
 - There is a need to visualize the change of a resource over time.
 
 ### Resource names for revisions
 
-When referring to specific revision of a resource, APIs must use the following syntax
-`{resource_name}/revisions/{revision_id}`. For example:
+Revisions **must** exist in a subcollection of the original resource. When 
+referring to specific revision of a resource, the subcollection name **must**
+named `revisions`. Resource revision has the name with the format
+ `{resource_name}/revisions/{revision_id}`. For example:
 
 publishers/123/books/les-miserables/revisions/c7cfa2a8
 
+### Creating revisions
+
+Depending on the resource, different APIs may have different strategies for
+when to create a new revision, such as:
+
+- Create a new revision any time that there is a change
+- Create a new revision when something important happens
+- Create a new revision when the user specifically asks
+
+APIs **may** use any of these strategies. APIs that want to create a revision on
+user request should handle this with a custom method on the resource:
+
+```proto
+rpc CommitBookRevision(CommitBookRevisionRequest) returns (BookRevision) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*}:commitRevision"
+    body: "*"
+  };
+}
+
+message CommitBookRequest {
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "library.googleapis.com/Book"
+    }];
+  string tag = 2 [(google.api.field_behavior) = OPTIONAL];
+}
+```
+
+- The method **must** use the `POST` HTTP verb.
+- The method **should** return a long running operation or resource revision.
+- The request message **must** include the `name` field.
+- The resource ID of the resource revision **should** be a string and contain a
+  short, automatically-generated random string. A good rule of thumb is the last
+  eight characters of a [UUID version 4 (random)](UUID4).
+- `tag` field is optional. If provided, revision created will have the tag set.
+
 ### Getting a revision
 
-Services `should` implement the standard `Get` method ([AIP-131][])
+Services `must` implement the standard `Get` method ([AIP-131][])
 
 ### Tagging revisions
 
-There are two types of tags: server defined and user specified.
+There are two types of tags: server and user specified.
 
-#### Server defined
+#### Server specified
 
-Services **may** reserve specific tags to be server-defined (e.g. `current`, `latest`), which are read-only and managed by the service.
+Services **may** reserve specific tags to be server-specified (e.g. `current`,
+`latest`), which are read-only and managed by the service.
 
-- `latest` represents the most recent created revision. The content of `publishers/{publisher}/books/{book}/revisions/latest` and `publishers/{publisher}/books/{book}` can differ. Because the latest revision may be different from the current state of the resource.
+- If a `latest` tag exists, it **must** represents the most recent created
+  revision.
+ The content of `publishers/{publisher}/books/{book}/revisions/latest` and
+  `publishers/{publisher}/books/{book}` can differ. Because the latest revision
+  may be different from the current state of the resource.
 
 ```
 GET /v1/publishers/{publisher}/books/{book}/revisions/{reserved_keyword}
 ```
 
-#### User Specified
+#### User specified
 
-User specified tags are tags provided by the user when tagging specific resource revision.
+User specified tags are tags provided by the user when tagging specific resource
+revision.
 
 APIs implementing resource revisions **may** provide a mechanism for users to
 tag a specific revision with a user provided name by implementing a "Tag
@@ -110,12 +168,13 @@ message TagBookRevisionRequest {
       type: "library.googleapis.com/BookRevision"
     }];
 
-  // The tag to apply.
-  // The tag should be at most 40 characters, and match `[a-z][a-z0-9-]{3,38}[a-z0-9]`.
+  // The tag to apply. The tag should be at most 40 characters, and match
+  // `[a-z][a-z0-9-]{3,38}[a-z0-9]`.
   string tag = 2 [(google.api.field_behavior) = REQUIRED];
 }
 ```
-- The `name` field **should** require an explicit resource revision to be provided.
+- The `name` field **should** require an explicit resource revision to be
+  provided.
   - The field **should** be [annotated as required][aip-203].
   - The field **should** identify the [resource type][aip-123] that it
     references.
@@ -123,18 +182,19 @@ message TagBookRevisionRequest {
   - Additionally, tags **should** restrict letters to lower-case.
 - Once a revision is tagged, the API **must** support using the tag in place of
   the revision ID in `name` fields.
-  - If the user sends a tag or revision ID, the API **must** return the revision ID in the resource's
-    `name` field.
+  - If the user sends a tag or revision ID, the API **must** return the revision
+    ID in the resource's `name` field.
 - If the user calls the `Tag` method with an existing tag, the request **must**
   succeed and the tag updated to point to the new requested revision ID. This
   allows users to write code against specific tags (e.g. `published`) and the
   revision can change in the background with no code change.
 ### Listing revisions
 
-Services `should` implement the standard `List` method ([AIP-132][])
+Services `must` implement the standard `List` method ([AIP-132][])
 
-
-- By default, revisions in the list response **must** be ordered in reverse chronological order. User can supply `order_by` to override the default behavior.
+- By default, revisions in the list response **must** be ordered in reverse
+  chronological order. User can supply `order_by` to override the default
+  behavior.
 
 ### Child resources
 
@@ -146,56 +206,8 @@ there are two potential variants:
 - Child resources where each child resource is a child of _a single revision
   of_ the parent resource.
 
-If a child resource is a child of a single revision, the child resource's name
-**must** always explicitly include the parent's revision ID:
-
-    publishers/123/books/les-miserables/revisions/c7cfa2a8/pages/42
-
-If necessary, APIs **may** explicitly support listing child resources across
-parent revisions by accepting the `-` syntax. For example:
-
-    GET /v1/publishers/123/books/les-miserables/revisions/-/pages
-
 APIs **should not** include multiple levels of resources with revisions, as
 this quickly becomes difficult to reason about.
-
-### Committing revisions
-
-Depending on the resource, different APIs may have different strategies for
-when to commit a new revision, such as:
-
-- Commit a new revision any time that there is a change
-- Commit a new revision when something important happens
-- Commit a new revision when the user specifically asks
-
-APIs **may** use any of these strategies. APIs that want to commit a revision on user request should
-handle this with a custom method on the resource:
-
-```proto
-rpc CommitBookRevision(CommitBookRevisionRequest) returns (BookRevision) {
-  option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*}:commitRevision"
-    body: "*"
-  };
-}
-
-message CommitBookRequest {
-  string name = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference) = {
-      type: "library.googleapis.com/Book"
-    }];
-  string tag = 2 [(google.api.field_behavior) = OPTIONAL];
-}
-```
-
-- The method **must** use the `POST` HTTP verb.
-- The method **should** return a long running operation or resource revision.
-- The request message **must** include the `name` field.
-- The resource ID of the resource revision **should** be a
-  string and contain a short, automatically-generated random string. A good
-  rule of thumb is the last eight characters of a [UUID version 4 (random)](UUID4).
-- `tag` field is optional. If provided, revision created will have the tag set.
 
 ### Rollback
 
@@ -252,17 +264,24 @@ ranges of time.
 Revisions are sometimes expensive to store, and there are valid use cases to
 want to remove one or more revisions from a resource's revision history.
 
-APIs **may** define a standard `Delete` ([AIP-135][]) method to delete resource revisions
+APIs **may** define a standard `Delete` ([AIP-135][]) method to delete resource
+revisions
 
-- Resource revisions **should** be automatically deleted on parent resource deletion.
-- If resource revisions meant to have longer lifespan than the parent resource, resource and resource revision
-should be side by side resource collections.
+- Resource revisions **should** be automatically deleted on parent resource
+  hard deletion. If the parent resource is soft deleted, resource revisions 
+  under it **should** be soft deleted.
 
 ## Rationale
 
 ### Deprecate the @-based approach
 
-Historically, Resource revision was recommended to be referenced by `{resource_id}@{revision_id}`.
+Historically, Resource revision was recommended to be referenced by
+`{resource_id}@{revision_id}`.
+
+It has several advantages:
+
+- The ability of handling a revision resource or a normal resource in the 
+same way.
 
 It has several disadvantages:
 
@@ -273,18 +292,24 @@ It has several disadvantages:
 
 ### Abstract revisions as nested collection
 
-Revisions being resources under nested collection make revisions a first class citizen. 
+Revisions being resources under nested collection make revisions a first class
+citizen. 
 
 - Revisions can offer standard get, list, and delete methods.
-- Revision has its own separate message type and inherits from the parent resource type. It retains the flexibility of extending new fields to revision resources.
+- Revision has its own separate message type and inherits from the parent
+  resource type. It retains the flexibility of extending new fields to revision
+  resources.
 
 ## History
 
-In 2023-06, revisions are abstracted as nested resource. Prior to this, revisions are more like extension of an existing resource by using `@` symbol. List and delete revisions are custom method on the resource collection. Getting revision shares the same method with get resource.
+In 2023-07, revisions are abstracted as nested resource. Prior to this,
+revisions are more like extension of an existing resource by using `@` symbol.
+List and delete revisions are custom method on the resource collection. Getting
+revision shares the same method with get resource.
 
 ## Changelog
 
-- **2023-06-21**: Added a new AIP version of resource revisions.
+- **2023-07-05**: Added a new AIP version of resource revisions.
 - **2021-04-27**: Added guidance on returning the resource from Delete Revision.
 
 [aip-123]: ./0123.md


### PR DESCRIPTION
Per discussed with Yusuke, it would be good to have a PR in flight to facilitate making progress

This PR includes:

1. Rewrite the AIP-162 guide with the idea of implementing resource revisions as nested collections.
2. Try to keep most non-conflicting parts of existing guide.