### PR TITLE
AIP-4236 - API Versioning for Version-aware clients

### DIFF
--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -13,21 +13,38 @@ include the value of `google.api.api_version` in the request to the API.
 ### Expected Generator and Client Library Behavior
 
 If a service is annotated with `google.api.api_version`, client library
-generators **must** include the version in requests sent to the API via
-the HTTP Header `X-Goog-Api-Version`.
-
-Requests which contain the API version, **must** include either an HTTP query
-parameter `$apiVersion` or HTTP header `X-Goog-Api-Version`, but a request
-**must not** contain both.
+generators **must** include either an HTTP query parameter `$apiVersion`
+or HTTP header `X-Goog-Api-Version`, but a request **must not** contain both.
 
 Generated documentation for a given service **may** include the value of
 `google.api.api_version`, if it exists in the source protos.
 
 ## Rationale
 
-The `google.api.api_version` annotation allows services to abide by the schema and
-service behavior at the time the API version was deployed. The format of the
-API version **must** be treated as opaque by clients. Generators and clients **must not**
-interpret the value of `google.api.api_version` beyond the uses mentioned above.
+### Necessity for Versioning
+
+Explicit API versioning using the `google.api.api_version` annotation is essential
+for maintaining compatibility between clients and services over time. As services
+evolve, their schemas and behaviors may change. By specifying the API version, a
+client communicates its expectations to the service. This allows the service to
+respond in a manner consistent with the client's understanding, preventing errors
+or unexpected results due to incompatible changes.
+
+### Importance of Opaque Treatment
+
+Clients must treat the value of `google.api.api_version` as opaque to ensure robust
+compatibility.  This means that the specific format or structure of the version string
+should not be parsed or interpreted for any purpose beyond identifying the intended API
+version. By relying on this opaque identifier, clients avoid making assumptions about the
+underlying versioning scheme, which may change independently of the API itself. This
+flexibility allows service providers to evolve their versioning strategies without
+impacting client compatibility.
+
+### Mutual Exclusivity of Query and Header
+
+Both the query parameter and header mechanisms exist to provide flexibility for different
+client environments. However, allowing both simultaneously could lead to ambiguity if the
+values differ. To ensure consistent version identification and prevent potential conflicts,
+only one mechanism should be used at a time.
 
 [`google.api.api_version`]: https://github.com/googleapis/googleapis/blob/master/google/api/client.proto

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -26,7 +26,7 @@ Generated documentation for a given service **may** include the value of
 ## Rationale
 
 The `google.api.api_version` annotation allows services to abide by the schema and
-service behavior at the time that the API version was deployed. The format of the
+service behavior at the time the API version was deployed. The format of the
 API version **must** be treated as opaque by clients. Generators and clients **must not**
 interpret the value of `google.api.api_version` beyond the uses mentioned above.
 

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -21,7 +21,7 @@ Generated documentation for a given service **may** include the value of
 
 Clients **must** treat the value of `google.api.api_version` as opaque to ensure
 robust compatibility.  This means that the specific format or structure of the
-version string should not be parsed or interpreted for any purpose beyond identifying
+version string **must not** be parsed or interpreted for any purpose beyond identifying
 the intended API version.
 
 ## Rationale

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -1,7 +1,7 @@
 ---
 id: 4236
-state: reviewing
-created: 2024-03-25
+state: approved
+created: 2024-05-16
 ---
 
 # Version-aware clients

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -6,13 +6,9 @@ created: 2024-05-16
 
 # Version-aware clients
 
-APIs can annotate services with [`google.api.api_version`][]. If 
-`google.api.api_version` is specified, version-aware clients **must** include
-the value of `google.api.api_version` in the request to the API. This allows
-services to abide by the schema and behavior of the service at the time that
-this API version was deployed. The format of the API version **must** be treated
-as opaque by clients. Clients **must not** rely on this to determine components within an API version,
-or attempt to construct other valid API versions.
+APIs can annotate services with [`google.api.api_version`][]. If
+`google.api.api_version` is specified, version-aware clients **must**
+include the value of `google.api.api_version` in the request to the API.
 
 ### Expected Generator and Client Library Behavior
 
@@ -32,8 +28,9 @@ Generated documentation for a given service **may** include the value of
 
 ## Rationale
 
