### PR TITLE
fix(AIP-164): add missing requirement for delete_time

### DIFF
--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -24,9 +24,10 @@ mark the resource as having been deleted, but not completely remove it from the
 system. If the method behaves this way, it **should** return the updated
 resource instead of `google.protobuf.Empty`.
 
-Resources that support soft delete **should** have a `purge_time` field as
-described in AIP-148. Additionally, resources **should** include a `DELETED`
-state value if the resource includes a `state` field (AIP-216).
+Resources that support soft delete **should** have both a `delete_time` and
+`purge_time` field as described in AIP-148. Additionally, resources **should**
+include a `DELETED` state value if the resource includes a `state` field
+(AIP-216).
 
 ### Undelete
 
@@ -147,6 +148,7 @@ resource is not deleted, the service **must** respond with `ALREADY_EXISTS`
 
 ## Changelog
 
+- **2024-09-24**: Included missing requirement for `delete_time`.
 - **2023-07-13**: Renamed overloaded `expire_time` to `purge_time`.
 - **2021-07-12**: Added error behavior when soft deleting a deleted resource.
 - **2021-07-12**: Clarified that `ALREADY_EXISTS` errors apply to `Undelete`.


### PR DESCRIPTION
While reviewing some Soft Delete design documents, I noticed that `delete_time` as defined by AIP-148 was missing from AIP-164. Add this missing recommendation to AIP-164 alongside that of `purge_time`.