### PR TITLE
Clarify breaking change rules around pagination

### DIFF
--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -159,6 +159,12 @@ now is only getting the first 50 (and does not know to advance pagination).
 Even if the API set a higher default limit, such as 100, the user's collection
 could grow, and _then_ the code would break.
 
+Additionally, [client libraries implement automatic
+pagination](../client-libraries/4233.md), typically representing paginated
+RPCs using different method signatures to unpaginated ones. This means that
+adding pagination to a previously-unpaginated method causes a breaking change
+in those libraries.
+
 For this reason, it is important to always add pagination to RPCs returning
 collections _up front_; they are consistently important, and they can not be
 added later without causing problems for existing users.
@@ -172,6 +178,8 @@ paginate) is reasonable for initially-small collections.
 
 ## Changelog
 
+- **2020-05-24**: Clarified that adding pagination breaks client
+  libraries.
 - **2020-05-13**: Added guidance for skipping results.
 - **2020-08-24**: Clarified that responses are not streaming responses.
 - **2020-06-24**: Clarified that page size is always optional for users.

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -258,7 +258,7 @@ version.
 [aip-158]: ./0158.md
 [aip-181]: ./0181.md
 [aip-203]: ./0203.md
-[aip-4231]: ./client-libraries/4231.md
-[aip-4232]: ./client-libraries/4232.md
+[aip-4231]: ../client-libraries/4231.md
+[aip-4232]: ../client-libraries/4232.md
 [ec2]: https://aws.amazon.com/blogs/aws/theyre-here-longer-ec2-resource-ids-now-available/
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
(In particular, that adding pagination breaks client libraries too.)

Fixes #1357.