### PR TITLE
fix: links from "general" should be relative in effective output directory

### DIFF
--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -160,7 +160,7 @@ Even if the API set a higher default limit, such as 100, the user's collection
 could grow, and _then_ the code would break.
 
 Additionally, [client libraries implement automatic
-pagination](../client-libraries/4233.md), typically representing paginated
+pagination](./client-libraries/4233.md), typically representing paginated
 RPCs using different method signatures to unpaginated ones. This means that
 adding pagination to a previously-unpaginated method causes a breaking change
 in those libraries.

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -261,7 +261,7 @@ version.
 [aip-158]: ./0158.md
 [aip-181]: ./0181.md
 [aip-203]: ./0203.md
-[aip-4231]: ../client-libraries/4231.md
-[aip-4232]: ../client-libraries/4232.md
+[aip-4231]: ./client-libraries/4231.md
+[aip-4232]: ./client-libraries/4232.md
 [ec2]: https://aws.amazon.com/blogs/aws/theyre-here-longer-ec2-resource-ids-now-available/
 <!-- prettier-ignore-end -->

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -521,7 +521,7 @@ data instead.
 
 <!-- prettier-ignore-start -->
 
-[aip-4221]: ../client-libraries/4221.md
+[aip-4221]: ./client-libraries/4221.md
 [details]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
 [ErrorInfo]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L27-L76
 [ErrorInfo-reason]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L57


### PR DESCRIPTION
Even though in the source there's a "general" directory (so ../client-libraries/ makes sense) that isn't the case when built... which I assume is why none of these links work. I'm not sure the best way to test this - if it doesn't work, we may need to just use absolute URLs, like the ones to the auth AIPs.

Fixes #1394