### PR TITLE
Erroneous example JSON, should have http status, and missing space fixed.

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -29,7 +29,7 @@ assume that the user will know anything about its underlying
 implementation.
 
 Error messages **should** be brief but actionable. Any extra information
-**should** be provided in the `details`field. If even more information
+**should** be provided in the `details` field. If even more information
 is necessary, you **should** provide a link where a reader can get more
 information or ask questions to help resolve the issue. It is also
 important to [set the right tone][writing-tone] when writing messages.
@@ -50,7 +50,7 @@ users.
 ```json
 {
   "error": {
-    "code": 8,
+    "code": 429,
     "message": "The zone 'us-east1-a' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
     "status": "RESOURCE_EXHAUSTED",
     "details": [


### PR DESCRIPTION
Actual JSON responses should and do contain HTTP code for status not the integer value of the code proto enum. There is also a type, a missing space.