### PR TITLE
feat(AIP-203): introduce IDENTIFIER field behavior

### DIFF
--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -43,10 +43,7 @@ message Topic {
     pattern: "projects/{project}/topics/{topic}"
   };
 
-  // The resource's name.
-  string name = 1;
-
-  // And so on...
+  // name and so on...
 }
 ```
 
@@ -91,10 +88,7 @@ message LogEntry {
     pattern: "billingAccounts/{billing_account}/logs/{log}"
   };
 
-  // The resource's name.
-  string name = 1;
-
-  // And so on...
+  // name and so on...
 }
 ```
 
@@ -195,10 +189,7 @@ message FeedItemTarget {
     pattern: "customers/{customer}/feedItemTargets/{feed}~{feed_item}"
   };
 
-  // The resource name of this event.
-  string name = 1;
-
-  // Other fields...
+  // name and other fields...
 }
 ```
 

--- a/aip/cloud/2510.md
+++ b/aip/cloud/2510.md
@@ -88,7 +88,7 @@ message Book {
   };
 
   // The resource name of the Book.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // A reference to another resource, a Shelf.
   string shelf = 2 [(google.api.resource_reference) = {

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -196,7 +196,7 @@ message Book {
 
   // The resource name of the book.
   // Format: publishers/{publisher}/books/{book}
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // Other fields...
 }
@@ -282,7 +282,7 @@ When a field represents another resource, the field **should** be of type
 `string` and accept the resource name of the other resource. The field name
 **should** be equivalent to the corresponding message's name in snake case.
 
-The field **should not** be of type `message` using the `message` that 
+The field **should not** be of type `message` using the `message` that
 implements the resource, _unless_ the API is internal-only, has tight lifecycle
 relationships, and has a permission model that enables inherited access to
 embedded resources.
@@ -307,7 +307,7 @@ message Book {
 
   // Name of the book.
   // Format is `publishers/{publisher}/books/{book}`
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The shelf where the book currently sits.
   // Format is `shelves/{shelf}`.

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -67,10 +67,7 @@ message Topic {
     plural: "topics"
   };
 
-  // The resource name of the topic.
-  string name = 1;
-
-  // Other fields...
+  // Name and other fields...
 }
 ```
 

