### PR TITLE
fix(AIP-134): consolidate AIP-161 mask guidance

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -90,7 +90,7 @@ message UpdateBookRequest {
   - The field **must** identify the [resource type][aip-123] of the resource
     being updated.
 - If partial resource update is supported, a field mask **must** be included.
-  It **must** be of type `google.protobuf.FieldMask`, and it **should** be
+  It **must** be of type `google.protobuf.FieldMask`, and it **must** be
   called `update_mask`.
   - The fields used in the field mask correspond to the resource being updated
     (not the request message).

--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -21,9 +21,9 @@ without waiting for UI or client updates.
 
 ## Guidance
 
-Update methods (AIP-134) **must** include an `update_mask` field. These
-are called "field masks", and they use the `google.protobuf.FieldMask`
-type.
+These masks of field names are called "field masks". Fields representing a field
+mask **must** use the `google.protobuf.FieldMask` type. Field masks are most
+common on Update requests (AIP-134).
 
 Field masks **must** always be relative to the resource:
 


### PR DESCRIPTION
Consolidate guidance re:`update_mask` for Standard Update into AIP-134.

Change AIP-134 guidance on `update_mask` field name from `**should**` to `**must**`. There isn't really another reasonable name for this field and it is critical to the Update flow, so we should avoid giving wiggle room on the naming.

Fixes #1164 