### PR TITLE
feat (AIP-136) Update guidance of billable stateless methods

### DIFF
--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -2,7 +2,7 @@
 id: 136
 state: approved
 created: 2019-01-25
-updated: 2023-03-02
+updated: 2023-05-31
 placement:
   category: operations
   order: 100
@@ -127,7 +127,6 @@ rpc TranslateText(TranslateTextRequest) returns (TranslateTextResponse) {
 - The URI **should** place both the verb and noun after the `:` separator
   (avoid a "faux collection key" in the URI in this case, as there is no
   collection). For example, `:translateText` is preferable to `text:translate`.
-- Stateless methods **must** use `POST` if they involve billing.
 
 ### Declarative-friendly resources
 
@@ -174,8 +173,17 @@ RPC name itself causes confusion, and can even cause issues for client libraries
 which generate both synchronous and asynchronous methods to call the RPC in some
 languages.
 
+### Choice of HTTP methods for stateless methods
+
+Stateless method **should** use `GET` HTTP method for retrieval use cases due to
+its cache-friendly nature. This can reduce the costs for both the server and the
+client.
+
 ## Changelog
 
+- **2023-05-31:** Remove the guidance that stateless methods involving
+  billing should use POST. Clarify the choice of HTTP methods for stateless
+  methods.
 - **2023-05-16:** Added prohibition of the term "async" within RPC names.
 - **2023-05-09:** Adding guidance for POST and GET, require parent instead of
   the resource singular.

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -180,6 +180,9 @@ it is doing data retrieval. Stateless methods that are cacheable and send no
 payload **should** use `GET` HTTP method due to its cache-friendly nature. 
 This can reduce the costs for both the server and the client.
 
+If the stateless method is not cacheable by design, it **should** use `POST`
+HTTP method to prevent the response being cached.
+
 ## Changelog
 
 - **2023-05-31:** Remove the guidance that stateless methods involving

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -2,7 +2,7 @@
 id: 136
 state: approved
 created: 2019-01-25
-updated: 2023-05-31
+updated: 2023-06-06
 placement:
   category: operations
   order: 100
@@ -185,7 +185,7 @@ HTTP method to prevent the response being cached.
 
 ## Changelog
 
-- **2023-05-31:** Remove the guidance that stateless methods involving
+- **2023-06-06:** Remove the guidance that stateless methods involving
   billing should use POST. Clarify the choice of HTTP methods for stateless
   methods.
 - **2023-05-16:** Added prohibition of the term "async" within RPC names.

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -175,9 +175,10 @@ languages.
 
 ### Choice of HTTP methods for stateless methods
 
-Stateless method **should** use `GET` HTTP method for retrieval use cases due to
-its cache-friendly nature. This can reduce the costs for both the server and the
-client.
+HTTP clients such as browsers often cache `GET` responses as `GET` implies that
+it is doing data retrieval. Stateless methods that are cacheable and send no
+payload **should** use `GET` HTTP method due to its cache-friendly nature. 
+This can reduce the costs for both the server and the client.
 
 ## Changelog
 

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -180,9 +180,6 @@ it is doing data retrieval. Stateless methods that are cacheable and send no
 payload **should** use `GET` HTTP method due to its cache-friendly nature. 
 This can reduce the costs for both the server and the client.
 
-If the stateless method is not cacheable by design, it **should** use `POST`
-HTTP method to prevent the response being cached.
-
 ## Changelog
 
 - **2023-06-06:** Remove the guidance that stateless methods involving


### PR DESCRIPTION
Proposes changes for AIP-136 regarding the use of GET and POST for stateless methods.