### PR TITLE
Update AIP 122 to state field "name" is immutable

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -53,6 +53,7 @@ the leading slash:
   - Resources **must not** expose tuples, self-links, or other forms of
     resource identification.
   - All ID fields **should** be strings.
+  - The resource `name` field **must** be considered immutable by mutation requests.
 
 **Note:** Resource names as described here are used within the scope of a
 single API (or else in situations where the owning API is clear from the


### PR DESCRIPTION
Update AIP 122 to be explicit that a resource name must be considered immutable during a mutation operation.

Based on discussion with @noahdietz who recommended the update.