### PR TITLE
fix(AIP-122): clarify shortening rules for nested collections

### DIFF
--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -124,7 +124,7 @@ referenced in the API, or else not at all.
 
 ### Resource ID segments
 
-A resource ID segment identifiers the resource within its parent collection. In
+A resource ID segment identifies the resource within its parent collection. In
 the resource name `publishers/123/books/les-miserables`, `123` is the resource
 ID for the publisher, and `les-miserables` is the resource ID for the book.
 

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -104,6 +104,20 @@ In this situation, the _message_ and _resource type_ are still called
 shortened. Since the _resource type_ is not shortened, the `singular` and
 `plural` are similarly _not shortened_.
 
+```
+message UserEvent {
+  option (google.api.resource) = {
+    type: "example.googleapis.com/UserEvent"
+    // Only the collection & resource identfiers in the `pattern` are shortened.    
+    pattern: "projects/{project}/users/{user}/events/{event}"
+    singular: "userEvent"
+    plural: "userEvents"
+  };
+
+  string name = 1;
+}
+```
+
 **Note:** APIs wishing to do this **must** follow this format consistently
 throughout the API, or else not at all.
 

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -119,8 +119,8 @@ message UserEvent {
 ```
 
 **Note:** APIs wishing to do this **must** follow this format consistently
-throughout all of its `pattern`s defined and anywhere else the resource is
-referenced in the API, or else not at all.
+throughout all of its `pattern` entries defined and anywhere else the
+resource is referenced in the API, or else not at all.
 
 ### Resource ID segments
 

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -99,8 +99,10 @@ An API **should** use the less-redundant form:
 users/vhugo1802/events/birthday-dinner-226
 ```
 
-In this situation, the _message_ is still called `UserEvent`; only the resource
-name is shortened.
+In this situation, the _message_ and _resource type_ are still called
+`UserEvent`; only the collection and resource identifiers in the pattern(s) are 
+shortened. Since the _resource type_ is not shortened, the `singular` and
+`plural` are similarly _not shortened_.
 
 **Note:** APIs wishing to do this **must** follow this format consistently
 throughout the API, or else not at all.
@@ -357,6 +359,8 @@ isolation of logical concerns per-resource.
 
 ## Changelog
 
+- **2024-06-14**: Clarify resource annotation shortening rules for nested
+  collections.
 - **2023-09-19**: Prohibit duplicate collection identifiers.
 - **2023-09-01**: Add a clause that allows embedding for revision resource
   messages.

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -124,7 +124,7 @@ referenced in the API, or else not at all.
 
 ### Resource ID segments
 
-A resource ID segment identifies the resource within its parent collection. In
+A resource ID segment identifiers the resource within its parent collection. In
 the resource name `publishers/123/books/les-miserables`, `123` is the resource
 ID for the publisher, and `les-miserables` is the resource ID for the book.
 

--- a/aip/general/0122.md
+++ b/aip/general/0122.md
@@ -119,7 +119,8 @@ message UserEvent {
 ```
 
 **Note:** APIs wishing to do this **must** follow this format consistently
-throughout the API, or else not at all.
+throughout all of its `pattern`s defined and anywhere else the resource is
+referenced in the API, or else not at all.
 
 ### Resource ID segments
 


### PR DESCRIPTION
While implementing rules for `singular`/`plural` presence in `pattern` values including the nested collection exception, I noticed that the guidance was vague for each specific field in the `google.api.resource` annotation.