### PR TITLE
fix: markdown mistake when referring to an AIP

### DIFF
--- a/aip/general/0162.md
+++ b/aip/general/0162.md
@@ -68,7 +68,7 @@ message BookRevision {
   parent resource, with a field name of `snapshot`.
     - The value of `snapshot` **must** be the configuration of the parent
       at the point in time the revision was created.
-- The resource revision **must** contain a `create_time` field (see [AIP-142][]).
+- The resource revision **must** contain a `create_time` field (see AIP-142).
 - The resource revision **may** contain a repeated field `alternate_ids`, which would
   contain a list of resource IDs that the revision is also known by (e.g. `latest`)
 


### PR DESCRIPTION
Currently, the AIP reference renders wrongly, and this commit fixes it.

![image](https://github.com/aip-dev/google.aip.dev/assets/16375100/5a95c2c3-cb95-4b12-8ee5-bcf690d72036)