### PR TITLE
fix(AIP-140): identify exception to base64-encoded string guidance

### DIFF
--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -123,7 +123,7 @@ binary contents over the wire, and **should not** ask the user to manually
 base64-encode a field into a `string` field. The one exception is when the
 API is designed to handle data that is meant to be base64-encoded at rest and
 the double base64-encoding as a result of using `bytes` is undesirable - in
-the double services **may** use a `string`.
+this case, services **may** use a `string`.
 
 ### URIs
 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -120,7 +120,10 @@ are an exception to this rule. For example, `is_new` (**not** `new`).
 When using `bytes`, the contents of the field are base64-encoded when using
 JSON on the wire. Services **should** use `bytes` when there is a need to send
 binary contents over the wire, and **should not** ask the user to manually
-base64-encode a field into a `string` field.
+base64-encode a field into a `string` field. The one exception is when the
+API is designed to handle data that is meant to be base64-encoded at rest and
+the double base64-encoding as a result of using `bytes` is undesirable - in
+the double services **may** use a `string`.
 
 ### URIs
 
@@ -159,6 +162,7 @@ field **should not** have a uniqueness requirement.
 
 ## Changelog
 
+- **2024-08-26**: Codify exception to string and base64 guidance 
 - **2024-05-18**: Documented the effect of field names on client surfaces.
 - **2023-04-25**: Field names **must not** be expressed as verbs.
 - **2021-07-12**: Normalized display name guidance to "should".


### PR DESCRIPTION
Allow for `string` to be used for a field that is meant to be base64 encoded at rest. This is an exception to the rule that enforces the guidance rather bluntly: https://linter.aip.dev/140/base64.

Internal feedback http://b/234800622