### PR TITLE
 feat(AIP-203): document field behavior compatibility

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -284,6 +284,7 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
+- **2023-07-17**: Make `update_mask` name guidance a **must**.
 - **2022-11-04**: Aggregated error guidance to AIP-193.
 - **2022-06-02**: Changed suffix descriptions to eliminate superfluous "-".
 - **2021-11-04**: Changed the permission check if `allow_missing` is set.

--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -146,3 +146,7 @@ service considers invalid).
 When writing data, field masks **should** return an `INVALID_ARGUMENT` error if
 an entry points to a value that can not exist; however, the service **may**
 permit deletions.
+
+## Changelog
+
+- **2023-07-17**: Move `update_mask` guidance to AIP-134.

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -139,6 +139,30 @@ code, as such changes will be seen as breaking by those users.
 whether a proposed change is likely to break users, and an expansive reading of
 this guidance could ostensibly prevent _any_ change (which is not the intent).
 
+#### Field behavior compatibility
+
+The behavior of field within an API, whether it is required, whether it is only
+presented as output and not accepted as input, or vice versa, is documented with
+the `google.api.field_behavior` annotation as described in [AIP-203][]. Changing
+the value of this annotation can represent a semantic change in the API that is
+percevied as incompatible for existing clients. The following are examples of
+backwards incompatible changes with `google.api.field_behavior`:
+
+* Adding `REQUIRED` to an existing field previously considered `OPTIONAL`
+(implicitly or otherwise).
+* Adding `OUTPUT_ONLY` to an existing field previously accepted as input
+* Removing `OUTPUT_ONLY` from an existing field previously ignored as input
+* Adding `INPUT_ONLY` to an existing field previously emitted as output
+* Adding `IMMUTABLE` to an existing field previously considered mutable
+* Removing `IMMUTABLE` from an existing field previously considered immutable
+
+There are some changes that *are* compatible, which are as follows:
+
+* Adding `OPTIONAL` to an existing field
+* Changing from `REQUIRED` to `OPTIONAL` on an existing field
+* Removing `REQUIRED` from an existing field
+* Removing `INPUT_ONLY` from an existing field previosuly excluded in responses
+
 #### Default values must not change
 
 Default values are the values set by servers for resources when they are not
@@ -236,6 +260,7 @@ version.
 
 ## Changelog
 
+- **2023-07-20**: Added field behavior compatibility section.
 - **2022-08-11**: Added "Moving components between files" section.
 - **2022-06-01**: Added more links to other AIPs with compatibility concerns
 - **2019-12-16**: Clarified that moving existing fields into oneofs is
@@ -246,6 +271,7 @@ version.
 [aip-151]: ./0151.md
 [aip-158]: ./0158.md
 [aip-181]: ./0181.md
+[aip-203]: ./0203.md
 [aip-4231]: ./client-libraries/4231.md
 [aip-4232]: ./client-libraries/4232.md
 [ec2]: https://aws.amazon.com/blogs/aws/theyre-here-longer-ec2-resource-ids-now-available/

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -154,7 +154,6 @@ backwards incompatible changes with `google.api.field_behavior`:
 * Removing `OUTPUT_ONLY` from an existing field previously ignored as input
 * Adding `INPUT_ONLY` to an existing field previously emitted as output
 * Adding `IMMUTABLE` to an existing field previously considered mutable
-* Removing `IMMUTABLE` from an existing field previously considered immutable
 
 There are some changes that *are* compatible, which are as follows:
 
@@ -162,6 +161,7 @@ There are some changes that *are* compatible, which are as follows:
 * Changing from `REQUIRED` to `OPTIONAL` on an existing field
 * Removing `REQUIRED` from an existing field
 * Removing `INPUT_ONLY` from an existing field previously excluded in responses
+* Removing `IMMUTABLE` from an existing field previously considered immutable
 
 #### Default values must not change
 

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -155,7 +155,7 @@ backwards incompatible changes with `google.api.field_behavior`:
 * Adding `INPUT_ONLY` to an existing field previously emitted as output
 * Adding `IMMUTABLE` to an existing field previously considered mutable
 
-There are some changes that *are* compatible, which are as follows:
+There are some changes that *are* backwards-compatible, which are as follows:
 
 * Adding `OPTIONAL` to an existing field
 * Changing from `REQUIRED` to `OPTIONAL` on an existing field

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -161,7 +161,7 @@ There are some changes that *are* compatible, which are as follows:
 * Adding `OPTIONAL` to an existing field
 * Changing from `REQUIRED` to `OPTIONAL` on an existing field
 * Removing `REQUIRED` from an existing field
-* Removing `INPUT_ONLY` from an existing field previosuly excluded in responses
+* Removing `INPUT_ONLY` from an existing field previously excluded in responses
 
 #### Default values must not change
 

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -145,7 +145,7 @@ The behavior of field within an API, whether it is required, whether it is only
 presented as output and not accepted as input, or vice versa, is documented with
 the `google.api.field_behavior` annotation as described in [AIP-203][]. Changing
 the value of this annotation can represent a semantic change in the API that is
