### PR TITLE
Update 0194.md

### DIFF
--- a/aip/general/0194.md
+++ b/aip/general/0194.md
@@ -30,7 +30,7 @@ would cause unintended state changes.
 **Note:** This AIP does not cover client streaming or bi-directional streaming.
 
 **Note:** For client side retry behavior in the client libraries: see
-[AIP-4221](./client-libraries/4221.md).
+[AIP-4221][].
 
 ### Retryable codes
 


### PR DESCRIPTION
Back with yet another attempt at fixing the broken link to AIP-4221 - this time with a different approach than what we tried in #1177 #1178 and #1179. Inspired by what I saw in [133](https://github.com/aip-dev/google.aip.dev/blob/master/aip/general/0133.md)