### PR TITLE
chore(AIP-9): copy API Title from cloud site glossary

### DIFF
--- a/aip/general/0009.md
+++ b/aip/general/0009.md
@@ -161,6 +161,7 @@ organizations separate from those that consume them.
 
 ## Changelog
 
+- **2024-10-23**: Add API Title entry
 - **2023-07-24**: Rename IaC to Declarative Clients
 - **2023-04-01**: Adding definition of IaC
 - **2023-03-24**: Reformatting content to include anchor links.

--- a/aip/general/0009.md
+++ b/aip/general/0009.md
@@ -88,6 +88,11 @@ Requests. One API Service may have multiple API Service Endpoints, such as
 Refers to the logical identifier of an API Service. Google APIs use RFC 1035 DNS
 compatible names as their API Service Names, such as `pubsub.googleapis.com`.
 
+### API Title
+
+Refers to the user-facing product title of an API service, such as "Cloud Pub/Sub
+API".
+
 ### API Request
 
 A single invocation of an API Method. It is often used as the unit for billing,


### PR DESCRIPTION
Copies the glossary entry for `API Title` from the cloud site glossary so that we have complete parity.