### PR TITLE
chore(AIP-156): require singular and plural in resource

### DIFF
--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -115,7 +115,7 @@ found lacking.
 ### Including `plural` definition
 
 While a Singleton is by definition singular, there are certain cases where
-a Singleton resource may appear in a plural form e.g., is the service supports
+a Singleton resource may appear in a plural form e.g., if the service supports
 Standard List (as defined here). As such, it is better to forward declare the
 plural form of the Singleton resource type than to not have it when needed.
 

--- a/aip/general/0156.md
+++ b/aip/general/0156.md
@@ -26,6 +26,8 @@ message Config {
   option (google.api.resource) = {
     type: "api.googleapis.com/Config"
     pattern: "users/{user}/config"
+    singular: "config"
+    plural: "configs"
   };
 
   // additional fields including name
@@ -55,6 +57,8 @@ rpc UpdateConfig(UpdateConfigRequest) returns (Config) {
   - Example: `users/1234/config`
 - Singleton resources are always singular.
   - Example: `users/1234/thing`
+- Singleton resource defintions **must** provide both the `singular` and
+  `plural` fields (see above example).
 - Singleton resources **may** parent other resources.
 - Singleton resources **must not** define the [`Create`][aip-133] or
   [`Delete`][aip-135] standard methods. The singleton is implicitly created or
@@ -108,8 +112,16 @@ Furthermore, presenting the Singleton resource as a pseudo-collection in such
 methods enables future expansion to a real collection, should a Singleton be
 found lacking.
 
+### Including `plural` definition
+
+While a Singleton is by definition singular, there are certain cases where
+a Singleton resource may appear in a plural form e.g., is the service supports
+Standard List (as defined here). As such, it is better to forward declare the
+plural form of the Singleton resource type than to not have it when needed.
+
 ## Changelog
 
+- **2024-04-15:** Singletons must specify `singular` and `plural` in resource.
 - **2023-08-10:** Add Standard `List` support.
 - **2023-07-26:** Clarified that read-only singletons should not have `Update`.
 - **2021-11-02:** Added an example message and state parent eligibility.


### PR DESCRIPTION
After a bit of back and forth ([see conflicted ApiLinter issue](https://github.com/googleapis/api-linter/issues/1333)), we want Singleton resources to always declare `singular` and `plural` just like AIP-123 dictates. We should call this out specifically.