### PR TITLE
feat AIP-127: Add comment that multiple binding allows mixed POST and GET

### DIFF
--- a/aip/general/0127.md
+++ b/aip/general/0127.md
@@ -116,6 +116,9 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
       post: "/v1/books"
       body: "book"
     }
+    additional_bindings: {
+      get: "/v1/books:Create"
+    }
   };
 }
 ```
@@ -124,11 +127,14 @@ rpc CreateBook(CreateBookRequest) returns (Book) {
   identical to the `google.api.http` annotation (in fact, it is a recursive
   reference).
 - RPCs **must not** define an additional binding within an additional binding.
-- The `body` clause **must** be identical in the top-level annotation and each
-  additional binding.
+- The `body` clause **must** be identical for `POST` methods in the top-level
+  annotation and each additional binding.
+- One RPC can have HTTP bindings to both `GET` and `POST`.
 
 ## Changelog
 
+- **2023-07-06**: Added the comment that it is possible to allow multiple uri
+  bindings with both HTTP `GET` and `POST`.
 - **2022-08-18**: Added the comment that query string parameter names are
   in camelCase.
 - **2021-01-06**: Added clarification around `body` and nested fields.


### PR DESCRIPTION
feat AIP-127: Add comment that multiple binding allows mixed POST and GET