### PR TITLE
fix(AIP-134): add full replace usage caveats

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -105,11 +105,11 @@ message UpdateBookRequest {
     populated (have a non-empty value).
   - Update masks **must** support a special value `*`, meaning full replacement
     (the equivalent of `PUT`).
-    - API producers need to be concious of how adding new, mutable fields to a
+    - API producers need to be conscious of how adding new, mutable fields to a
       resource will be handled when consumers use `*` without knowledge of said
-      new, mutable fields. Likewise consumers need to be concious of using `*`
-      only when the risks of doing so are acceptable. In general, it is safest
-      to explicitly specify the fields to update rather than use `*`.
+      new, mutable fields. Likewise consumers need to use `*` only when the
+      risks of doing so are acceptable. In general, it is safest to explicitly
+      specify the fields to update rather than use `*`.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
   or another AIP.

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -302,6 +302,7 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 ## Changelog
 
+- **2024-12-03**: Add caveats to usage of full replacement `update_mask`.
 - **2024-03-14**: Make `update_mask` optional field_behaviour guidance a **must**.
 - **2023-08-26**: Adding consistency requirement.
 - **2023-07-17**: Make `update_mask` name guidance a **must**.

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -105,6 +105,11 @@ message UpdateBookRequest {
     populated (have a non-empty value).
   - Update masks **must** support a special value `*`, meaning full replacement
     (the equivalent of `PUT`).
+    - API producers need to be concious of how adding new, mutable fields to a
+      resource will be handled when consumers use `*` without knowledge of said
+      new, mutable fields. Likewise consumers need to be concious of using `*`
+      only when the risks of doing so are acceptable. In general, it is safest
+      to explicitly specify the fields to update rather than use `*`.
 - The request message **must not** contain any other required fields, and
   **should not** contain other optional fields except those described in this
   or another AIP.


### PR DESCRIPTION
Document the usage caveats for full replacement `update_mask` incantation `"*"`. 

Internal bug http://b/382094654