-The format of the API version **must** be treated as opaque by clients. Generators and
-clients **must not** interpret the value of `google.api.api_version` beyond the uses
-mentioned above.
+The `google.api.api_version` annotation allows services to abide by the schema and
+behavior of the service at the time that the API version was deployed. The format of the
+API version **must** be treated as opaque by clients. Generators and clients **must not**
+interpret the value of `google.api.api_version` beyond the uses mentioned above.
 
 [`google.api.api_version`]: https://github.com/googleapis/googleapis/blob/master/google/api/client.proto

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -19,6 +19,11 @@ or HTTP header `X-Goog-Api-Version`, but a request **must not** contain both.
 Generated documentation for a given service **may** include the value of
 `google.api.api_version`, if it exists in the source protos.
 
+Clients must treat the value of `google.api.api_version` as opaque to ensure
+robust compatibility.  This means that the specific format or structure of the
+version string should not be parsed or interpreted for any purpose beyond identifying
+the intended API version.
+
 ## Rationale
 
 ### Necessity for Versioning
@@ -32,13 +37,11 @@ or unexpected results due to incompatible changes.
 
 ### Importance of Opaque Treatment
 
-Clients must treat the value of `google.api.api_version` as opaque to ensure robust
-compatibility.  This means that the specific format or structure of the version string
-should not be parsed or interpreted for any purpose beyond identifying the intended API
-version. By relying on this opaque identifier, clients avoid making assumptions about the
-underlying versioning scheme, which may change independently of the API itself. This
-flexibility allows service providers to evolve their versioning strategies without
-impacting client compatibility.
+Treating the `google.api.api_version` value as opaque is important for ensuring robust
+compatibility guarantees. By relying on this opaque identifier, clients avoid making
+assumptions about the underlying versioning scheme, which may change independently of
+the API itself. This flexibility allows service providers to evolve their versioning
+strategies without impacting client compatibility.
 
 ### Mutual Exclusivity of Query and Header
 

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -26,7 +26,7 @@ Generated documentation for a given service **may** include the value of
 ## Rationale
 
 The `google.api.api_version` annotation allows services to abide by the schema and
-behavior of the service at the time that the API version was deployed. The format of the
+service behavior at the time that the API version was deployed. The format of the
 API version **must** be treated as opaque by clients. Generators and clients **must not**
 interpret the value of `google.api.api_version` beyond the uses mentioned above.
 

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -25,7 +25,7 @@ For HTTP Requests, an HTTP Query Parameter `$apiVersion` can be used
 instead of the `X-Goog-Api-Version` HTTP header.
 
 Requests which contain the API version, must include either an HTTP query
-parameter `X-Goog-Api-Version` or HTTP header `$apiVersion`, but not both.
+parameter `$apiVersion` or HTTP header `X-Goog-Api-Version`, but not both.
 
 Generated documentation for a given service can include the value of
 [google.api.api_version], if it exists in the source protos.

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -11,8 +11,7 @@ APIs can annotate services with [`google.api.api_version`][]. If
 the value of `google.api.api_version` in the request to the API. This allows
 services to abide by the schema and behavior of the service at the time that
 this API version was deployed. The format of the API version **must** be treated
-as opaque by clients. Services may use a format with an apparent structure,
-but clients **must not** rely on this to determine components within an API version,
+as opaque by clients. Clients **must not** rely on this to determine components within an API version,
 or attempt to construct other valid API versions.
 
 ### Expected Generator and Client Library Behavior
@@ -21,10 +20,10 @@ If a service is annotated with `google.api.api_version`, client library
 generators **must** include the version in requests sent to the API via
 the HTTP Header `X-Goog-Api-Version`.
 
-For HTTP Requests, an HTTP Query Parameter `$apiVersion` can be used
+For HTTP Requests, an HTTP Query Parameter `$apiVersion` **may** be used
 instead of the `X-Goog-Api-Version` HTTP header.
 
-Requests which contain the API version, must include either an HTTP query
+Requests which contain the API version, **must** include either an HTTP query
 parameter `$apiVersion` or HTTP header `X-Goog-Api-Version`, but a request
 **must not** contain both.
 

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -1,23 +1,23 @@
 ---
 id: 4236
-state: approved
+state: reviewing
 created: 2024-05-16
 ---
 
 # Version-aware clients
 
-APIs may choose to annotate services with [google.api.api_version]. If 
-[google.api.api_version] is specified, version-aware clients **must** include
-the value of [google.api.api_version] in the request to the API. This allows
+APIs can annotate services with [`google.api.api_version`][]. If 
+`google.api.api_version` is specified, version-aware clients **must** include
+the value of `google.api.api_version` in the request to the API. This allows
 services to abide by the schema and behavior of the service at the time that
