### PR TITLE
fix(AIP-203): explain IDENTIFIER behavior

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -226,13 +226,18 @@ There are some changes that *are* backwards compatible, which are as follows:
 
 ## Rationale
 
-## Identifier field behavior
+### Identifier field behavior
 
 Resource names, the primary identifier for any compliant resource, are never
-fully constructed by the user on create. They are, however, often read as input
-in scenarios where the resource itself is primary source of information in the
-request. This contextual field behavior meant that a new value was necessary to
-convey the behavior of the resource name.
+fully constructed by the user on create. Such a field is typically assigned
+`OUTPUT_ONLY` field behavior. They are, however, also often consumed as
+the primary identifier in scenarios where the resource itself is the primary
+request payload. Such a field could *not* be considered `OUTPUT_ONLY`.
+Furthermore, in mutation requests, like Standard Update, the resource name as
+the primary identifier cannot be changed in place. Such a field is typically
+assigned `IMMUTABLE` field behavior. These conflicting and context-dependent
+field behaviors meant that a new value was necessary to single out and convey
+the behavior of the resource name field.
 
 ### Required set of annotations
 

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -75,7 +75,6 @@ The `IDENTIFIER` value conveys that the field is not accepted as input (i.e.
 `IMMUTABLE` and accepted as input for mutation methods that accept the
 resource as the primary input e.g. [Standard Update][aip-134].
 
-
 This annotation **must not** be applied to references to other resources within
 a message.
 
@@ -228,13 +227,13 @@ There are some changes that *are* backwards compatible, which are as follows:
 
 ### Identifier field behavior
 
-Resource names, the primary identifier for any compliant resource, are never
-fully constructed by the user on create. Such a field is typically assigned
+Resource names, the primary identifiers for any compliant resource, are never
+fully constructed by the user on create. Such fields are typically assigned
 `OUTPUT_ONLY` field behavior. They are, however, also often consumed as
 the primary identifier in scenarios where the resource itself is the primary
-request payload. Such a field could *not* be considered `OUTPUT_ONLY`.
+request payload. Such fields could *not* be considered `OUTPUT_ONLY`.
 Furthermore, in mutation requests, like Standard Update, the resource name as
-the primary identifier cannot be changed in place. Such a field is typically
+the primary identifier cannot be changed in place. Such fields are typically
 assigned `IMMUTABLE` field behavior. These conflicting and context-dependent
 field behaviors meant that a new value was necessary to single out and convey
 the behavior of the resource name field.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -70,6 +70,12 @@ The use of `IDENTIFIER` indicates that a field within a resource message is used
 to identify the resource. It **must** be attached to the `name` field and **must
 not** be attached to any other field (see [fields representing resource names]).
 
+The `IDENTIFIER` value conveys that the field is not accepted as input (i.e.
+`OUTPUT_ONLY`) in the context of a create method, while also being considered
+`IMMUTABLE` and accepted as input for mutation methods that accept the
+resource as the primary input e.g. [Standard Update][aip-134].
+
+
 This annotation **must not** be applied to references to other resources within
 a message.
 
@@ -219,6 +225,14 @@ There are some changes that *are* backwards compatible, which are as follows:
 * Removing `IMMUTABLE` from an existing field previously considered immutable
 
 ## Rationale
+
+## Identifier field behavior
+
+Resource names, the primary identifier for any compliant resource, are never
+fully constructed by the user on create. They are, however, often read as input
+in scenarios where the resource itself is primary source of information in the
+request. This contextual field behavior meant that a new value was necessary to
+convey the behavior of the resource name.
 
 ### Required set of annotations
 


### PR DESCRIPTION
The actual behavior was unclear, but what is added conveys the behavior we expected before we had this value.

Also add rationale for its creation/use.