### PR TITLE
Fix minor typo in AIP-0203

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -81,7 +81,7 @@ a message.
 ### Immutable
 
 The use of `IMMUTABLE` indicates that a field on a resource cannot be changed
-after it's creation. This can apply to either fields that are input or outputs,
+after its creation. This can apply to either fields that are input or outputs,
 required or optional.
 
 When a service receives an immutable field in an update request (or similar),


### PR DESCRIPTION
Reading through AIPs as we are implementing them in our company and I found this very small typo. Thanks for these guidelines!

This PR
- Renames `it's` -> `its` possessive in [AIP-203](https://google.aip.dev/203)