-percevied as incompatible for existing clients. The following are examples of
+perceived as incompatible for existing clients. The following are examples of
 backwards incompatible changes with `google.api.field_behavior`:
 
 * Adding `REQUIRED` to an existing field previously considered `OPTIONAL`

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -139,30 +139,6 @@ code, as such changes will be seen as breaking by those users.
 whether a proposed change is likely to break users, and an expansive reading of
 this guidance could ostensibly prevent _any_ change (which is not the intent).
 
-#### Field behavior compatibility
-
-The behavior of field within an API, whether it is required, whether it is only
-presented as output and not accepted as input, or vice versa, is documented with
-the `google.api.field_behavior` annotation as described in [AIP-203][]. Changing
-the value of this annotation can represent a semantic change in the API that is
-perceived as incompatible for existing clients. The following are examples of
-backwards incompatible changes with `google.api.field_behavior`:
-
-* Adding `REQUIRED` to an existing field previously considered `OPTIONAL`
-(implicitly or otherwise).
-* Adding `OUTPUT_ONLY` to an existing field previously accepted as input
-* Removing `OUTPUT_ONLY` from an existing field previously ignored as input
-* Adding `INPUT_ONLY` to an existing field previously emitted as output
-* Adding `IMMUTABLE` to an existing field previously considered mutable
-
-There are some changes that *are* backwards-compatible, which are as follows:
-
-* Adding `OPTIONAL` to an existing field
-* Changing from `REQUIRED` to `OPTIONAL` on an existing field
-* Removing `REQUIRED` from an existing field
-* Removing `INPUT_ONLY` from an existing field previously excluded in responses
-* Removing `IMMUTABLE` from an existing field previously considered immutable
-
 #### Default values must not change
 
 Default values are the values set by servers for resources when they are not
@@ -252,6 +228,7 @@ version.
 
 ## Further reading
 
+- For compatibility around field behavior, see [AIP-203][].
 - For compatibility around pagination, see [AIP-158][].
 - For compatibility around long-running operations, see [AIP-151][].
 - For understanding stability levels and expectations, see [AIP-181][].
@@ -260,7 +237,7 @@ version.
 
 ## Changelog
 
-- **2023-07-20**: Added field behavior compatibility section.
+- **2023-07-20**: Added reference to field behavior compatibility.
 - **2022-08-11**: Added "Moving components between files" section.
 - **2022-06-01**: Added more links to other AIPs with compatibility concerns
 - **2019-12-16**: Clarified that moving existing fields into oneofs is

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -189,16 +189,18 @@ an RPC or a resource in an [IaC][] client.
 ## History
 
 In 2023-05 field_behavior was made mandatory. Prior to this change, the
-annotation was often omitted. Its values, e.g. REQUIRED, OUTPUT_ONLY, and
-IMMUTABLE, are relied upon to produce high quality clients. Further, when the
-value is added after the fact or changes, within a major version, it is
-backwards-incompatible, which is likely to break clients.
+annotation was often omitted. Its values are relied upon to produce high quality
+clients. Further, when a value other than OPTIONAL is added after the fact or 
+any of the values are changed on an existing annotation within a major version,
+it is backwards-incompatible, which is likely to break clients. See [AIP-180][]
+for more.
 
 The benefits of requiring field_behavior, at the time that the API is authored,
 surpass the costs to clients and API users of not doing so.
 
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md
+[aip-180]: ./0180.md
 [google.api.FieldBehavior]: https://github.com/googleapis/googleapis/blob/master/google/api/field_behavior.proto#L49
 [IaC]: ./0009.md#iac
 

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -181,22 +181,21 @@ behavior improves programmatic clients and user understanding.
 Requiring the annotation also forces the API author to explicitly consider the
 behavior when initially authoring of the API.
 
-Modifying field behavior after initial authoring results in
-backwards-incompatible changes in clients, _unless_ it is to add OPTIONAL to an
-unannotated field. For example, making an optional field required, results in 
-backwards-incompatible changes in the method signature of an RPC or a resource
-in an [IaC][] client.
+Modifying field behavior after initial authoring can result in
+backwards-incompatible changes in clients. For example, making an optional field
+required results in backwards-incompatible changes in the method signature of an
+RPC or a resource in an [IaC][] client. See [AIP-180][] for more detailed
+compatibility guidance.
 
 ## History
 
 In 2023-05 field_behavior was made mandatory. Prior to this change, the
 annotation was often omitted. Its values are relied upon to produce high quality
-clients. Further, when a value other than OPTIONAL is added after the fact or 
-any of the values are changed on an existing annotation within a major version,
-it is backwards-incompatible, which is likely to break clients. See [AIP-180][]
-for more.
+clients. Furthermore, adding or changing some of the field_behavior values after
+the fact within a major version can be backwards-incompatible. See [AIP-180][]
+for more detailed compatibility guidance.
 
