### PR TITLE
fix(AIP-160): move validation guidance to new section

### DIFF
--- a/aip/general/0160.md
+++ b/aip/general/0160.md
@@ -208,7 +208,8 @@ Schematic validation refers, but is not limited to, the following:
 - Field values for bounded data types e.g. `enum` provided in the `filter`
   **must** be a valid value in the set
 - Field values for standardized types e.g. `Timestamp` **must** conform to the
-  documented standard
+  documented standard (see [Comparison Operators](#comparison-operators) for a
+  list of such types)
 
 <!-- prettier-ignore-start -->
 [aip-132]: ./0132.md

--- a/aip/general/0160.md
+++ b/aip/general/0160.md
@@ -190,9 +190,25 @@ above what is defined here. For example, a service may support the logical
 operators but only permit a certain number of them (to avoid "queries of death"
 or other performance concerns).
 
-Further structure or limitations **must** be clearly documented, **must not**
-violate requirements set forth in this document, and a non-compliant filter
-query **must** error with `INVALID_ARGUMENT`.
+Further structure or limitations **must** be clearly documented, and
+**must not** violate requirements set forth in this document.
+
+### Validation
+
+If a non-compliant or schematically invalid `filter` string is specified,
+the API **should** error with `INVALID_ARGUMENT`. Wherever validation is relaxed
+for `filter`, the API **must** document the difference.
+
+Schematic validation refers, but is not limited to, the following:
+
+- Fields referenced in the `filter` **must** exist on the filtered schema
+- Field values provided in the `filter` **must** align to the type of the field
+  - For example, for a field `int32 age` a `filter` like `"age=hello"` is
+    invalid
+- Field values for bounded data types e.g. `enum` provided in the `filter`
+  **must** be a valid value in the set
+- Field values for standardized types e.g. `Timestamp` **must** conform to the
+  documented standard
 
 <!-- prettier-ignore-start -->
 [aip-132]: ./0132.md
@@ -204,3 +220,7 @@ query **must** error with `INVALID_ARGUMENT`.
 [rfc-3339]: https://tools.ietf.org/html/rfc3339
 [timestamps]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
 <!-- prettier-ignore-end -->
+
+## Changelog
+
+- **2024-12-11**: Move non-compliant filter guidance to Validation section.


### PR DESCRIPTION
The only mention of what to do in the face of a non-compliant `filter` is buried in a somewhat unrelated subsection. Furthermore, no explicit guidance is given as to how schematically invalid filters are handled in general e.g. referring to a field that doesn't exist, using a value that doesn't align with the field's type, etc.

This moves that "non-compliant `filter` == `INVALID_ARGUMENT`" to a dedicated `Validation` section and includes mention of some schematic validation.

Internal bug http://b/383153119