### PR TITLE
Update 0193.md

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -101,7 +101,7 @@ For each error, the service **must** populate the `message` field on
 [`google.rpc.Status`][Status]. This error message,
 
 - is a developer-facing, human-readable "debug message"
-- is presented in the service's native language
+- is presented in English
 - both explains the error and offers an actionable resolution to it
   ([citation](https://cloud.google.com/apis/design/errors#error_model))
 


### PR DESCRIPTION
According to the API readability exam solutions *Error messages must be in English*. Is the exam or these docs correct?