### PR TITLE
fix: STS region_url should optional

### DIFF
--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -205,7 +205,7 @@ endpoint.
 | Field Name                                       | Required | Description |
 |--------------------------------------------------|----------|:------------|
 | environment_id                 | Yes      | This is the environment identifier, of format `aws${version}`. A version should be specified to indicate to the auth library whether breaking changes were introduced to the underlying AWS implementation. So if aws1 is supported in the current version of the library but a credential file with aws2 is provided, an error should be thrown instructing the developer to upgrade to a newer version of the library. |
-| region_url                     | Yes      | This URL should be used to determine the current AWS region needed for the signed request construction. |
+| region_url                     | No       | This URL should be used to determine the current AWS region needed for the signed request construction when the region environment variables are not present. |
 | url                            | No       | This AWS metadata server URL should be used to retrieve the access key, secret key and security token needed to sign the `GetCallerIdentity` request. The $ROLE_NAME should be retrieved from calling this endpoint without any parameter and then calling again with the returned role name appended to this URL: http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME |
 | regional_cred_verification_url | Yes      | This defines the regional AWS `GetCallerIdentity` action URL. This URL should be used to determine the AWS account ID and its roles. This should not actually be called by the Auth libraries. It should be called on the STS token server. The region should be substituted by SDK, e.g. `sts.eu-west-1.amazonaws`.com. |
 | imdsv2_session_token_url       | No       | Presence of this URL enforces the auth libraries to fetch a Session Token from AWS. This field is required for EC2 instances using IMDSv2. This Session Token would later be used while making calls to the metadata enpoint. |
@@ -244,7 +244,7 @@ The auth libraries and applications **must** follow the steps below:
 - Check the environment variables in the following order (`AWS_REGION` and
   then the `AWS_DEFAULT_REGION`) to determine the AWS region. If found, skip
   using the AWS metadata server to determine this value.
-- If the region environment variable is not provided, use the **region_url**
+- If the region environment variables are not provided, use the **region_url**
   to determine the current AWS region. The API returns the zone name, e.g.
   `us-east-1d`. The region should be determined by stripping the last
   character, e.g. `us-east-1`.
@@ -279,7 +279,7 @@ The auth libraries and applications **must** follow the steps below:
       {
         "value": "AWS4-HMAC-SHA256 Credential=AKIASOZTBDV4D7ABCDEDF/20200228/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date,Signature=abcedefdfedfd",
         "key": "Authorization"
-      }, 
+      },
       {
         "value": "sts.us-east-1.amazonaws.com",
         "key": "host"
@@ -288,7 +288,7 @@ The auth libraries and applications **must** follow the steps below:
         "value": "IQoJb3JpZ2luX2VjEIz//////////wEaCXVzLWVh...",
         "key": "x-amz-security-token"
       }
-    ], 
+    ],
     "method": "POST",
     "body": ""
   }
@@ -375,7 +375,7 @@ in the `credential_source` object to facilitate retrieval of file-sourced
 credentials to be passed as subject tokens to the GCP STS token exchange
 endpoint.
 
-| Field Name                                        | Required | Description |        
+| Field Name                                        | Required | Description |
 |---------------------------------------------------|----------|:------------|
 | file                            | Yes      | This is the source of the credential. This should be used for a credential locally available. This should take precedence over `url` when both are provided. |
 | format.type                     | No       | This indicates the format of the file where the token is stored. This can be either "text" or "json". The default should be "text". |
@@ -419,7 +419,7 @@ in the `credential_source` object to facilitate retrieval of executable-sourced
 credentials to be passed as subject tokens to the GCP STS token exchange
 endpoint.
 
-| Field Name                | Required | Description                                                                                                                                                                                                                                                                                              |        
+| Field Name                | Required | Description                                                                                                                                                                                                                                                                                              |
 |---------------------------|----------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | executable                | Yes      | Holds the information necessary to run the executable.                                                                                                                                                                                                                                                   |
 | executable.command        | Yes      | Specifies the full command to run to retrieve the subject token. This can include arguments. Must be an absolute path for the program.                                                                                                                                                                   |
@@ -452,7 +452,7 @@ Additionally, the executable **must** adhere to the following response format:
 
 Successful responses:
 
-| Field Name                | Type    | Description                                                                                                                                                                        |        
+| Field Name                | Type    | Description                                                                                                                                                                        |
 |---------------------------|---------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | version                   | number  | The version of the JSON output. Currently only version 1 is supported.                                                                                                             |
 | success                   | boolean | The status of the response. True in this case.                                                                                                                                     |
@@ -484,7 +484,7 @@ A sample successful executable SAML response:
 
 Error responses:
 
-| Field Name | Type    | Description                                                            |        
+| Field Name | Type    | Description                                                            |
 |------------|---------|:-----------------------------------------------------------------------|
 | version    | number  | The version of the JSON output. Currently only version 1 is supported. |
 | success    | boolean | The status of the response. False in this case.                        |                                                                                                                                                                  |
@@ -509,7 +509,7 @@ The auth libraries and applications **must** follow the steps below:
   **credential_source.executable** field.
 - Check that the `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` environment variable is set to **1**. If not, error out.
 - Before the next step, check if **credential_source.executable.output_file** was specified in the credential configuration.
-  - If present, check if there is an executable response at that location. 
+  - If present, check if there is an executable response at that location.
   - If the response is valid and unexpired, or there is no response at that location, continue execution.
   - If the response is malformed or invalid, error out.
 - Ensure the following environment variables will be available to the executable:
@@ -528,7 +528,7 @@ The auth libraries and applications **must** follow the steps below:
     **urn:ietf:params:oauth:token-type:id_token**, or **urn:ietf:params:oauth:token-type:saml2**.
   - If the **token_type** is **urn:ietf:params:oauth:token-type:saml2**, the subject token will be parsed from the **saml_response** field.
   - Otherwise it will be parsed from the **id_token** field.
-  
+
 ## Changelog
 
 - **2021-12-10**: Add AIP for External Account Credentials (AIP 4117).

--- a/aip/auth/4117.md
+++ b/aip/auth/4117.md
@@ -534,6 +534,7 @@ The auth libraries and applications **must** follow the steps below:
 - **2021-12-10**: Add AIP for External Account Credentials (AIP 4117).
 - **2022-05-18**: Document executable-sourced credentials (AIP 4117).
 - **2022-08-31**: Document configurable token lifetime (AIP 4117).
+- **2023-09-12**: Mark region_url as optional (AIP 4117).
 
 <!-- prettier-ignore-start -->
 [0]: https://cloud.google.com/iam/docs/configuring-workload-identity-federation#aws


### PR DESCRIPTION
According to https://github.com/googleapis/google-auth-library-php/pull/474#discussion_r1312138753, the `region_url` should not be required in the external account JSON credentials. Updating the AIP to reflect this.