### PR TITLE
chore(AIP-129): change state-driven to declarative in text

### DIFF
--- a/aip/general/0129.md
+++ b/aip/general/0129.md
@@ -145,5 +145,4 @@ service to validate it was set correctly.
 
 <!-- prettier-ignore-start -->
 [aip-180]: ./0180.md
-[state-driven-clients]: ./009.md#state-driven-clients
 <!-- prettier-ignore-end -->

--- a/aip/general/0129.md
+++ b/aip/general/0129.md
@@ -89,7 +89,7 @@ annotation.
 ## Rationale
 
 Server-modified and default values often make it harder to implement
-[state-driven clients](state-driven-clients). These clients are often unable to
+[declarative clients][]. These clients are often unable to
 tell when their desired state matches the current state for these fields, as the
 rules by which a server may modify and return values are complex, not public,
 and not repeatable.
@@ -97,7 +97,7 @@ and not repeatable.
 ### Rationale for Single Owner Fields
 
 When fields do not have a single owner they can cause issues for
-[state-driven clients](state-driven-clients). These clients may attempt to set
+[declarative clients][]. These clients may attempt to set
 values for fields that are overwritten by server set values, leading to the
 client entering an infinite loop to correct the change.
 


### PR DESCRIPTION
Change links from state-driven clients to declarative clients in AIP 129