### PR TITLE
Move JSON example (HTTP) lower, outside of "Guidance"

### DIFF
--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -415,12 +415,6 @@ parent does not exist, the service **must** error with `NOT_FOUND` (HTTP
 A JSON representation of an error response might look like the following
 example.
 
-For the purposes of following best practices, it’s helpful to break the
-error response into sections. Note that the order in which you write the
-error message is often different from how the error is presented to
-users.
-
-
 ```json
 {
   "error": {

--- a/aip/general/0193.md
+++ b/aip/general/0193.md
@@ -36,54 +36,6 @@ important to [set the right tone][writing-tone] when writing messages.
 
 ### Error Response
 
-#### JSON representation
-
-A JSON representation of an error response might look like the following
-example.
-
-For the purposes of following best practices, it’s helpful to break the
-error response into sections. Note that the order in which you write the
-error message is often different from how the error is presented to
-users.
-
-
-```json
-{
-  "error": {
-    "code": 429,
-    "message": "The zone 'us-east1-a' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
-    "status": "RESOURCE_EXHAUSTED",
-    "details": [
-      {
-        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
-        "reason": "RESOURCE_AVAILABILITY",
-        "domain": "compute.googleapis.com",
-        "metadata": {
-          "zone": "us-east1-a",
-          "vmType": "e2-medium",
-          "attachment": "local-ssd=3,nvidia-t4=2",
-          "zonesWithCapacity": "us-central1-f,us-central1-c"
-        }
-      },
-      {
-        "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
-        "locale": "en-US",
-        "message": "An <e2-medium> VM instance with <local-ssd=3,nvidia-t4=2> is currently unavailable in the <us-east1-a> zone. Consider trying your request in the <us-central1-f,us-central1-c> zone(s), which currently has/have capacity to accommodate your request. Alternatively, you can try your request again with a different VM hardware configuration or at a later time. For more information, see the troubleshooting documentation."
-      },
-      {
-        "@type": "type.googleapis.com/google.rpc.Help",
-        "links": [
-          {
-            "description": "Additional information on this error",
-            "url": "https://cloud.google.com/compute/docs/resource-error"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
 #### google.rpc.Status
 
 Services must return a [`google.rpc.Status`][Status] message when an API
@@ -457,6 +409,55 @@ checking if the resource or parent exists.
 If the user does have proper permission, but the requested resource or
 parent does not exist, the service **must** error with `NOT_FOUND` (HTTP
 404).
+
+## HTTP Transcoding
+
+A JSON representation of an error response might look like the following
+example.
+
+For the purposes of following best practices, it’s helpful to break the
+error response into sections. Note that the order in which you write the
+error message is often different from how the error is presented to
+users.
+
+
+```json
+{
+  "error": {
+    "code": 429,
+    "message": "The zone 'us-east1-a' does not have enough resources available to fulfill the request. Try a different zone, or try again later.",
+    "status": "RESOURCE_EXHAUSTED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "RESOURCE_AVAILABILITY",
+        "domain": "compute.googleapis.com",
+        "metadata": {
+          "zone": "us-east1-a",
+          "vmType": "e2-medium",
+          "attachment": "local-ssd=3,nvidia-t4=2",
+          "zonesWithCapacity": "us-central1-f,us-central1-c"
+        }
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.LocalizedMessage",
+        "locale": "en-US",
+        "message": "An <e2-medium> VM instance with <local-ssd=3,nvidia-t4=2> is currently unavailable in the <us-east1-a> zone. Consider trying your request in the <us-central1-f,us-central1-c> zone(s), which currently has/have capacity to accommodate your request. Alternatively, you can try your request again with a different VM hardware configuration or at a later time. For more information, see the troubleshooting documentation."
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "Additional information on this error",
+            "url": "https://cloud.google.com/compute/docs/resource-error"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 
 ## Rationale
 


### PR DESCRIPTION
Also removes a paragraph that seems superfluous.