-The benefits of requiring field_behavior, at the time that the API is authored,
+The benefits of requiring field_behavior at the time that the API is authored
 surpass the costs to clients and API users of not doing so.
 
 [aip-133]: ./0133.md
@@ -207,8 +206,7 @@ surpass the costs to clients and API users of not doing so.
 
 ## Changelog
 
-- **2023-07-17**: Clarify statements regarding compatibility of changes to the
-  field_behavior annotation on a field.
+- **2023-07-20**: Clarify compatibility guidance by redirecting to AIP-180.
 - **2023-05-24**: Clarify that `IMMUTABLE` does not imply input nor required.
 - **2023-05-10**: Added guidance to require the annotation.
 - **2020-12-15**: Added guidance for `UNORDERED_LIST`.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -207,6 +207,8 @@ surpass the costs to clients and API users of not doing so.
 
 ## Changelog
 
+- **2023-07-17**: Clarify statements regarding compatibility of changes to the
+  field_behavior annotation on a field.
 - **2023-05-24**: Clarify that `IMMUTABLE` does not imply input nor required.
 - **2023-05-10**: Added guidance to require the annotation.
 - **2020-12-15**: Added guidance for `UNORDERED_LIST`.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -182,9 +182,10 @@ Requiring the annotation also forces the API author to explicitly consider the
 behavior when initially authoring of the API.
 
 Modifying field behavior after initial authoring results in
-backwards-incompatible changes in clients. For example, making an optional field
-required, results in backwards-incompatible changes in the method signature of
-an RPC or a resource in an [IaC][] client.
+backwards-incompatible changes in clients, _unless_ it is to add OPTIONAL to an
+unannotated field. For example, making an optional field required, results in 
+backwards-incompatible changes in the method signature of an RPC or a resource
+in an [IaC][] client.
 
 ## History
 

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -161,6 +161,29 @@ the user's behalf.
 A resource with an unordered list **may** return the list in a stable order, or
 **may** return the list in a randomized, unstable order.
 
+## Backwards compatibility
+
+Adding or changing `google.api.field_behavior` values can represent a semantic
+change in the API that is perceived as incompatible for existing clients. The
+following are examples of backwards incompatible changes with
+`google.api.field_behavior`:
+
+* Adding `REQUIRED` to an existing field previously considered `OPTIONAL`
+(implicitly or otherwise).
+* Adding a new field annotated as `REQUIRED` to an existing request message.
+* Adding `OUTPUT_ONLY` to an existing field previously accepted as input
+* Removing `OUTPUT_ONLY` from an existing field previously ignored as input
+* Adding `INPUT_ONLY` to an existing field previously emitted as output
+* Adding `IMMUTABLE` to an existing field previously considered mutable
+
+There are some changes that *are* backwards compatible, which are as follows:
+
+* Adding `OPTIONAL` to an existing field
+* Changing from `REQUIRED` to `OPTIONAL` on an existing field
+* Removing `REQUIRED` from an existing field
+* Removing `INPUT_ONLY` from an existing field previously excluded in responses
+* Removing `IMMUTABLE` from an existing field previously considered immutable
+
 ## Rationale
 
 ### Required set of annotations
@@ -184,7 +207,8 @@ behavior when initially authoring of the API.
 Modifying field behavior after initial authoring can result in
 backwards-incompatible changes in clients. For example, making an optional field
 required results in backwards-incompatible changes in the method signature of an
-RPC or a resource in an [IaC][] client. See [AIP-180][] for more detailed
+RPC or a resource in an [IaC][] client. See the
+[Backwards compatibility](#backwards-compatibility) section for more detailed
 compatibility guidance.
 
 ## History
@@ -192,8 +216,9 @@ compatibility guidance.
 In 2023-05 field_behavior was made mandatory. Prior to this change, the
 annotation was often omitted. Its values are relied upon to produce high quality
 clients. Furthermore, adding or changing some of the field_behavior values after
-the fact within a major version can be backwards-incompatible. See [AIP-180][]
-for more detailed compatibility guidance.
+the fact within a major version can be backwards-incompatible. See the
+[Backwards compatibility](#backwards-compatibility) section for more detailed
+compatibility guidance.
 
 The benefits of requiring field_behavior at the time that the API is authored
 surpass the costs to clients and API users of not doing so.
@@ -206,7 +231,7 @@ surpass the costs to clients and API users of not doing so.
 
 ## Changelog
 
-- **2023-07-20**: Clarify compatibility guidance by redirecting to AIP-180.
+- **2023-07-20**: Describe compatibility guidance with new section.
 - **2023-05-24**: Clarify that `IMMUTABLE` does not imply input nor required.
 - **2023-05-10**: Added guidance to require the annotation.
 - **2020-12-15**: Added guidance for `UNORDERED_LIST`.


### PR DESCRIPTION
Language in the `History` of AIP-203 speaks to compatibility concerns, but needed some clarification on what would produce a backwards incompatible change. 

Includes compatibility guidance in AIP-203, and adds a reference to it from AIP-180

Fixes #1163 