### PR TITLE
Promote AIP-162 to approved

### DIFF
--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -1,8 +1,8 @@
 ---
 id: 162
-state: draft
+state: approved
 created: 2019-09-17
-updated: 2023-09-01
+updated: 2023-12-12
 placement:
   category: design-patterns
   order: 88

--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -45,8 +45,14 @@ resource. In other words, resource revisions exist after resource deletion.
 
 ```proto
 message BookRevision {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/BookRevision"
+    pattern: "publishers/{publisher}/books/{book}/revisions/{revision}"
+  };
+
   // The name of the book revision.
-  string name = 1;
+  // Format: publishers/{publisher}/books/{book}/revisions/{revision}
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // The snapshot of the book
   Book snapshot = 2
@@ -72,7 +78,7 @@ message BookRevision {
 - The resource revision **may** contain a repeated field `alternate_ids`, which would
   contain a list of resource IDs that the revision is also known by (e.g. `latest`)
 
-### Creating Revisions
+### Strategies for Creating Revisions
 
 Depending on the resource, different APIs may have different strategies for
 
@@ -112,13 +118,16 @@ APIs **may** provide a mechanism for users to assign an [alias][] ID to an
 existing revision with a custom method "alias":
 
 ```proto
-rpc AliasBookRevision(TagBookRevisionRequest) returns (Book) {
+rpc AliasBookRevision(AliasBookRevisionRequest) returns (BookRevision) {
   option (google.api.http) = {
     post: "/v1/{name=publishers/*/books/*/revisions/*}:alias"
     body: "*"
   };
 }
 ```
+
+- The method **must** use the `POST` HTTP verb [aip-136].
+- The method **must** return the modified resource revision.
 
 ```proto
 message AliasBookRevisionRequest {
@@ -128,7 +137,7 @@ message AliasBookRevisionRequest {
       type: "library.googleapis.com/BookRevision"
     }];
 
-  // The ID of the revision to alias to, e.g. `CURRENT` or a semantic
+  // The ID of the revision to alias to, e.g. `current` or a semantic
   // version.
   string alias_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
@@ -161,7 +170,7 @@ rpc RollbackBook(RollbackBookRequest) returns (BookRevision) {
 ```
 
 - The method **must** use the `POST` HTTP verb.
-- The method **should** return a resource revision.
+- The method **must** return a resource revision.
 
 ```proto
 message RollbackBookRequest {
@@ -195,15 +204,30 @@ this quickly becomes difficult to reason about.
 
 ### Standard methods
 
-Any standard methods **must** implement the corresponding AIPs (AIP-131,
-AIP-132, AIP-133, AIP-134, AIP-135), with the following additional behaviors:
+#### Get
 
-- List methods: By default, revisions in the list response **must** be ordered
-  in reverse chronological order. User can supply `order_by` to override the
-  default behavior.
-- If the revision supports aliasing, a delete method with the resource name
-  of the alias (e.g. `revisions/1.0.2`) **must** remove the alias instead of
-  deleting the resource.
+Get **must** be implemented.
+
+#### List
+
+List **must** be implemented. By default, revisions in the list response **must**
+be ordered in reverse chronological order. User can supply `order_by` to override the
+default behavior.
+
+#### Create
+
+Create **must** be implemented if the resource uses a create strategy of creating
+a new revision when specifically requested.
+
+#### Update
+
+Update **must not** be implemented, as revision resources do not include any mutable fields.
+
+#### Delete
+
+Delete **must** be implemented. If the revision supports aliasing, a delete method with the 
+resource name of the alias (e.g. `revisions/1.0.2`) **must** remove the alias instead of
+deleting the resource.
 
 As revisions are nested under the resource, also see [cascading delete][].
 

--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -74,9 +74,11 @@ message BookRevision {
   parent resource, with a field name of `snapshot`.
     - The value of `snapshot` **must** be the configuration of the parent
       at the point in time the revision was created.
-- The resource revision **must** contain a `create_time` field (see [AIP-142][]).
-- The resource revision **may** contain a repeated field `alternate_ids`, which would
-  contain a list of resource IDs that the revision is also known by (e.g. `latest`)
+- The resource revision **must** contain a `create_time` field
+  (see [AIP-142][]).
+- The resource revision **may** contain a repeated field `alternate_ids`, which 
+  would contain a list of resource IDs that the revision is also known by 
+  (e.g. `latest`).
 
 ### Strategies for Creating Revisions
 
@@ -206,28 +208,29 @@ this quickly becomes difficult to reason about.
 
 #### Get
 
-Get **must** be implemented.
+Get [aip-131] **must** be implemented.
 
 #### List
 
-List **must** be implemented. By default, revisions in the list response **must**
-be ordered in reverse chronological order. User can supply `order_by` to override the
-default behavior.
+List [aip-132] **must** be implemented. By default, revisions in the list
+response **must** be ordered in reverse chronological order. User can supply
+`order_by` to override the default behavior.
 
 #### Create
 
-Create **must** be implemented if the resource uses a create strategy of creating
-a new revision when specifically requested.
+Create [aip-133] **must** be implemented, if the chosen [create strategy] is to
+create a new revision when specifically requested.
 
 #### Update
 
-Update **must not** be implemented, as revision resources do not include any mutable fields.
+Update [aip-134] **must not** be implemented, as revision resources do not
+include any mutable fields.
 
 #### Delete
 
-Delete **must** be implemented. If the revision supports aliasing, a delete method with the 
-resource name of the alias (e.g. `revisions/1.0.2`) **must** remove the alias instead of
-deleting the resource.
+Delete [aip-135] **must** be implemented. If the revision supports aliasing, 
+a delete method with the resource name of the alias (e.g. `revisions/1.0.2`)
+**must** remove the alias instead of deleting the resource.
 
 As revisions are nested under the resource, also see [cascading delete][].
 
@@ -282,7 +285,7 @@ clients to easily list, get, create, and update revisions.
 
 ### Using resource ID instead of tag
 
-In the previous design, revisions had a separate identifer for a revision known
+In the previous design, revisions had a separate identifier for a revision known
 as a `tag`, that would live in a revision.
 
 Tags were effectively a shadow resource ID, requiring methods to create, get and
@@ -293,9 +296,18 @@ needs to be familiar with a second set of retrieval and identifier methods.
 
 ## Changelog
 
+- **2023-12-12**: Added more detailed guidance on which standard methods must be
+  implemented.
 - **2023-09-01**: AIP was updated to be a sub-collection.
 - **2021-04-27**: Added guidance on returning the resource from Delete Revision.
 
+[aip-131]: https://google.aip.dev/131
+[aip-132]: https://google.aip.dev/132
+[aip-133]: https://google.aip.dev/133
+[aip-134]: https://google.aip.dev/134
+[aip-135]: https://google.aip.dev/135
+[aip-136]: https://google.aip.dev/136
 [alias]: ./0122.md#resource-id-aliases
 [cascading delete]: ./0135.md#cascading-delete
+[create strategy]: #strategies-for-creating-revisions
 [UUID4]: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)


### PR DESCRIPTION
Summary:

- Disallow `Update` standard method, as revisions don't expose mutable fields
- Fix code samples
- Promote AIP to approved

There are a few items that still need clarification, as called out in https://github.com/aip-dev/google.aip.dev/issues/1206:

* The user journey of creating a revision with a semantic name is a bit rough: you have to create a revision, then assign it an alias. Ideally it should be one call.
* Revisions also states that a revision could be a sibling collection instead of a child collection. This pattern is probably possible to support, the AIP needs to be rewritten to allow that (e.g. clarify what the custom method path should be in the case of siblings).
* How do we allow a single field to address "either a resource or a revision".

These changes can be incrementally added later, moving AIP to approved as we're not planning to address these gaps in the near future.