-this API version was deployed. The format of the API version must be treated
+this API version was deployed. The format of the API version **must** be treated
 as opaque by clients. Services may use a format with an apparent structure,
-but clients must not rely on this to determine components within an API version,
+but clients **must not** rely on this to determine components within an API version,
 or attempt to construct other valid API versions.
 
 ### Expected Generator and Client Library Behavior
 
-If a service is annotated with [google.api.api_version], client library
+If a service is annotated with `google.api.api_version`, client library
 generators **must** include the version in requests sent to the API via
 the HTTP Header `X-Goog-Api-Version`.
 
@@ -25,12 +25,16 @@ For HTTP Requests, an HTTP Query Parameter `$apiVersion` can be used
 instead of the `X-Goog-Api-Version` HTTP header.
 
 Requests which contain the API version, must include either an HTTP query
-parameter `$apiVersion` or HTTP header `X-Goog-Api-Version`, but not both.
+parameter `$apiVersion` or HTTP header `X-Goog-Api-Version`, but a request
+**must not** contain both.
 
-Generated documentation for a given service can include the value of
-[google.api.api_version], if it exists in the source protos.
+Generated documentation for a given service **may** include the value of
+`google.api.api_version`, if it exists in the source protos.
 
-The format of the API version must be treated as opaque by clients. Generators
-and clients must not use the value of [google.api.api_version] to make decisions.
+## Rationale
 
-[google.api.api_version]: https://github.com/googleapis/googleapis/blob/master/google/api/client.proto
+The format of the API version **must** be treated as opaque by clients. Generators and
+clients **must not** interpret the value of `google.api.api_version` beyond the uses
+mentioned above.
+
+[`google.api.api_version`]: https://github.com/googleapis/googleapis/blob/master/google/api/client.proto

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -1,0 +1,36 @@
+---
+id: 4236
+state: reviewing
+created: 2024-03-25
+---
+
+# Version-aware clients
+
+APIs may choose to annotate services with [google.api.api_version]. If 
+[google.api.api_version] is specified, version-aware clients **must** include
+the value of [google.api.api_version] in the request to the API. This allows
+services to abide by the schema and behavior of the service at the time that
+this API version was deployed. The format of the API version must be treated
+as opaque by clients. Services may use a format with an apparent structure,
+but clients must not rely on this to determine components within an API version,
+or attempt to construct other valid API versions.
+
+### Expected Generator and Client Library Behavior
+
+If a service is annotated with [google.api.api_version], client library
+generators **must** include the version in requests sent to the API via
+the HTTP Header `X-Goog-Api-Version`.
+
+For HTTP Requests, an HTTP Query Parameter `$apiVersion` can be used
+instead of the `X-Goog-Api-Version` HTTP header.
+
+Requests which contain the API version, must include either an HTTP query
+parameter `X-Goog-Api-Version` or HTTP header `$apiVersion`, but not both.
+
+Generated documentation for a given service can include the value of
+[google.api.api_version], if it exists in the source protos.
+
+The format of the API version must be treated as opaque by clients. Generators
+and clients must not use the value of [google.api.api_version] to make decisions.
+
+[google.api.api_version]: https://github.com/googleapis/googleapis/blob/master/google/api/client.proto

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -19,7 +19,7 @@ or HTTP header `X-Goog-Api-Version`, but a request **must not** contain both.
 Generated documentation for a given service **may** include the value of
 `google.api.api_version`, if it exists in the source protos.
 
-Clients must treat the value of `google.api.api_version` as opaque to ensure
+Clients **must** treat the value of `google.api.api_version` as opaque to ensure
 robust compatibility.  This means that the specific format or structure of the
 version string should not be parsed or interpreted for any purpose beyond identifying
 the intended API version.

--- a/aip/client-libraries/4236.md
+++ b/aip/client-libraries/4236.md
@@ -16,9 +16,6 @@ If a service is annotated with `google.api.api_version`, client library
 generators **must** include the version in requests sent to the API via
 the HTTP Header `X-Goog-Api-Version`.
 
-For HTTP Requests, an HTTP Query Parameter `$apiVersion` **may** be used
-instead of the `X-Goog-Api-Version` HTTP header.
-
 Requests which contain the API version, **must** include either an HTTP query
 parameter `$apiVersion` or HTTP header `X-Goog-Api-Version`, but a request
 **must not** contain both.


### PR DESCRIPTION
The following is an AIP for the API Versioning feature in client library generators.

Googlers see b/330951736