### PR TITLE
chore(AIP-121): remove errant full stop

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -102,7 +102,7 @@ synchronous) **must** mean that the state of the resource's existence and all
 user-settable values have reached a steady-state.
 
 [output only][] values unrelated to the resource [state][] **should** also have
-reached a steady-state. for values that are related to the resource [state][].
+reached a steady-state for values that are related to the resource [state][].
 
 Examples include:
 


### PR DESCRIPTION
There was a problem with the punctuation where a period was left in the middle of a sentence.