### PR TITLE
chore(AIP-1): remove TL section, update editors

### DIFF
--- a/aip/general/0001.md
+++ b/aip/general/0001.md
@@ -262,6 +262,7 @@ state, and will link to the new, current AIP.
 
 ## Changelog
 
+- **2024-09-04**: Updated names of current editors and remove TLs.
 - **2023-05-10**: Updated names of current and editors and TLs.
 - **2019-07-30**: Further clarified AIP quorum requirements.
 - **2019-05-12**: Collapsed AIP approvers and editors into a single position,
@@ -272,11 +273,9 @@ state, and will link to the new, current AIP.
 [aip github repository]: https://github.com/googleapis/aip
 [open an issue]: https://github.com/googleapis/aip/issues
 [@alin04]:https://github.com/alin04
-[@bgrant0607]: https://github.com/bgrant0607
-[@hrasadi]: https://github.com/hrasadi
 [@jskeet]: https://github.com/jskeet
 [@loudej]: https://github.com/loudej
 [@noahdietz]: https://github.com/noahdietz
+[@slevenick]: https://github.com/slevenick
 [@shwoodard]: https://github.com/shwoodard
-[@andrei-scripniciuc]: https://github.com/andrei-scripniciuc
 [@itsStrobe]: https://github.com/itsStrobe

--- a/aip/general/0001.md
+++ b/aip/general/0001.md
@@ -68,12 +68,6 @@ digraph d_front_back {
 }
 ```
 
-### Technical leads
-
-The current TL (technical lead) for APIs is Eric Brewer; he has delegated some
-responsibilities for API Design to the API Design TL (Andrei Scripniciuc
-([@andreisc][])).
-
 As noted in the diagram above, the TL is the final decision-maker on the AIP
 process and the final point of escalation if necessary.
 
@@ -86,14 +80,12 @@ and these Googlers will be approvers for each AIP in the general scope.
 
 The list of AIP editors is currently:
 
-- Andrei Scripniciuc ([@andrei-scripniciuc][])
 - Angie Lin ([@alin04][])
-- Brian Grant ([@bgrant0607][])
-- Hami Asaadi ([@hrasadi][])
 - Jon Skeet ([@jskeet][])
 - Jose Juan Zavala Iglesias ([@itsStrobe][])
 - Louis Dejardin ([@loudej][])
 - Noah Dietz ([@noahdietz][])
+- Sam Levenick ([@slevenick][])
 - Sam Woodard ([@shwoodard][])
 
 The editors are also responsible for the administrative and editorial aspects


### PR DESCRIPTION
Remove the Technical Lead section - it isn't necessary to advertise explicitly and we have plenty of internal pointers for this.

Also remove emeritus Editors, add new Editor :)