### PR TITLE
fix(AIP-121): clarify acyclic parent-child relation

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -142,9 +142,10 @@ have sole responsibility and authority for maintaining the application state.
 
 ### Cyclic References
 
-The relationship between resources, such as parent-child or
-[resource references][], **must** be representable via a
-[directed acyclic graph][].
+The relationship between resources, such as with [resource references][],
+**must** be representable via a [directed acyclic graph][]. The parent-child
+relationship also **must** be acyclic, and as per [AIP-124][] a given resource
+instance will only have one canonical parent resource.
 
 A cyclic relationship between resources increases the complexity of managing
 resources. Consider resources A and B that refer to
@@ -161,6 +162,7 @@ This requirement does not apply to relationships that are expressed via
 [output only][] fields, as they do not require the user to specify the values
 and in turn do not increase resource management complexity.
 
+[AIP-124]: ./0124.md
 [create]: ./0133.md
 [custom methods]: ./0136.md
 [delete]: ./0135.md
@@ -181,6 +183,7 @@ and in turn do not increase resource management complexity.
 
 ## Changelog
 
+- **2024-07-08**: Clarify acyclic nature of parent-child relationship.
 - **2023-08-24**: Added guidance on consistency guarantees of methods.
 - **2023-07-23**: Clarify stateless protocol definition.
 - **2023-01-21**: Explicitly require matching schema across standard methods.


### PR DESCRIPTION
Clarifying that parent-child relationship is acyclic and refer AIP-124 guidance re:only one parent resource per child. This clarifies confusion raised in (internal link) http://b/350510598.