### PR TITLE
Correct Link references and typos

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -106,7 +106,7 @@ reached a steady-state. for values that are related to the resource [state][].
 
 Examples include:
 
-- Following a successful create that is is latest mutation on a resource, a get
+- Following a successful create that is the latest mutation on a resource, a get
   request for a resource **must** return the resource.
 - Following a successful update that is the latest mutation on a resource, a get
   request for a resource **must** return the final values from the update

--- a/aip/general/0129.md
+++ b/aip/general/0129.md
@@ -140,8 +140,8 @@ service to validate it was set correctly.
 
 - **2023-10-31:** Update to approved.
 
-[Declarative clients]: ./0009#declarative-clients
-[aip-202]: ./202.md
+[Declarative clients]: ./0009.md#declarative-clients
+[aip-202]: ./0202.md
 
 <!-- prettier-ignore-start -->
 [aip-180]: ./0180.md

--- a/aip/general/0133.md
+++ b/aip/general/0133.md
@@ -113,6 +113,7 @@ operation (AIP-151) instead:
 rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
     post: "/v1/{parent=publishers/*}/books"
+    body: "book"
   };
   option (google.longrunning.operation_info) = {
     response_type: "Book"
@@ -211,7 +212,7 @@ name and use it in references from other resources.
 [data plane]: ./0111.md#data-plane
 [management plane]: ./0111.md#management-plane
 [errors]: ./0193.md
-[field_behavior]: ./203.md
+[field_behavior]: ./0203.md
 [Declarative clients]: ./0009.md#declarative-clients
 [permission-denied]: ./0193.md#permission-denied
 [strong consistency]: ./0121.md#strong-consistency

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -161,6 +161,7 @@ operation (AIP-151) instead:
 rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
   option (google.api.http) = {
     patch: "/v1/{book.name=publishers/*/books/*}"
+    body: "book"
   };
   option (google.longrunning.operation_info) = {
     response_type: "Book"


### PR DESCRIPTION
While reading the AIPs, fixing typos, reference links and missing `body` field for post/patch requests