### PR TITLE
fix(AIP-122): remove redundant guidance on user-settable

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -108,30 +108,22 @@ A resource ID segment identifies the resource within its parent collection. In
 the resource name `publishers/123/books/les-miserables`, `123` is the resource
 ID for the publisher, and `les-miserables` is the resource ID for the book.
 
-- Resource IDs **may** be either always set by users (required on resource
-  creation), optionally set by users (optional on resource creation,
-  server-generated if unset), or never set by users (not accepted at resource
-  creation). They **should** be immutable once created.
-  - If resource IDs are user-settable, the API **must** document allowed
-    formats. User-settable resource IDs **should** conform to [RFC-1034][];
-    which restricts to letters, numbers, and hyphen, with the first character
-    a letter, the last a letter or a number, and a 63 character maximum.
-    - Additionally, user-settable resource IDs **should** restrict letters to
-      lower-case (`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`).
-    - Characters outside of ASCII **should not** be permitted; however, if
-      Unicode characters are necessary, APIs **must** follow guidance in
-      [AIP-210][].
-    - User-settable IDs **should not** be permitted to be a UUID (or any value
-      that syntactically appears to be a UUID).
-  - If resource IDs are not user-settable, the API **should** document the
-    basic format, and any upper boundaries (for example, "at most 63
-    characters").
-  - For more information, see the [create][] standard method.
+- If resource IDs are user-specified, the API **must** document allowed
+  formats. User-specified resource IDs **should** conform to [RFC-1034][];
+  which restricts to letters, numbers, and hyphen, with the first character
+  a letter, the last a letter or a number, and a 63 character maximum.
+  - Additionally, user-specified resource IDs **should** restrict letters to
+    lower-case (`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`).
+  - Characters outside of ASCII **should not** be permitted; however, if
+    Unicode characters are necessary, APIs **must** follow guidance in
+    [AIP-210][].
+  - User-specified IDs **should not** be permitted to be a UUID (or any value
+    that syntactically appears to be a UUID).
+- If resource IDs are not user-settable, the API **should** document the
+  basic format, and any upper boundaries (for example, "at most 63
+  characters").
+- For more information, see the [create][] standard method.
 
-**Important:** Resources that are declarative-friendly ([AIP-128][]) **must** use
-user-settable resource IDs.
-
-[aip-128]: ./0128.md
 [create]: ./0133.md#user-specified-ids
 [rfc-1034]: https://tools.ietf.org/html/rfc1034
 

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -175,16 +175,16 @@ NOT_FOUND errors][permission-denied].
 
 ## Rationale
 
-### Requiring client-settable ids
+### Requiring user-specified ids
 
 [IaC][] clients use the resource ID as a way to identify a resource for applying
-updates and for conflict resolution. The lack of a client-settable ID means a
+updates and for conflict resolution. The lack of a user-specified ID means a
 client is unable to find the resource unless they store the identifier locally,
 and can result in re-creating the resource. This in turn has a downstream effect
 on all resources that reference it, forcing them to update to the the ID of the
 newly-created resource.
 
-Having a client-settable ID also means the client can precalculate the resource
+Having a user-specified ID also means the client can precalculate the resource
 name and use it in references from other resources.
 
 [aip-121]: ./0121.md
@@ -201,7 +201,8 @@ name and use it in references from other resources.
 ## Changelog
 
 - **2023-05-11**: Changing guidance around resource_id to a must.
-- **2022-11-04**: Referencing aggregated error guidance in AIP-193, similar to other CRUDL AIPs.
+- **2022-11-04**: Referencing aggregated error guidance in AIP-193, similar to
+  other CRUDL AIPs.
 - **2022-06-02**: Changed suffix descriptions to eliminate superfluous "-".
 - **2020-10-06**: Added declarative-friendly guidance.
 - **2020-08-14**: Updated error guidance to use permission denied over


### PR DESCRIPTION
Guidance on user-settable IDs are already defined in AIP-133.

Reiterating the guidance in AIP-122 is redundant and can make maintaining
guidance more difficult.

Also consolidating terminlogy to "user-specified" IDs, which is
how it is currently referred to.