### PR TITLE
fix formatting issue in AIP-2718

### DIFF
--- a/aip/apps/2718.md
+++ b/aip/apps/2718.md
@@ -46,7 +46,7 @@ with One Platform or not.
 For compliant references, you **should** avoid the use of the terms "reference"
 and "name" in the field name. That is, `koala` is preferred to
 `koala_reference` or `koala_name`
-([see AIP-122](../0122.md#fields-representing-another-resource)).
+(see [AIP-122](../0122.md#fields-representing-another-resource)).
 
 For other target APIs, you **should** echo that API's terminology in the name
 for clarity. For example, if the target API's `GetKoalaDataRequest` has a

--- a/aip/apps/2718.md
+++ b/aip/apps/2718.md
@@ -46,7 +46,7 @@ with One Platform or not.
 For compliant references, you **should** avoid the use of the terms "reference"
 and "name" in the field name. That is, `koala` is preferred to
 `koala_reference` or `koala_name`
-(see [AIP-122](../0122.md#fields-representing-another-resource)).
+(see [AIP-122][]).
 
 For other target APIs, you **should** echo that API's terminology in the name
 for clarity. For example, if the target API's `GetKoalaDataRequest` has a


### PR DESCRIPTION
Weird formatting issue is happening on https://google.aip.dev/apps/2718 because the `AIP-122` is automatically being replaced with a link, which gets placed inside another link.

<img width="724" alt="Screenshot 2024-08-19 at 12 12 06 PM" src="https://github.com/user-attachments/assets/7ae1b5a9-b465-4624-917d-a03fd7d64e2c">
