### PR TITLE
feat(AIP-193) Clarify Code usage in proto vs json

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -138,6 +138,18 @@ descriptions, and examples:
     `ErrorInfo`,`LocalizedMessage`, and so on.
   - *Example*: Described in the [ErrorDetails](#error-details) section.
 
+
+**Important:** In the context of the of the `google.rpc.Status` Protobuf
+message, the value of the field `code` is the numeric equivalent of the
+enum value chosen from [`google.rpc.Code`][Code]. Meanwhile, when the
+error is exressed as JSON, e.g. in the [sample
+above](#json-representation), the value of the field by the same name,
+"code", is the HTTP status code equivalent of the selected
+`google.rpc.Code`. For example, if [`INVALID_ARGUMENT`][InvalidArgument]
+is chosen, the value of `code` (in the context of the Protobuf message,
+`google.rpc.Status`) will be `3`, and the value of the field "code" in
+the JSON reply will be `400`.
+
 #### [ErrorDetails][details]
 
 Google defines a set of [standard detail payloads][details] for error
@@ -538,5 +550,6 @@ data instead.
 [Error model]: https://cloud.google.com/apis/design/errors#error_model
 [Help]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L256
 [resource-error]: https://cloud.google.com/compute/docs/resource-error
+[InvalidArgument]: https://github.com/googleapis/googleapis/blob/d4acb64370d333024a167551e7da854506109ba2/google/rpc/code.proto#L52-L58
 
 <!-- prettier-ignore-end -->

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -139,8 +139,8 @@ descriptions, and examples:
   - *Example*: Described in the [ErrorDetails](#error-details) section.
 
 
-**Important:** In the context of the of the `google.rpc.Status` Protobuf
-message, the value of the field `code` is the numeric equivalent of the
+**Important:** In the context of the`google.rpc.Status` protobuf
+message, the value of the field `code` is the numeric equivalent to the
 enum value chosen from [`google.rpc.Code`][Code]. For example, if
 [`INVALID_ARGUMENT`][InvalidArgument] is chosen, the value of `code`
 will be `3` (in the context of the Protobuf message,

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -141,14 +141,13 @@ descriptions, and examples:
 
 **Important:** In the context of the of the `google.rpc.Status` Protobuf
 message, the value of the field `code` is the numeric equivalent of the
-enum value chosen from [`google.rpc.Code`][Code]. Meanwhile, when the
-error is expressed as JSON, e.g. in the [sample
-above](#json-representation), the value of the field by the same name,
-"code", is the HTTP status code equivalent of the selected
-`google.rpc.Code`. For example, if [`INVALID_ARGUMENT`][InvalidArgument]
-is chosen, the value of `code` (in the context of the Protobuf message,
-`google.rpc.Status`) will be `3`, and the value of the field "code" in
-the JSON reply will be `400`.
+enum value chosen from [`google.rpc.Code`][Code]. When the error is
+expressed as JSON, as in the [sample above](#json-representation), the
+value of the field by the same name, "code", is the HTTP status code
+equivalent of the selected `google.rpc.Code`. For example, if
+[`INVALID_ARGUMENT`][InvalidArgument] is chosen, the value of `code` (in
+the context of the Protobuf message, `google.rpc.Status`) will be `3`,
+and the value of the field "code" in the JSON reply will be `400`.
 
 #### [ErrorDetails][details]
 

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -142,7 +142,7 @@ descriptions, and examples:
 **Important:** In the context of the of the `google.rpc.Status` Protobuf
 message, the value of the field `code` is the numeric equivalent of the
 enum value chosen from [`google.rpc.Code`][Code]. Meanwhile, when the
-error is exressed as JSON, e.g. in the [sample
+error is expressed as JSON, e.g. in the [sample
 above](#json-representation), the value of the field by the same name,
 "code", is the HTTP status code equivalent of the selected
 `google.rpc.Code`. For example, if [`INVALID_ARGUMENT`][InvalidArgument]

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -141,13 +141,14 @@ descriptions, and examples:
 
 **Important:** In the context of the of the `google.rpc.Status` Protobuf
 message, the value of the field `code` is the numeric equivalent of the
-enum value chosen from [`google.rpc.Code`][Code]. When the error is
-expressed as JSON, as in the [sample above](#json-representation), the
-value of the field by the same name, "code", is the HTTP status code
-equivalent of the selected `google.rpc.Code`. For example, if
-[`INVALID_ARGUMENT`][InvalidArgument] is chosen, the value of `code` (in
-the context of the Protobuf message, `google.rpc.Status`) will be `3`,
-and the value of the field "code" in the JSON reply will be `400`.
+enum value chosen from [`google.rpc.Code`][Code]. For example, if
+[`INVALID_ARGUMENT`][InvalidArgument] is chosen, the value of `code`
+will be `3` (in the context of the Protobuf message,
+`google.rpc.Status`). However, when the error is expressed as JSON, as
+in the [sample above](#json-representation), the value of the field by
+the same name, `"code"`, is the HTTP status code equivalent of the
+selected `google.rpc.Code`. For example, the value of the field `"code"`
+in the JSON reply would be `400`.
 
 #### [ErrorDetails][details]
 


### PR DESCRIPTION
Adds a callout of type "Important" that explains that `code` in google.rpc.Status is the numeric equivalent of the proto enum value found in `google.rpc.Code` while in JSON, it is the equivalent HTTP status.

![image](https://github.com/user-attachments/assets/f0bb1f1d-fcc7-4ae7-a87e-d40639d850c7)

Fixes: #1396