### PR TITLE
fix(AIP-151): Use standard method for LRO example

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -25,15 +25,15 @@ Individual API methods that might take a significant amount of time to complete
 ultimate response message.
 
 ```proto
-// Write a book.
-rpc WriteBook(WriteBookRequest) returns (google.longrunning.Operation) {
+// Create a book.
+rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
-    post: "/v1/{parent=publishers/*}/books:write"
-    body: "*"
+    post: "/v1/{parent=publishers/*}/books"
+    body: "book"
   };
   option (google.longrunning.operation_info) = {
-    response_type: "WriteBookResponse"
-    metadata_type: "WriteBookMetadata"
+    response_type: "Book"
+    metadata_type: "OperationMetadata"
   };
 }
 ```


### PR DESCRIPTION
Update the Long-running operations AIP to use a standard method for the code example instead of a custom method

cc: @noahdietz