### PR TITLE
fix(AIP-4231): include type and child_type ref compat guidance

### DIFF
--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -222,10 +222,10 @@ to the following backwards-compatibility expectations:
 - Changing a `google.api.resource_reference` from `child_type` to `type`
   **must** be a backwards-compatible change when the `child_type` referenced
   is single-parented and the newly referenced `type` is that exact parent.
-- Changing a `google.api.resource_reference` from `type` to `child_type`
-  **must** be a backwards-compatible change when the resource originally
-  referenced via the `type` is included in the possible resources implied
-  by the `child_type` resolution.
+- For references that appear in a request, changing from `type` to
+  `child_type` **must** be a backwards-compatible change when the resource
+  originally referenced via the `type` is included in the possible resources
+  implied by the `child_type` resolution.
 
 Note: The `ORIGINALLY_SINGLE_PATTERN` and `FUTURE_MULTI_PATTERN` flags are
 deprecated, and must not be used.

--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -219,6 +219,13 @@ to the following backwards-compatibility expectations:
   libraries.
 - The addition of a `google.api.resource_reference` annotation on an existing
   field **must** be a backwards-compatible change.
+- Changing a `google.api.resource_reference` from `child_type` to `type`
+  **must** be a backwards-compatible change when the `child_type` referenced
+  is single-parented and the newly referenced `type` is that exact parent.
+- Changing a `google.api.resource_reference` from `type` to `child_type`
+  **must** be a backwards-compatible change when the resource originally
+  referenced via the `type` is included in the possible resources implied
+  by the `child_type` resolution.
 
 Note: The `ORIGINALLY_SINGLE_PATTERN` and `FUTURE_MULTI_PATTERN` flags are
 deprecated, and must not be used.
@@ -230,6 +237,7 @@ deprecated, and must not be used.
 
 ## Changelog
 
+- **2023-03-25**: Include compatibility guidance for `type` and `child_type`.
 - **2022-10-28**: Pattern variables are considered final
 - **2020-09-14**: Disallow simultaneous use of both `type` and `child_type`.
 - **2020-05-14**: Added complex resource ID path segments.

--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -221,11 +221,17 @@ to the following backwards-compatibility expectations:
   field **must** be a backwards-compatible change.
 - Changing a `google.api.resource_reference` from `child_type` to `type`
   **must** be a backwards-compatible change when the `child_type` referenced
-  is single-parented and the newly referenced `type` is that exact parent.
+  has a single `pattern` and the newly referenced `type` is the matching
+  parent resource `pattern` (see the
+  [Referencing other resources](#referencing-other-resources) section for
+  more info).
 - For references that appear in a request, changing from `type` to
   `child_type` **must** be a backwards-compatible change when the resource
-  originally referenced via the `type` is included in the possible resources
-  implied by the `child_type` resolution.
+  `pattern` originally referenced via the `type` is included in the set of
+  possible resource `pattern`s derived through `child_type` resolution (see
+  the above [Multi-pattern resources](#multi-pattern-resources) and
+  [Referencing other resources](#referencing-other-resources) sections for
+  more examples).
 
 Note: The `ORIGINALLY_SINGLE_PATTERN` and `FUTURE_MULTI_PATTERN` flags are
 deprecated, and must not be used.


### PR DESCRIPTION
This backfills guidance that wasn't written down explicitly, but should've been implemented in all languages that support resource references.

Covers two cases that involve switching between `type` and `child_type` references that should be safe to make as the the field either remains the same or _gains_ additional possible patterns.