### PR TITLE
AIP-121: List responses contain the resource

### DIFF
--- a/aip/general/0121.md
+++ b/aip/general/0121.md
@@ -65,13 +65,13 @@ If the request to or the response from a standard method (or a custom method in
 the same *service*) **is** the resource or **contains** the resource, the
 resource schema for that resource across all methods **must** be the same.
 
-| Standard method | Request               | Response        |
-| --------------- | --------------------- | --------------- |
-| Create          | Contains the resource | Is the resource |
-| Get             | None                  | Is the resource |
-| Update          | Contains the resource | Is the resource |
-| Delete          | None                  | None            |
-| List            | None                  | Is the resource |
+| Standard method | Request               | Response               |
+| --------------- | --------------------- | ---------------------- |
+| Create          | Contains the resource | Is the resource        |
+| Get             | None                  | Is the resource        |
+| Update          | Contains the resource | Is the resource        |
+| Delete          | None                  | None                   |
+| List            | None                  | Contains the resources |
 
 *The table above describes each standard method's relationship to the resource,
 where "None" indicates that the resource neither **is** nor **is contained** in


### PR DESCRIPTION
AIP-132 documents the guidance for List responses, which *contain* the resource as a `repeated` field, along with pagination information. This patch updates AIP-121 to consistently indicate that the List request merely contains the resource rather than being the resource, which wouldn't make sense since the point of a List request is to enumerate multiple such resources.

wchargin-branch: list-contains
