### PR TITLE
fix(AIP-121): clarify stateless protocol definition

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -97,11 +97,12 @@ patterns, such as database transactions, import and export, or data analysis.
 ### Stateless protocol
 
 As with most public APIs available today, resource-oriented APIs **must**
-operate over a stateless protocol: The fundamental behavior of any individual
-request is independent of other requests made by the caller. This is to say,
-each request happens in isolation of other requests made by that client or
-another, and resources exposed by an API are directly addressable without
-needing to apply a series of specific requests to "reach" the desired resource.
+operate over a [stateless protocol][]: The fundamental behavior of any
+individual request is independent of other requests made by the caller.
+This is to say, each request happens in isolation of other requests made by that
+client or another, and resources exposed by an API are directly addressable
+without needing to apply a series of specific requests to "reach" the desired
+resource.
 
 In an API with a stateless protocol, the server has the responsibility for
 persisting data, which may be shared between multiple clients, while clients
@@ -130,6 +131,7 @@ and in turn do not increase resource management complexity.
 
 [rest]: https://en.wikipedia.org/wiki/Representational_state_transfer
 [rpc]: https://en.wikipedia.org/wiki/Remote_procedure_call
+[stateless protocol]: https://en.wikipedia.org/wiki/Stateless_protocol
 [get]: ./0131.md
 [list]: ./0132.md
 [create]: ./0133.md

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -144,6 +144,7 @@ and in turn do not increase resource management complexity.
 
 ## Changelog
 
+- **2023-07-23**: Clarify stateless protocol definition.
 - **2023-01-21**: Explicitly require matching schema across standard methods.
 - **2022-12-19**: Added a section requiring Get and List.
 - **2022-11-02**: Added a section restricting resource references.

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -100,7 +100,7 @@ As with most public APIs available today, resource-oriented APIs **must**
 operate over a stateless protocol: The fundamental behavior of any individual
 request is independent of other requests made by the caller. This is to say,
 each request happens in isolation of other requests made by that client or
-another, and resources exposed by an API are directly adddressible without
+another, and resources exposed by an API are directly addressable without
 needing to apply a series of specific requests to "reach" the desired resource.
 
 In an API with a stateless protocol, the server has the responsibility for

--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -98,7 +98,10 @@ patterns, such as database transactions, import and export, or data analysis.
 
 As with most public APIs available today, resource-oriented APIs **must**
 operate over a stateless protocol: The fundamental behavior of any individual
-request is independent of other requests made by the caller.
+request is independent of other requests made by the caller. This is to say,
+each request happens in isolation of other requests made by that client or
+another, and resources exposed by an API are directly adddressible without
+needing to apply a series of specific requests to "reach" the desired resource.
 
 In an API with a stateless protocol, the server has the responsibility for
 persisting data, which may be shared between multiple clients, while clients


### PR DESCRIPTION
Clarifies definition of a stateless protocol as applied to resource oriented APIs after some confusion created by the lack of concrete/applied language.

cc: @berg3