### PR TITLE
Fix link to aip-163 in aip-151

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -163,7 +163,6 @@ updated status) but server don't need to maintain any additional state.
 
 ## Changelog
 
-- **2024-05-29**: Fix link to [AIP-163][]
 - **2024-04-23**: Provided pattern for validation on RPCs returning
   long-running operations.
 - **2022-05-31**: Added compatibility section.

--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -59,7 +59,7 @@ rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
 - APIs with messages that return `Operation` **must** implement the
   [`Operations`][lro] service. Individual APIs **must not** define their own
   interfaces for long-running operations to avoid non-uniformity.
-- If an RPC supports a [validate-only mode](aip-163), the response to a
+- If an RPC supports a [validate-only mode][aip-163], the response to a
   validation request **must** be one of the following:
   - A successful response with an `Operation` which is already complete, with
     the `done` field set to `true`, and a valid (but potentially empty) response
@@ -163,6 +163,7 @@ updated status) but server don't need to maintain any additional state.
 
 ## Changelog
 
+- **2024-05-29**: Fix link to [AIP-163][]
 - **2024-04-23**: Provided pattern for validation on RPCs returning
   long-running operations.
 - **2022-05-31**: Added compatibility section.


### PR DESCRIPTION
The link to aip-163 was using the incorrect syntax, causing it to generate a link to https://google.aip.dev/aip-163 instead of https://google.aip.dev/163.