### PR TITLE
fix: Make all client library links absolute

### DIFF
--- a/aip/general/0123.md
+++ b/aip/general/0123.md
@@ -78,7 +78,7 @@ message Topic {
 - Pattern variables **must** be unique within any given pattern. (e.g.
   `projects/{abc}/topics/{abc}` is invalid; this is usually a natural
   corollary of collection identifiers being unique within a pattern.)
-- Resources with [multiple patterns][aip-4231] **must**
+- Resources with [multiple patterns][multi-pattern-resources] **must**
   preserve ordering: new patterns **must** be added at the end of the list, and
   existing patterns **must not** be removed or re-ordered, as this breaks client
   library backward compatibility.
@@ -114,7 +114,7 @@ such as UpperCamelCase and snake_case.
 
 <!-- prettier-ignore-start -->
 [aip-122]: ./0122.md
-[aip-4231]: ./4231.md#multi-pattern-resources
+[multi-pattern-resources]: https://google.aip.dev/client-libraries/4231#multi-pattern-resources
 [API Group]: https://kubernetes.io/docs/concepts/overview/kubernetes-api/#api-groups
 [nested collections]: ./0122.md#collection-identifiers
 [Object]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -160,7 +160,7 @@ Even if the API set a higher default limit, such as 100, the user's collection
 could grow, and _then_ the code would break.
 
 Additionally, [client libraries implement automatic
-pagination](./4233.md), typically representing paginated
+pagination](https://google.aip.dev/client-libraries/4233), typically representing paginated
 RPCs using different method signatures to unpaginated ones. This means that
 adding pagination to a previously-unpaginated method causes a breaking change
 in those libraries.

--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -264,7 +264,7 @@ version.
 [aip-158]: ./0158.md
 [aip-181]: ./0181.md
 [aip-203]: ./0203.md
-[aip-4231]: ./4231.md
-[aip-4232]: ./4232.md
+[aip-4231]: https://google.aip.dev/client-libraries/4231
+[aip-4232]: https://google.aip.dev/client-libraries/4232
 [ec2]: https://aws.amazon.com/blogs/aws/theyre-here-longer-ec2-resource-ids-now-available/
 <!-- prettier-ignore-end -->

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -521,7 +521,7 @@ data instead.
 
 <!-- prettier-ignore-start -->
 
-[aip-4221]: ./4221.md
+[aip-4221]: https://google.aip.dev/client-libraries/4221
 [details]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
 [ErrorInfo]: https://github.com/googleapis/googleapis/blob/6f3fcc058ff29989f6d3a71557a44b5e81b897bd/google/rpc/error_details.proto#L27-L76
 [ErrorInfo-reason]: https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L57


### PR DESCRIPTION
We can't work out how to use relative links correctly, so let's just go with absolute ones.