### PR TITLE
feat(AIP-203): clarify fb in nested messages

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -42,6 +42,26 @@ backwards-compatility. Nontheless, this annotation **must not** be omitted.
 only, and does not itself add any validation. The purpose is to consistently
 document this behavior for clients.
 
+### field behavior of nested messages
+
+`google.api.field_behavior` annotations on a nested message are independent of
+the annotations of the parent.
+
+For example, a nested message can have a field behavior of `REQUIRED` while the
+parent field can be `OPTIONAL`:
+
+```proto
+message Title {
+  string text = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+message Slide {
+  Title title = 1 [(google.api.field_behavior) = OPTIONAL];
+}
+```
+
+In the case above, if a `title` is specified, the `text` field is required.
+
 ## Vocabulary
 
 ### Required
@@ -204,6 +224,8 @@ surpass the costs to clients and API users of not doing so.
 
 ## Changelog
 
+- **2023-07-21**: Clarify that nested behavior and parent behavior are
+  independent.
 - **2023-05-24**: Clarify that `IMMUTABLE` does not imply input nor required.
 - **2023-05-10**: Added guidance to require the annotation.
 - **2020-12-15**: Added guidance for `UNORDERED_LIST`.


### PR DESCRIPTION
There have been internal questions about whether nested fields
can have required fields if the parent is optional. Therefore
it is worth clarifying the expectations around such fields.