### PR TITLE
fix(AIP-156): Do not define Update on singletons with only output only fields.

### DIFF
--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -67,6 +67,7 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
 
 ## Changelog
 
+- **2023-07-26:** Clarified that read-only singletons should not have `Update`.
 - **2021-11-02:** Added an example message and state parent eligibility.
 - **2021-01-14:** Changed example from `settings` to `config` for clarity.
 

--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -20,6 +20,7 @@ always exist by virtue of the existence of its parent, with one and exactly one
 per parent.
 
 For example:
+
 ```proto
 message Config {
   option (google.api.resource) = {
@@ -32,6 +33,7 @@ message Config {
 ```
 
 The `Config` singleton would have the following RPCs:
+
 ```proto
 rpc GetConfig(GetConfigRequest) returns (Config) {
   option (google.api.http) = {
@@ -57,8 +59,10 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
 - Singleton resources **should** define the [`Get`][aip-131] and
   [`Update`][aip-134] methods, and **may** define custom methods as
   appropriate.
+  - However, singleton resources **must not** define the [`Update`][aip-134]
+    method if all fields on the resource are [output only][aip-203]
 - Singleton resources are always singular.
-  - Example: 'users/1234/thing'
+  - Example: `users/1234/thing`
 - Singleton resources **may** parent other resources.
 
 ## Changelog
@@ -72,3 +76,4 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
 [aip-133]: ./0133.md
 [aip-134]: ./0134.md
 [aip-135]: ./0135.md
+[aip-203]: ./0203.md#output-only

--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -60,7 +60,7 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
   [`Update`][aip-134] methods, and **may** define custom methods as
   appropriate.
   - However, singleton resources **must not** define the [`Update`][aip-134]
-    method if all fields on the resource are [output only][aip-203]
+    method if all fields on the resource are [output only][aip-203].
 - Singleton resources are always singular.
   - Example: `users/1234/thing`
 - Singleton resources **may** parent other resources.


### PR DESCRIPTION
As discussed in the AIP meeting today. Should be non-controversial.