### PR TITLE
fix(AIP-143): align CLDR country/region guidance with CLDR list

### DIFF
--- a/aip/general/0143.md
+++ b/aip/general/0143.md
@@ -90,6 +90,7 @@ format][] to represent this, and the field **must** be named `utc_offset`.
 
 ## Changelog
 
+- **2024-11-12**: Change country/region code list to CLDR list from IANA list
 - **2020-05-12**: Replaced `country_code` guidance with `region_code`,
   correcting an original error.
 
@@ -101,6 +102,6 @@ format][] to represent this, and the field **must** be named `utc_offset`.
 [iso]: https://www.iso.org/
 [iso-4217]: https://en.wikipedia.org/wiki/ISO_4217
 [iso-8601 format]: https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
-[list]: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+[list]: https://www.unicode.org/cldr/charts/46/supplemental/territory_information.html
 [money]: https://github.com/googleapis/googleapis/blob/master/google/type/money.proto
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
It was noticed during API review that the list of codes referenced from AIP-143 for Countries and Regions actually refers to a different standard (IANA) than the one that is documented to be the standard (Unicode CLDR). This fixes that link to refer to the CLDR list for territories and their codes.

Fixes internal bug http://b/378748089