### PR TITLE
Fix Reference link for `Declarative clients`

### DIFF
--- a/aip/general/0009.md
+++ b/aip/general/0009.md
@@ -111,7 +111,7 @@ Examples of clients include the following:
 - Libraries, such as an SDK for a particular programming language
 - Scripts that operates on a JSON representation of a resource after reading it
   from an API
-- Tools, such as a [Declarative client][]
+- Tools, such as a [Declarative clients][]
 - Visual UIs, such as a web application
 
 ### Google API


### PR DESCRIPTION
Fixing Reference Link for `Declarative client`.
![image](https://github.com/aip-dev/google.aip.dev/assets/18348233/e4746acc-fc76-4c55-841d-972c288e1ad6)

At the end of [AIP 9 Code link](https://github.com/aip-dev/google.aip.dev/blob/9f44815cb14d68beab936f22bfe9224a15c83769/aip/general/0009.md?plain=1#L154): 
`[Declarative clients]: #declarative-clients` is defined and hence correcting the spell (From `Declarative client` to `Declarative clients`) will fix the link