--- a/aip/general/0124.md
+++ b/aip/general/0124.md
@@ -36,7 +36,7 @@ message Book {
   };
 
   // The resource name for the book.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The resource name for the book's author.
   string author = 2 [(google.api.resource_reference) = {
@@ -71,7 +71,7 @@ message Book {
     pattern: "publishers/{publisher}/books/{book}"
   };
 
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The resource names for the book's authors.
   repeated string authors = 2 [(google.api.resource_reference) = {
@@ -97,7 +97,7 @@ message BookAuthor {
   };
 
   // The resource name for the book-author association.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The resource name for the author.
   string author = 2 [(google.api.resource_reference) = {

--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -44,8 +44,7 @@ message Book {
     style: DECLARATIVE_FRIENDLY
   };
 
-  string name = 1;
-  // Other fields...
+  // Name and other fields...
 }
 ```
 

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -221,9 +221,14 @@ In this situation, the resource **should** contain a `string etag` field:
 
 ```proto
 message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
   // The resource name of the book.
   // Format: publishers/{publisher}/books/{book}
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The title of the book.
   // Example: "Mary Poppins"

--- a/aip/general/0144.md
+++ b/aip/general/0144.md
@@ -20,7 +20,13 @@ Resources **may** use repeated fields where appropriate.
 
 ```proto
 message Book {
-  string name = 1;
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
   repeated string authors = 2;
 }
 ```

--- a/aip/general/0147.md
+++ b/aip/general/0147.md
@@ -25,7 +25,7 @@ resource implies storage of the sensitive data. For example:
 
 ```proto
 message SelfManagedKeypair {
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The public key data in PEM-encoded form.
   bytes public_key = 2;
@@ -42,7 +42,7 @@ indicate whether or not the sensitive information is present. For example:
 
 ```proto
 message Integration {
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
   string uri = 2;
 
   // A secret to be passed in the `Authorization` header of the webhook.

--- a/aip/general/0149.md
+++ b/aip/general/0149.md
@@ -25,8 +25,13 @@ its default value (`0`, `false`, or empty string) from not setting it at all:
 ```proto
 // A representation of a book in a library.
 message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
   // The name of the book.
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The rating for the book, from 0 to 5.
   // 0 is distinct from no rating.

--- a/aip/general/0152.md
+++ b/aip/general/0152.md
@@ -22,13 +22,12 @@ distinct setup, configuration, and execution:
 
 ```proto
 message WriteBookJob {
-  // The resource name for the writing job.
-  string name = 1 [(google.api.resource) = {
+  option (google.api.resource) = {
     type: "library.googleapis.com/WriteBookJob"
     pattern: "publishers/{publisher}/writeBookJobs/{write_book_job}"
-  }];
+  };
 
-  // Additional configuration...
+  // Name and other fields...
 }
 ```
 
@@ -116,10 +115,8 @@ message WriteBookJobExecution {
     pattern: "publishers/{publisher}/writeBookJobs/{write_book_job}/executions/{execution}"
   };
 
-  string name = 1;
-
-  // Other information about the execution, such as metadata, the result,
-  // error information, etc.
+  // Name and other information about the execution, such as metadata, the
+  // result, error information, etc.
 }
 ```
 

--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -28,7 +28,7 @@ message Config {
     pattern: "users/{user}/config"
   };
 
-  string name = 1;
+  // additional fields including name
 }
 ```
 
@@ -66,7 +66,7 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
     method if all fields on the resource are [output only][aip-203].
 - Singleton resources **may** define the [`List`][aip-132] method, but **must**
   implement it according to [AIP-159][aip-159]. See the example below.
-  - The trailing segment in the path pattern that typically represents the 
+  - The trailing segment in the path pattern that typically represents the
     collection **should** be the `plural` form of the Singleton resource e.g.
     `/v1/{parent=users/*}/configs`.
   - If a parent resource ID is provided instead of the hyphen `-` as per

--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -101,9 +101,14 @@ map to indicate the specification of particular sub-fields in the collection:
 
 ```proto
 message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
   // The name of the book.
   // Format: publishers/{publisher}/books/{book}
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The author or authors of the book.
   // Valid field masks: authors, authors.*.given_name, authors.*.family_name

--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -32,10 +32,7 @@ APIs implementing resources with a revision history **must** provide a
 
 ```proto
 message Book {
-  // The name of the book.
-  string name = 1;
-
-  // Other fields…
+  // Name and other fields…
 
   // The revision ID of the book.
   // A new revision is committed whenever the book is changed in any way.

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -161,7 +161,8 @@ For example:
 
 ```proto
 message Book {
-    string name = 1;
+    // google.api.resource and other annotations and fields
+
     // The genre of the book
     // If this is not set when the book is created, the field will be given a value of FICTION.
     enum Genre {
@@ -176,7 +177,8 @@ Changing to:
 
 ```proto
 message Book {
-    string name = 1;
+    // google.api.resource and other annotations and fields
+
     // The genre of the book
     // If this is not set when the book is created, the field will be given a value of NONFICTION.
     enum Genre {
@@ -203,8 +205,7 @@ Consider the following proto, where the default value of `wheels` is `2`:
 ```proto
 // A representation of an automobile
 message Automobile {
-    // The name of the automobile.
-    string name = 1;
+    // google.api.resource and other annotations and fields
 
     // The number of wheels on the automobile.
     // The default value is 2, when no value is sent by the client.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -44,6 +44,73 @@ document this behavior for clients.
 
 ## Vocabulary
 
+### Immutable
+
+The use of `IMMUTABLE` indicates that a field on a resource cannot be changed
+after it's creation. This can apply to either fields that are input or outputs,
+required or optional.
+
+When a service receives an immutable field in an update request (or similar),
+even if included in the update mask, the service **should** ignore the field if
+the value matches, but **should** error with `INVALID_ARGUMENT` if a change is
+requested.
+
+Potential use cases for immutable fields (this is not an exhaustive list) are:
+
+- Names or IDs which are set on creation and then used as a primary key.
+
+**Note:** Fields which are "conditionally immutable" **must not** be given the
+immutable annotation.
+
+### Input only
+
+The use of `INPUT_ONLY` indicates that the field is provided in requests and
+that the corresponding field will not be included in output.
+
+Additionally, a field **should** only be described as input only if it is a
+field in a resource message or a field of a message included within a resource
+message. Notably, fields in request messages (a message which only ever acts as
+an argument to an RPC, with a name usually ending in `Request`) **should not**
+be described as input only because this is already implied.
+
+Potential use cases for input only fields (this is not an exhaustive list) are:
+
+- The `ttl` field as described in AIP-214.
+
+**Warning:** Input only fields are rare and should be considered carefully
+before use.
+
+### Optional
+
+The use of `OPTIONAL` indicates that a field is not required.
+
+A field **may** be described as optional if it is a field on a request message
+(a message that is an argument to an RPC, usually ending in `Request`), or a
+field on a submessage.
+
+### Output only
+
+The use of `OUTPUT_ONLY` indicates that the field is provided in responses, but
+that including the field in a message in a request does nothing (the server
+**must** clear out any value in this field and **must not** throw an error as a
+result of the presence of a value in this field on input). Similarly, services
+**must** ignore the presence of output only fields in update field masks.
+
+Additionally, a field **should** only be described as output only if it is a
+field in a resource message, or a field of a message farther down the tree.
+Notably, fields in response messages (a message which only ever acts as a
+return value to an RPC, usually ending in `Response`) **should not** be
+described as output only because this is already implied.
+
+Output only fields **may** be set to empty values if appropriate to the API.
+
+Potential use cases for output only fields (this is not an exhaustive list)
+are:
+
+- Create or update timestamps.
+- Derived or structured information based on original user input.
+- Properties of a resource assigned by the service which can not be altered.
+
 ### Required
 
 The use of `REQUIRED` indicates that the field **must** be present (and set to
@@ -80,73 +147,6 @@ Fields **should not** be described as required in order to signify:
 integers, or the unspecified value for enums) are indistinguishable from unset
 values, and therefore setting a required field to a falsy value yields an
 error. A corollary to this is that a required boolean must be set to `true`.
-
-### Optional
-
-The use of `OPTIONAL` indicates that a field is not required.
-
-A field **may** be described as optional if it is a field on a request message
-(a message that is an argument to an RPC, usually ending in `Request`), or a
-field on a submessage.
-
-### Output only
-
-The use of `OUTPUT_ONLY` indicates that the field is provided in responses, but
-that including the field in a message in a request does nothing (the server
-**must** clear out any value in this field and **must not** throw an error as a
-result of the presence of a value in this field on input). Similarly, services
-**must** ignore the presence of output only fields in update field masks.
-
-Additionally, a field **should** only be described as output only if it is a
-field in a resource message, or a field of a message farther down the tree.
-Notably, fields in response messages (a message which only ever acts as a
-return value to an RPC, usually ending in `Response`) **should not** be
-described as output only because this is already implied.
-
-Output only fields **may** be set to empty values if appropriate to the API.
-
-Potential use cases for output only fields (this is not an exhaustive list)
-are:
-
-- Create or update timestamps.
-- Derived or structured information based on original user input.
-- Properties of a resource assigned by the service which can not be altered.
-
-### Input only
-
-The use of `INPUT_ONLY` indicates that the field is provided in requests and
-that the corresponding field will not be included in output.
-
-Additionally, a field **should** only be described as input only if it is a
-field in a resource message or a field of a message included within a resource
-message. Notably, fields in request messages (a message which only ever acts as
-an argument to an RPC, with a name usually ending in `Request`) **should not**
-be described as input only because this is already implied.
-
-Potential use cases for input only fields (this is not an exhaustive list) are:
-
-- The `ttl` field as described in AIP-214.
-
-**Warning:** Input only fields are rare and should be considered carefully
-before use.
-
-### Immutable
-
-The use of `IMMUTABLE` indicates that a field on a resource cannot be changed
-after it's creation. This can apply to either fields that are input or outputs,
-required or optional.
-
-When a service receives an immutable field in an update request (or similar),
-even if included in the update mask, the service **should** ignore the field if
-the value matches, but **should** error with `INVALID_ARGUMENT` if a change is
-requested.
-
-Potential use cases for immutable fields (this is not an exhaustive list) are:
-
-- Names or IDs which are set on creation and then used as a primary key.
-
-**Note:** Fields which are "conditionally immutable" **must not** be given the
-immutable annotation.
 
 ### Unordered List
 

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -47,12 +47,11 @@ document this behavior for clients.
 ### Identifier
 
 The use of `IDENTIFIER` indicates that a field within a resource message is used
-to identify the resource. It **must** be attached to the `name` field and any
-other fields within a resource that are used in identifying the resource within
-a collection. See [fields representing resource names].
+to identify the resource. It **must** be attached to the `name` field and **must
+not** be attached to any other field (see [fields representing resource names]).
 
-This annotation **should not** be applied to references to other resources within a
-message.
+This annotation **must not** be applied to references to other resources within
+a message.
 
 ### Immutable
 
@@ -67,7 +66,8 @@ requested.
 
 Potential use cases for immutable fields (this is not an exhaustive list) are:
 
-- Names or IDs which are set on creation and then used as a primary key.
+- Attributes of resources that are not modifiable for the lifetime of the
+  application (e.g. a disk type).
 
 **Note:** Fields which are "conditionally immutable" **must not** be given the
 immutable annotation.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -46,12 +46,12 @@ document this behavior for clients.
 
 ### Identifier
 
-The use of `IDENTIFIER` indicates that the field is used to identify the
-resource. It must be attached to the name parameter and any other fields that
-are used in identifying the resource within the collection. See [fields
-representing resource names].
+The use of `IDENTIFIER` indicates that a field within a resource message is used
+to identify the resource. It **must** be attached to the `name` field and any
+other fields within a resource that are used in identifying the resource within
+a collection. See [fields representing resource names].
 
-This annotation should not be applied to references to other resources within a
+This annotation **should not** be applied to references to other resources within a
 message.
 
 ### Immutable

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -179,17 +179,21 @@ following are examples of backwards incompatible changes with
 `google.api.field_behavior`:
 
 * Adding `REQUIRED` to an existing field previously considered `OPTIONAL`
-(implicitly or otherwise).
-* Adding a new field annotated as `REQUIRED` to an existing request message.
+(implicitly or otherwise)
+* Adding a new field annotated as `REQUIRED` to an existing request message
 * Adding `OUTPUT_ONLY` to an existing field previously accepted as input
-* Removing `OUTPUT_ONLY` from an existing field previously ignored as input
 * Adding `INPUT_ONLY` to an existing field previously emitted as output
 * Adding `IMMUTABLE` to an existing field previously considered mutable
+* Removing `OUTPUT_ONLY` from an existing field previously ignored as input
+* Removing `IDENTIFIER` from an existing field.
 
 There are some changes that *are* backwards compatible, which are as follows:
 
 * Adding `OPTIONAL` to an existing field
+* Adding `IDENTIFIER` to an existing `name` field
 * Changing from `REQUIRED` to `OPTIONAL` on an existing field
+* Changing from `OUTPUT_ONLY` and/or `IMMUTABLE` to `IDENTIFIER` on an existing
+  field
 * Removing `REQUIRED` from an existing field
 * Removing `INPUT_ONLY` from an existing field previously excluded in responses
 * Removing `IMMUTABLE` from an existing field previously considered immutable
@@ -242,6 +246,7 @@ surpass the costs to clients and API users of not doing so.
 
 ## Changelog
 
+- **2023-08-25**: Add guidance on `IDENTIFIER`.
 - **2023-07-20**: Describe compatibility guidance with new section.
 - **2023-05-24**: Clarify that `IMMUTABLE` does not imply input nor required.
 - **2023-05-10**: Added guidance to require the annotation.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -44,6 +44,16 @@ document this behavior for clients.
 
 ## Vocabulary
 
+### Identifier
+
+The use of `IDENTIFIER` indicates that the field is used to identify the
+resource. It must be attached to the name parameter and any other fields that
+are used in identifying the resource within the collection. See [fields
+representing resource names].
+
+This annotation should not be applied to references to other resources within a
+message.
+
 ### Immutable
 
 The use of `IMMUTABLE` indicates that a field on a resource cannot be changed
@@ -228,6 +238,7 @@ surpass the costs to clients and API users of not doing so.
 [aip-180]: ./0180.md
 [google.api.FieldBehavior]: https://github.com/googleapis/googleapis/blob/master/google/api/field_behavior.proto#L49
 [Declarative client]: ./0009.md#declarative-clients
+[fields representing resource names]: ./0122.md#fields-representing-resource-names
 
 ## Changelog
 

--- a/aip/general/0214.md
+++ b/aip/general/0214.md
@@ -40,8 +40,7 @@ library.
 
 ```proto
 message ExpiringResource {
-  // The name of the resource; the format is: ...
-  string name = 1;
+  // google.api.resource and other annotations and fields
 
   oneof expiration {
     // Timestamp in UTC of when this resource is considered expired.

--- a/aip/general/0236.md
+++ b/aip/general/0236.md
@@ -16,7 +16,7 @@ of outcomes.
 
 Changes to policies without proper validation may have unintended consequences
 that can severely impact a customer’s overall infrastructure setup. To safely
-update resources, it is beneficial to test these changes via policy rollout 
+update resources, it is beneficial to test these changes via policy rollout
 APIs.
 
 Preview is a rollout safety mechanism for policy resources, which gives the
@@ -25,8 +25,8 @@ production traffic prior to the changes going live. The result of the policy
 evaluation against traffic is logged in order to give the customer the data
 required to test the correctness of the change.
 
-Firewall policies exemplify a case that is suitable for previewing. A new 
-configuration can be evaluated against traffic to observe which IPs would be 
+Firewall policies exemplify a case that is suitable for previewing. A new
+configuration can be evaluated against traffic to observe which IPs would be
 allowed or denied. This gives the customer the data to guide a decision on
 whether to promote the proposed changes to live.
 
@@ -60,7 +60,7 @@ following resource name pattern:
 The experimental versions of the resource used for previewing or other safe
 rollout practices are represented as a nested collection under `Policy` using a
 new resource type. The resource type **must** follow the naming convention
-*RegularResourceType*`Experiment`. 
+*RegularResourceType*`Experiment`.
 
 The following pattern is used for the experiment collection:
 
@@ -76,9 +76,8 @@ A proto used to represent an experiment **must** contain the following:
 ```proto
 message PolicyExperiment {
 
-  // The resource name of the PolicyExperiment.
-  string name = 1;
- 
+  // google.api.resource, name, and other annotations and fields
+
   // The policy experiment. This Policy will be used to preview the effects of
   // the change but will not affect live traffic.
   Policy policy = 2;
@@ -93,17 +92,17 @@ message PolicyExperiment {
 ```
 
 - The experiment proto **must** have a top-level field with the same type as the
-  live policy. 
+  live policy.
   - It **must** be named as the live resource type. For example, if the
     experiment is for FirewallPolicy, then this field **must** be named
     `firewall_policy`.
   - The name inside the embedded `policy` message **must** be the name of the
-    live policy. 
-- When the user is ready to promote an experiment, they **must** copy the 
+    live policy.
+- When the user is ready to promote an experiment, they **must** copy the
   `policy` message into the live policy and delete the experiment. This can be
   done manually or via a "commit" custom method.
-- A product **may** support multiple experiments concurrently being previewed 
-  for a single live policy. 
+- A product **may** support multiple experiments concurrently being previewed
+  for a single live policy.
   - Each experiment must generate logs having each entry preceded by log_prefix
     so that the user can compare the results of the experiment with the behavior
     of the live policy.
@@ -120,19 +119,19 @@ message PolicyExperiment {
 messages **must** follow the convention: *RegularResourceType*`PreviewMetadata`.
 This is so the proto can be defined uniquely for each resource type in the
 same service with experiments.
- 
-```proto 
+
+```proto
 message PolicyPreviewMetadata {
   // Possible values of the state of previewing the experiment.
   enum State {
     // Default value. This value is unused.
     STATE_UNDEFINED = 0;
-    
+
     // The experiment is actively previewing.
     ACTIVE = 1;
 
     // The previewing of the experiment has been stopped.
-    SUSPENDED = 2;  
+    SUSPENDED = 2;
   }
 
   // The state of previewing the experiment.
@@ -160,26 +159,26 @@ message PolicyPreviewMetadata {
   or stopped. This happens when the "startPreview" or "stopPreview custom methods
   are invoked, respectively.
 - The first time the "startPreview" custom method is used, the system **must**
-  create `preview_metadata` and do the following: 
+  create `preview_metadata` and do the following:
   - It **must** set the `state` to `ACTIVE`
-  - It **must** populate `start_time` with the current time. 
+  - It **must** populate `start_time` with the current time.
     - `start_time` **must** be updated every time `state` is changed to
       `ACTIVE`.
   - It **must** set a system generated `log_prefix` string, which is a
-    predefined constant hard coded by the system developers. 
+    predefined constant hard coded by the system developers.
   - The same value is used for previewing experiments for the given resource
     type. For example, "FirewallPolicyPreviewLog" for FirewallPolicy.
 - When the "stopPreview" custom method is used, the system **must** do the
   following:
   - It **must** set the `state` to `SUSPENDED`
-  - It **must** populate the `stop_time` with the current time. 
+  - It **must** populate the `stop_time` with the current time.
 
 ### Methods
 
 #### create
 
-- The resource **must** be created using long-running 
-  [Create][aip-133-long-running] and 
+- The resource **must** be created using long-running
+  [Create][aip-133-long-running] and
   `google.longrunning.operation_info.response_type` **must** be
   `PolicyExperiment`.
 - Creating a new experiment to preview **must** support the following use
@@ -189,13 +188,13 @@ cases:
   - Preview a deletion of a current policy.
 - For the update and delete use cases, the `policy` field in the experiment
   **must** have the full payload of the live policy copied into it, including
-  the name. 
+  the name.
   - The user **must** set the rules to the new intended state to preview an
     update.
   - The user **must** set set the rules to represent a no-op to preview a
     delete.
-- To preview a new policy, the system must do the following: 
-  - If the system does not support a nested collection without a live policy, 
+- To preview a new policy, the system must do the following:
+  - If the system does not support a nested collection without a live policy,
     the user **must** create a live policy and set the rules to represent a
     no-op. For example, the rules of a no-op policy **may** be empty.
     - An experiment is created as a child of the no-op policy.
@@ -204,8 +203,8 @@ cases:
 
 #### update
 
-- The resource **must** be updated using long-running 
-  [Update][aip-134-long-running] and 
+- The resource **must** be updated using long-running
+  [Update][aip-134-long-running] and
   `google.longrunning.operation_info.response_type` **must** be
   `PolicyExperiment`.
 - The name inside `policy` **must not** change but the other fields can in
@@ -227,13 +226,13 @@ cases:
   `PolicyExperiment` resource types.
 - Filtering on `PolicyPreviewMetadata` indicates which experiments are actively
   previewed.
-  - For example, the following filter string returns a List response with 
+  - For example, the following filter string returns a List response with
     experiments being previewed: preview_metadata.state = ACTIVE.
 
 #### delete
 
-- The resource **must** be deleted using long-running 
-  [Delete][aip-135-long-running] and 
+- The resource **must** be deleted using long-running
+  [Delete][aip-135-long-running] and
   `google.longrunning.operation_info.response_type` **must** be
   `PolicyExperiment`.
 
@@ -264,7 +263,7 @@ message StartPreviewPolicyExperimentRequest {
 - This custom method is required.
 - `google.longrunning.Operation.metadata_type` **must** follow guidance on
   [Long-running operations][aip-151]
-- This method **must** trigger the system to start generating logs to preview 
+- This method **must** trigger the system to start generating logs to preview
   the experiment.
 - Whenever the method is called successfully, the system **must** set the
   following values in the `PolicyPreviewMetadata`:
@@ -356,7 +355,7 @@ message CommitPolicyExperimentRequest {
     intended.
   - A `parent_etag` **may** be provided to guarantee that the experiment
     overwrites a specific version of the live policy.
-- The method is not idempotent and calling it twice on the same experiment 
+- The method is not idempotent and calling it twice on the same experiment
   **must** return a 404 NOT_FOUND as the experiment is deleted as part of the
   first call.
 
@@ -379,7 +378,7 @@ associated with that experiment alongside that of the live policy, and be
 preceded by the value of `log_prefix`.
   - The `etag` fields help the user identify which
     configurations of the live and experiment are evaluated in the log.
-  - `log_prefix` helps the user separate logs specifically generated for 
+  - `log_prefix` helps the user separate logs specifically generated for
     previewing the experiment from other use cases.
 
 Overall, these logs help the user make a decision about whether to promote the


### PR DESCRIPTION
Identifier fields are often multi-modal: they are required or optional
in various situations. Adding an explicit field behavior for these
fields helps eliminate ambiguity for an author to fully annotate field
behavior on all request fields, as well as clarify which fields to use
in identifying the resource for clients.

fixes #1176.