### PR TITLE
Add guidance to avoid overly generic resource names.

### DIFF
--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -42,8 +42,8 @@ the following pattern: `{Service Name}/{Type}`. The type name **must**:
 - Be of the singular form of the noun.
 - Use PascalCase (UpperCamelCase).
 
-Additionally APIs **should** avoid overly generic resource names like Metadata,
-Resource, Config, Settings, etc.
+Additionally APIs **should** avoid overly generic resource names like
+`Metadata`, `Resource`, `Config`, `Settings`, etc.
 
 ### Examples
 
@@ -110,6 +110,13 @@ proper name to use in code and documentation.
 
 lowerCamelCase can be translated into other common forms of a resource name
 such as UpperCamelCase and snake_case.
+
+### Overly Generic Type Names
+
+Overly generic types like `Metadata` or `Resource` will cause confusion as the 
+API introduces more concepts.  Unless the resource represents a 
+[singleton][aip-156] containing API-level settings, a more specific name should 
+be used.
 
 <!-- prettier-ignore-start -->
 [aip-122]: ./0122.md

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -42,8 +42,8 @@ the following pattern: `{Service Name}/{Type}`. The type name **must**:
 - Be of the singular form of the noun.
 - Use PascalCase (UpperCamelCase).
 
-Additionally APIs **should** avoid avoid overly generic resource names like 
-Metadata, Resource, Config, Settings, etc.
+Additionally APIs **should** avoid overly generic resource names like Metadata,
+Resource, Config, Settings, etc.
 
 ### Examples
 

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -42,6 +42,9 @@ the following pattern: `{Service Name}/{Type}`. The type name **must**:
 - Be of the singular form of the noun.
 - Use PascalCase (UpperCamelCase).
 
+Additionally APIs **should** avoid avoid overly generic resource names like 
+Metadata, Resource, Config, Settings, etc.
+
 ### Examples
 
 Examples of resource types include:

--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -121,7 +121,7 @@ such as UpperCamelCase and snake_case.
 <!-- prettier-ignore-end -->
 
 ## Changelog
-
+- **2023-12-20**: Added guidance on overly-generic resource type names.
 - **2023-09-19**: Prohibit duplicate pattern variables.
 - **2023-05-06**: Adding requirement of singular and plural.
 - **2023-01-28**: Clarifying guidance for the resource type name.


### PR DESCRIPTION
These often cause confusion down the line as the API introduces more concepts.