### PR TITLE
chore(AIP-121): Write Out "Long-Running Operation"

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -97,9 +97,9 @@ patterns, such as database transactions, import and export, or data analysis.
 ### Strong Consistency
 
 For methods that operate on the [management plane][], the completion of those
-operations (either successful or with an error, LRO or synchronous) **must**
-mean that the state of the resource's existence and all user-settable values
-have reached a steady-state.
+operations (either successful or with an error, long-running operation, or
+synchronous) **must** mean that the state of the resource's existence and all
+user-settable values have reached a steady-state.
 
 [output only][] values unrelated to the resource [state][] **should** also have
 reached a steady-state. for values that are related to the resource [state][].


### PR DESCRIPTION
Currently, this page uses the acronym "LRO" (long-running operation) which is not defined anywhere on the page. Nor is this defined in the introductory AIPs like the Glossary (AIP-9).

Write out "long-running operation" rather than expecting readers look up or already know the LRO acronym.