### PR TITLE
fix(AIP-143): strengthen country/region field naming rationale

### DIFF
--- a/aip/general/0143.md
+++ b/aip/general/0143.md
@@ -61,9 +61,8 @@ Fields representing individual countries or nations **must** use the [Unicode
 CLDR region codes][cldr] ([list][]), such as `US` or `CH`, and the field
 **must** be called `region_code`.
 
-**Important:** We use `region_code` and not `country_code` to include regions
-distinct from any country, and avoid political disputes over whether or not
-some regions are countries.
+**Important:** Please read the [rationale](#countryregion-field-naming) for this
+requirement.
 
 ### Currency
 
@@ -88,8 +87,22 @@ Fields also **may** represent a UTC offset rather than a time zone (note that
 these are subtly different). In this case, the field **must** use the [ISO-8601
 format][] to represent this, and the field **must** be named `utc_offset`.
 
+## Rationale
+
+### Country/region field naming
+
+The use of `region_code` instead of `country_code` is critical to being able to
+convey regions that are distinct from any country and to avoid any political
+disputes associated with said region regarding their soverignty or affiliation.
+Google and many other companies are supporters of Unicode CLDR and standardize
+their product internationalization efforts on Unicode CLDR, and APIs are no
+different here. Furthermore, many of the values supported by Unicode CLDR are
+not countries on their own, so using a more generic name is actually more
+compatible with the specification.
+
 ## Changelog
 
+- **2024-12-03**: Strengthen rationale of country/region field naming
 - **2024-11-12**: Change country/region code list to CLDR list from IANA list
 - **2020-05-12**: Replaced `country_code` guidance with `region_code`,
   correcting an original error.


### PR DESCRIPTION
Strengthen the rationale for the country/region field naming requirements, referring to cross-product internalization standards and inclusiveness of the name.

Internal bug http://b/382099096