### PR TITLE
Update normalized IPv6 address to follow RFC 5952

### DIFF
--- a/aip/general/0202.md
+++ b/aip/general/0202.md
@@ -55,9 +55,9 @@ comparison. Instead, an [RFC 791][] compliant implementation **must** be used.
 The `IPV6` format represents an IP v6 address as governed by [RFC 4291][]. It
 **must** only be used on a field of type `string`.
 
-Such a value **may** be normalized by the service to entirely lowercase letters,
-and zero-padded partial and empty octets. For example, the value `2001:DB8::`
-would be normalized to `2001:0db8:0:0`.
+Such a value **may** be normalized by the service to entirely lowercase letters
+with zeros compressed, following [RFC 5952][]. For example, the value
+`2001:0DB8:0::0` would be normalized to `2001:db8::`.
 
 As such, equivalence comparison **must not** be done via primitive text
 comparison. Instead, an [RFC 4291][] compliant implementation **must** be used.


### PR DESCRIPTION
The previous example of a normalized address is invalid because it leaves ambiguous where to pad additional zeros. Example: https://go.dev/play/p/mcJ7sdBl79v