### PR TITLE
chore(AIP-155): fix request message to include book_id

### DIFF
--- a/aip/general/0155.md
+++ b/aip/general/0155.md
@@ -35,13 +35,20 @@ message CreateBookRequest {
       child_type: "library.googleapis.com/Book"
     }];
 
+  // The ID to use for the book, which will become the final component of
+  // the book's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  string book_id = 2 [(google.api.field_behavior) = REQUIRED];
+
   // The book to create.
-  Book book = 2 [(google.api.field_behavior) = REQUIRED];
+  Book book = 3 [(google.api.field_behavior) = REQUIRED];
 
   // A unique identifier for this request. Restricted to 36 ASCII characters.
   // A random UUID is recommended.
   // This request is only idempotent if a `request_id` is provided.
-  string request_id = 3 [(google.api.field_info).format = UUID4];
+  string request_id = 4 [(google.api.field_info).format = UUID4];
 }
 ```
 
@@ -89,6 +96,7 @@ for collisions when done correctly.
 
 ## Changelog
 
+- **2024-01-08**: Add book_id to request message.
 - **2023-10-02**: Add UUID format extension guidance.
 - **2019-08-01**: Changed the examples from "shelves" to "publishers", to
   present a better example of resource ownership.


### PR DESCRIPTION
`CreateBookRequest` must include `book_id`, per https://google.aip.dev/133#user-specified-ids.