### PR TITLE
fix(AIP-202): rename type to FieldInfo

### DIFF
--- a/aip/general/0202.md
+++ b/aip/general/0202.md
@@ -9,22 +9,22 @@ placement:
 
 # Fields
 
-The [`google.api.Field`][field proto] type, through its accompanying extension
-`google.api.field`, enriches a field's schema beyond the basic name and type
-information.
+The [`google.api.FieldInfo`][field info proto] type, through its accompanying
+extension `google.api.field_info`, enriches a field's schema beyond the basic
+name and type information.
 
 ## Guidance
 
-Decorating a field with `google.api.field` is only necessary when explicitly
-stated in this AIP or another that leverages `google.api.Field` information. As
-such, the guidance herein applies to those scenarios as well.
+Decorating a field with `google.api.field_info` is only necessary when
+explicitly stated in this AIP or another that leverages `google.api.FieldInfo`
+information. As such, the guidance herein applies to those scenarios as well.
 
 ### Format
 
 Fields with a primitive type can still have a specific format. To convey that
-type format, the `Field.Format` enumeration is used via the
-`(google.api.field).format` extension field. The following guidance conveys the
-meaning of and requirements for use of each `Field.Format` value.
+type format, the `FieldInfo.Format` enumeration is used via the
+`(google.api.field_info).format` extension field. The following guidance conveys
+the meaning of and requirements for use of each `FieldInfo.Format` value.
 
 #### UUID4
 
@@ -78,7 +78,7 @@ backwards compatible.
 
 #### Extending Format
 
-Any new `Field.Format` value **must** be governed by an
+Any new `FieldInfo.Format` value **must** be governed by an
 [IETF-approved RFC][ietf rfc] or a [Google-approved AIP](./0001.md).
 
 ## Rationale
@@ -109,10 +109,10 @@ create a user-friendly surface.
 Those formats which are sufficiently standardized to merit an RFC or AIP are
 stable enough and widely enough known to be incorporated as a supported value
 and see usage in Google APIs. Requiring such extra guidance means that governing
-the format specification is not the responsibility of the `Field.Format`
+the format specification is not the responsibility of the `FieldInfo.Format`
 enumeration itself.
 
-[field proto]: https://github.com/googleapis/googleapis/blob/master/google/api/field.proto
+[field info proto]: https://github.com/googleapis/googleapis/blob/master/google/api/field_info.proto
 [rfc 4122]: https://datatracker.ietf.org/doc/html/rfc4122
 [rfc 791]: https://datatracker.ietf.org/doc/html/rfc791
 [rfc 4291]: https://datatracker.ietf.org/doc/html/rfc4291#section-2.2


### PR DESCRIPTION
Renaming `s/Field/FieldInfo` and `s/field/field_info`. This is to avoid collisions with `google.protobuf.Field`.