### PR TITLE
Add clarifications to AIP 131 and 136 about resources that don't comply with AIP 122

### DIFF
--- a/aip/general/0131.md
+++ b/aip/general/0131.md
@@ -21,7 +21,9 @@ resource.
 ## Guidance
 
 APIs **must** provide a get method for resources. The purpose of the get method
-is to return data from a single resource.
+is to return data from a single resource. If the data being retrieved is not an
+([AIP-122][]) compliant resource, please see ([AIP-136][]) to add a Custom Method
+instead.
 
 Get methods are specified using the following pattern:
 

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -18,10 +18,11 @@ vocabulary to adhere to user intent.
 ## Guidance
 
 Custom methods **should** only be used for functionality that can not be easily
-expressed via standard methods; prefer standard methods if possible, due to
-their consistent semantics. (Of course, this only applies if the functionality
-in question actually conforms to the normal semantics; it is _not_ a good idea
-to contort things to endeavor to make the standard methods "sort of work".)
+expressed via standard methods and for resources that are not ([AIP-122][])
+compliant; prefer standard methods if possible, due to their consistent semantics.
+(Of course, this only applies if the functionality in question actually conforms to
+the normal semantics; it is _not_ a good idea to contort things to endeavor to make
+the standard methods "sort of work".)
 
 While custom methods vary widely in how they are designed, many principles
 apply consistently:


### PR DESCRIPTION
This change makes it clear in AIP 131 (standard GET) that resources that are not standard (don't comply with AIP 122) should use custom methods. Add the same clarification in AIP 136 (custom methods)