### PR TITLE
fix(AIP-192): expand xref resolution rules

### DIFF
--- a/aip/general/0192.md
+++ b/aip/general/0192.md
@@ -92,9 +92,21 @@ documentation page containing the diagram as an image.
 
 ### Cross-references
 
-Comments **may** "link" to another component (service, method, message, field,
-enum, or enum value) by using the fully-qualified name of the element as a
-Markdown reference link. For example: `[Book][google.example.v1.Book]`
+A comment can "link" to another component (service, method, message, field,
+enum, or enum value) as a Markdown reference link. The reference **must** be one
+of the following forms:
+- The fully-qualified name of the element e.g. `[Book][google.example.v1.Book]`
+- A scope-relative reference qualified e.g. `[Sci-Fi genre][Genre.GENRE_SCI_FI]`
+- An implied reference e.g. `[Book][]` which equates to `[Book][Book]`
+
+These references are solved as per [name resolution][] rules.
+
+Containing fields names **must not** be used in references. They will not
+resolve. The original definition **must** be referenced instead. For example,
+`[author][Book.author.family_name]` where `author` is a field of `Book`, will
+not resolve, but `[author][Author.family_name]` would.
+
+[name resolution]: https://protobuf.dev/programming-guides/proto3/#name-resolution
 
 ### External links
 
@@ -144,6 +156,7 @@ of inadvertent omissions of the internal content annotation.
 
 ## Changelog
 
+- **2024-10-29**: Include cross-reference resolution rules.
 - **2023-08-11**: Expand deprecated comment requirement to all components.
 - **2021-04-20**: Added guidance for deprecated services and RPCs.
 - **2020-04-01**: Added guidance requiring absolute URLs for external links.


### PR DESCRIPTION
This documentation was copied over from the "old" Cloud api design site.

While we only previously stated that fully-qualified references should be used, scope-relative references are also allowed and resolved by API infrastructure. It is important that we document this because it will continue to be used and if there are issues, we need to know how references are meant to be resolved so that we can fix them.