### PR TITLE
fix(AIP-149): differentiate field presence and behavior

### DIFF
--- a/aip/general/0149.md
+++ b/aip/general/0149.md
@@ -38,3 +38,29 @@ message Book {
 value and unset most of the time; if an alternative design does not require
 such a distinction, it is usually preferred. In practice, this means `optional`
 **should** only ever be used for integers and floats.
+
+**Important:** Tracking field presence is *not* the same as documenting API
+field behavior as defined in [AIP-203][]. For example, a field labeled with
+`optional` for presence tracking **may** also be annotated as
+`google.api.field_behavior = REQUIRED` if the field must be set. If you only
+want to document the server perceived behavior of a field, read [AIP-203][].
+
+## Rationale
+
+### `optional` and field behavior
+
+The field behavior annotation and `optional` label are not mutually exclusive,
+because they address different problems. The former,
+`google.api.field_behavior`, focuses on communicating the server's perception of
+a field within the API e.g. if it is required or not, if it is immutable, etc.
+The latter, proto3's `optional`, is a wire format and code generation option
+that is strictly for toggling field presence tracking. While it might be
+confusing for a field to be simultaneously annotated with
+`google.api.field_behavior = REQUIRED` and labeled as `optional`, they are
+unrelated in practice and can reasonably be used together.
+
+## Changelog
+
+- **2023-06-20**: Differentiate from field behavior documentation
+
+[AIP-203]: ./0203.md

--- a/aip/general/0149.md
+++ b/aip/general/0149.md
@@ -47,7 +47,7 @@ want to document the server perceived behavior of a field, read [AIP-203][].
 
 ## Rationale
 
-### `optional` and field behavior
+### field behavior and `optional`
 
 The field behavior annotation and `optional` label are not mutually exclusive,
 because they address different problems. The former,


### PR DESCRIPTION
An internal discussion determined that `google.api.field_behavior` and `proto3_optional` are separate features and can be used simultaneously. See Rationale in this PR for more detailed reasoning.

Updates: https://github.com/googleapis/api-linter/issues/1169