### PR TITLE
fix(AIP-135): add parent deletion precondition behavior

### DIFF
--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -62,7 +62,8 @@ rpc DeleteBook(DeleteBookRequest) returns (google.protobuf.Empty) {
   deletion of parent and child resources is necessary.
   - If the only child resource type is a [Singleton][aip-156], deletion **must**
     be allowed, because the lifecycle of a Singleton is tied to that of its
-    parent resource.
+    parent resource. This applies even if there are multiple different Singleton
+    resource types for the same parent resource.
 
 
 The Delete method **should** succeed if and only if a resource was present and

--- a/aip/general/0135.md
+++ b/aip/general/0135.md
@@ -57,7 +57,12 @@ rpc DeleteBook(DeleteBookRequest) returns (google.protobuf.Empty) {
   [strong consistency][]: the completion of a delete operation **must** mean
   that the existence of the resource has reached a steady-state and reading
   resource state returns a consistent response.
-
+- The API **must** fail with a `FAILED_PRECONDITION` error if child resources
+  are present. See guidance on [Cascading Delete](#cascading-delete) if forcing
+  deletion of parent and child resources is necessary.
+  - If the only child resource type is a [Singleton][aip-156], deletion **must**
+    be allowed, because the lifecycle of a Singleton is tied to that of its
+    parent resource.
 
 
 The Delete method **should** succeed if and only if a resource was present and
@@ -225,6 +230,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 [aip-132]: ./0132.md
 [aip-136]: ./0136.md
 [aip-154]: ./0154.md
+[aip-156]: ./0156.md
 [aip-203]: ./0203.md
 [aip-214]: ./0214.md
 [aip-216]: ./0216.md
@@ -239,6 +245,7 @@ exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
+- **2024-06-11**: Add deletion behavior for parent resource deletion requests without a `force` field.
 - **2023-08-24**: Adding consistency requirement.
 - **2022-06-02:** Changed suffix descriptions to eliminate superfluous "-".
 - **2022-02-02**: Changed eTag error from `FAILED_PRECONDITION` to `ABORTED` making it consistent with change to [AIP-154][] & [AIP-134][etag] on 2021-03-05.


### PR DESCRIPTION
We were not documenting the expected behavior of a Delete request for a resource that parents other child resources. Only the Cascading Delete section, given a specific `force` field, had such documentation. After verifying with our frameworks team the expected behavior, we need to document it here.

Internal bug: http://b/342639237