### PR TITLE
converge AIP-161 and AIP-203 update field mask guidance for dealing with output only fields

### DIFF
--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -137,10 +137,9 @@ subfield), the service **must** ignore any output only fields provided as
 input, even if they are cleared or modified.
 
 If a user directly specifies an output only field in an update mask, the
-service **should** ignore the output only fields provided as input, even if
+service **must** ignore the output only fields provided as input, even if
 they are cleared or modified, to permit the same field mask to be used for
-input and output. However, the service **may** choose to error with
-`INVALID_ARGUMENT` if the field is modified in input.
+input and output.
 
 ### Invalid field mask entries
 
@@ -154,4 +153,6 @@ permit deletions.
 
 ## Changelog
 
+- **2023-10-18**: Update guidance for presence of output only fields in update
+  mask.
 - **2023-07-17**: Move `update_mask` guidance to AIP-134.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -129,7 +129,8 @@ The use of `OUTPUT_ONLY` indicates that the field is provided in responses, but
 that including the field in a message in a request does nothing (the server
 **must** clear out any value in this field and **must not** throw an error as a
 result of the presence of a value in this field on input). Similarly, services
-**must** ignore the presence of output only fields in update field masks.
+**must** ignore the presence of output only fields in update field masks (see:
+AIP-161).
 
 Additionally, a field **should** only be described as output only if it is a
 field in a resource message, or a field of a message farther down the tree.


### PR DESCRIPTION
There are inconsistencies between AIP-161 and AIP-203 guidance regarding server handling the presence of output fields in update Field Marks.

In these scenarios, servers should be flexible to allow re-using the same field masks for updates and read. Updating guidance in AIP-161 to reflect that.