### PR TITLE
chore(203): clarify INPUT_ONLY is not enough

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -247,6 +247,8 @@ In the case of an output, the `OUTPUT_ONLY` annotation is sufficient.
 
 In the case of an input, a field is either required or optional, and therefore
 should have at least the `REQUIRED` or `OPTIONAL` annotation, respectively.
+Only providing `INPUT_ONLY` does not convey the necessity of the field, so
+specifying either `REQUIRED` or `OPTIONAL` is still necessary.
 
 ### Requiring field behavior
 


### PR DESCRIPTION
Some confusion with the linter.aip.dev/203/field-behavior-required finding when a field has just `INPUT_ONLY`. It isn't sufficient for the purposes of fully documenting field behavior.