### PR TITLE
fix: invalid reference in AIP-001

### DIFF
--- a/aip/general/0001.md
+++ b/aip/general/0001.md
@@ -71,8 +71,7 @@ digraph d_front_back {
 ### Technical leads
 
 The current TL (technical lead) for APIs is Eric Brewer; he has delegated some
-responsibilities for API Design to the API Design TL (Andrei Scripniciuc
-([@andreisc][])).
+responsibilities for API Design to the API Design TL (Andrei Scripniciuc).
 
 As noted in the diagram above, the TL is the final decision-maker on the AIP
 process and the final point of escalation if necessary.


### PR DESCRIPTION
Removed a reference to personnel which was not rendering in UI, due to missing syntax. Also the same reference can be found below hence making it redundant. 

<img width="686" alt="image" src="https://github.com/user-attachments/assets/d32f3197-1836-469e-a6d0-a59dbe806b08">
