### PR TITLE
fix(AIP-4235): update generator behavior for explicit field presence

### DIFF
--- a/aip/client-libraries/4235.md
+++ b/aip/client-libraries/4235.md
@@ -7,7 +7,7 @@ created: 2024-03-07
 # Automatically populate fields in the request message
 
 For APIs that leverage request idempotency as described via [AIP-155], APIs may
-choose to have the client libraries automatically populate fields such as 
+choose to have the client libraries automatically populate fields such as
 `request_id` if they are not already set by the customer.
 
 **Note:** This feature is primarily written for `request_id` fields within the
@@ -38,14 +38,19 @@ If the aforementioned requirements are met for a given field, client library
 generators **must** enable automatic population of said field in the
 generated client.
 
+If the field value is not equal to default value at the time of sending the
+request, implying it was set by the user or if the field has explicit presence
+and is set by the user, the field **must not** be automatically populated by the
+client.
+
 If a field is specified in the `auto_populated_fields`, but does not meet the
 structural requirements, the client library generators **must not** enable
 automatic population for that field. Client library generators **may** emit an
 error during generation.
 
 Client libraries **must** reuse automatically populated values for retries of
-the same request. In other words, the automatically populated fields **must not**
-be regenerated for each RPC attempt with the same request message.
+the same request. In other words, the automatically populated fields
+**must not** be regenerated for each RPC attempt with the same request message.
 
 [AIP-155]: https://google.aip.dev/155
 

--- a/aip/client-libraries/4235.md
+++ b/aip/client-libraries/4235.md
@@ -38,12 +38,12 @@ If the aforementioned requirements are met for a given field, client library
 generators **must** enable automatic population of said field in the
 generated client.
 
-The field **must not** be automatically populated by the client if:
+The field **must** be automatically populated if and only if one of the
+following conditions holds:
 
-- The field does not support explicit presence, and its value is not equal to
-  the default
-- The field supports explicit presence, and presence indicates that it has been
-  set (even to the default value)
+- The field supports explicit presence, and has **not** been set by the user
+- The field doesn't support explicit presence, and its value is the empty
+  string (i.e. the default value)
 
 If a field is specified in the `auto_populated_fields`, but does not meet the
 structural requirements, the client library generators **must not** enable
@@ -51,8 +51,8 @@ automatic population for that field. Client library generators **may** emit an
 error during generation.
 
 Client libraries **must** reuse automatically populated values for retries of
-the same request. In other words, the automatically populated fields **must not**
-be regenerated for each RPC attempt with the same request message.
+the same request. In other words, the automatically populated fields
+**must not** be regenerated for each RPC attempt with the same request message.
 
 [AIP-155]: https://google.aip.dev/155
 

--- a/aip/client-libraries/4235.md
+++ b/aip/client-libraries/4235.md
@@ -38,10 +38,12 @@ If the aforementioned requirements are met for a given field, client library
 generators **must** enable automatic population of said field in the
 generated client.
 
-If the field value is not equal to default value at the time of sending the
-request, implying it was set by the user or if the field has explicit presence
-and is set by the user, the field **must not** be automatically populated by the
-client.
+The field **must not** be automatically populated by the client if:
+
+- The field does not support explicit presence, and its value is not equal to
+  the default
+- The field supports explicit presence, and presence indicates that it has been
+  set (even to the default value)
 
 If a field is specified in the `auto_populated_fields`, but does not meet the
 structural requirements, the client library generators **must not** enable
@@ -49,8 +51,8 @@ automatic population for that field. Client library generators **may** emit an
 error during generation.
 
 Client libraries **must** reuse automatically populated values for retries of
-the same request. In other words, the automatically populated fields
-**must not** be regenerated for each RPC attempt with the same request message.
+the same request. In other words, the automatically populated fields **must not**
+be regenerated for each RPC attempt with the same request message.
 
 [AIP-155]: https://google.aip.dev/155
 


### PR DESCRIPTION
Updates 4235 to include requirement that generators only automatically populate the field if it is not already set