### PR TITLE
fix(AIP-133): remove REQUIRED from the resource_id field.

### DIFF
--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -84,7 +84,7 @@ message CreateBookRequest {
   //
   // This value should be 4-63 characters, and valid characters
   // are /[a-z][0-9]-/.
-  string book_id = 2 [(google.api.field_behavior) = REQUIRED];
+  string book_id = 2;
 
   // The book to create.
   Book book = 3 [(google.api.field_behavior) = REQUIRED];


### PR DESCRIPTION
It is misleading to annotate `book_id` with `REQUIRED` in the example because in many cases, clients can/must omit the resource id and let the server pick one.

