### PR TITLE
fix(AIP-155): add format extension guidance

### DIFF
--- a/aip/general/0155.md
+++ b/aip/general/0155.md
@@ -41,7 +41,7 @@ message CreateBookRequest {
   // A unique identifier for this request. Restricted to 36 ASCII characters.
   // A random UUID is recommended.
   // This request is only idempotent if a `request_id` is provided.
-  string request_id = 3;
+  string request_id = 3 [(google.api.field_info).format = UUID4];
 }
 ```
 
@@ -56,6 +56,9 @@ message CreateBookRequest {
 - Request IDs **should** be able to be UUIDs, and **may** allow UUIDs to be the
   only valid format. The format restrictions for request IDs **must** be
   documented.
+  - Request IDs that are UUIDs **must** be annotated with the
+    `google.api.FieldInfo.Format` value `UUID4` using the extension
+    `(google.api.field_info).format = UUID4`. See [AIP-202](./0202.md) for more.
 
 ### Stale success responses
 
@@ -77,5 +80,6 @@ response with a similar response that reflects more current data.
 
 ## Changelog
 
+- **2023-10-02**: Add UUID format extension guidance.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.

--- a/aip/general/0155.md
+++ b/aip/general/0155.md
@@ -78,6 +78,15 @@ response with a similar response that reflects more current data.
 - For how to retry errors in client libraries, see
   [AIP-4221](https://aip.dev/4221).
 
+## Rationale
+
+### Using UUIDs for request identification
+
+When a value is required to be unique, leaving the format open-ended can lead to
+API consumers incorrectly providing a duplicate identifier. As such,
+standardizing on a universally unique identifier drastically reduces the chance
+for collisions when done correctly.
+
 ## Changelog
 
 - **2023-10-02**: Add UUID format extension guidance.


### PR DESCRIPTION
Requires that a `request_id` that is a UUID be documented with the `(google.api.field_info).format = UUID4` extension.

This intentionally does not change the guidance to force `request_id` to be a uuid. There could be other formats that are sufficient or already in use. So we will focus on those that self-document as uuid. At some point, we may change that to only allow uuid, but of course existing cases must be allowed as they are.