### PR TITLE
Clarify that resource type naming isn't completely free of constraints

### DIFF
--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -11,10 +11,10 @@ placement:
 
 Most APIs expose _resources_ (their primary nouns) which users are able to
 create, retrieve, and manipulate. APIs are allowed to name their resource types
-as they see fit, and are only required to ensure uniqueness within that API.
-This means that it is possible (and often desirable) for different APIs to use
-the same type name. For example, a Memcache and Redis API would both want to
-use `Instance` as a type name.
+reasonably freely (within the requirements of this AIP), and are only required
+to ensure uniqueness within that API. This means that it is possible (and often
+desirable) for different APIs to use the same type name. For example, a Memcache
+and Redis API would both want to use `Instance` as a type name.
 
 When mapping the relationships between APIs and their resources, however, it
 becomes important to have a single, globally-unique type name. Additionally,


### PR DESCRIPTION
I didn't want to list all the constraints in the overview as well as later on, but hopefully this is clearer.

Fixes b/351043291