### PR TITLE
fix(AIP-128): clarify usage of `annotations` field for Declarative-friendly resources

### DIFF
--- a/aip/general/0128.md
+++ b/aip/general/0128.md
@@ -75,14 +75,13 @@ is a comprehensive reference to declarative-friendly guidance in other AIPs:
 - Resources **should** provide change validation: see AIP-163.
 - Resources **should not** implement soft-delete. If the id cannot be re-used,
   the resource **must** implement soft-delete and the undelete RPC: see AIP-164
-
-
-### Annotations
-
-See [AIP-148 annotations][].
+- Resources **must** include a
+`map<string, string> annotations` field to allow clients to store small amounts
+of arbitrary data: see AIP-148
 
 ## Changelog
 
+- **2024-01-29**: Clarify usage of `annotations`.
 - **2023-07-13**: Move `annotations` from AIP-148.
 - **2023-06-17**: Definition of plane was removed and incorporated into AIP-111.
 - **2023-05-11**: Removed must on resource_id, which was upstreamed to a general

--- a/aip/general/0148.md
+++ b/aip/general/0148.md
@@ -175,6 +175,7 @@ Before 2023-07, `purge_time` for soft-deleted resources was also called
 
 ## Changelog
 
+- **2024-01-29**: Clarify usage of `annotations` in `Declarative-friendly resources`.
 - **2023-10-05**: Introduce well known string fields with IP Address and `uid`.
 - **2023-08-14**: Introduce the term `annotations` from AIP-128.
 - **2023-07-13**: Introduce the term `purge_time`.

--- a/aip/general/0148.md
+++ b/aip/general/0148.md
@@ -116,7 +116,7 @@ field **may** be added.
 
 The `annotations` field **must** use the [Kubernetes limits][] to maintain wire
 compatibility, and **should** require dot-namespaced annotation keys to prevent
-tools from trampling over one another.
+tools from trampling over one another. [Declarative-friendly resources][] **should** include this field.
 
 Examples of information that might be valuable to store in annotations include:
 

--- a/aip/general/0148.md
+++ b/aip/general/0148.md
@@ -116,7 +116,7 @@ field **may** be added.
 
 The `annotations` field **must** use the [Kubernetes limits][] to maintain wire
 compatibility, and **should** require dot-namespaced annotation keys to prevent
-tools from trampling over one another. [Declarative-friendly resources][] **should** include this field.
+tools from trampling over one another. [Declarative-friendly resources][] **must** include this field.
 
 Examples of information that might be valuable to store in annotations include:
 


### PR DESCRIPTION
In https://github.com/aip-dev/google.aip.dev/pull/1183, guide was moved from AIP-128 to AIP-148. 
As a result, the information whether `Declarative-friendly interfaces` must  include `annotations` field was lost. 
This PR or related issue do not justify the reason of recommendation change, therefore I consider it as a bug.

This change returns the recommendation to the one before the change and puts it in both AIP-128 and AIP-148
