### PR TITLE
chore(AIP-9): downcase headings and terms as per dev docs style

### DIFF
--- a/aip/general/0009.md
+++ b/aip/general/0009.md
@@ -18,90 +18,90 @@ The following terminology **should** be used consistently throughout AIPs.
 
 ### API
 
-Application Programming Interface. This can be a local interface (such as a
+Application programming interface. This can be a local interface (such as a
 client library) or a Network API (defined below).
 
-### API Backend
+### API backend
 
 A set of servers and related infrastructure that implements the business logic
-for an API Service. An individual API backend server is often called an API
+for an API service. An individual API backend server is often called an API
 server.
 
-### API Consumer
+### API consumer
 
-The entity that consumes an API Service. For Google APIs, it typically is a
+The entity that consumes an API service. For Google APIs, it typically is a
 Google project that owns the client application or the server resource.
 
-### API Definition
+### API definition
 
 The definition of an API, usually defined in a Protocol Buffer service. An API
-Definition can be implemented by any number of API Services.
+definition can be implemented by any number of API services.
 
-### API Frontend
+### API frontend
 
 A set of servers plus related infrastructure that provides common functionality
-across API Services, such as load balancing and authentication. An individual
+across API services, such as load balancing and authentication. An individual
 API frontend server is often called an API proxy.
 
 **Note:** the API frontend and the API backend may run next to each other or far
 away from each other. In some cases, they can be compiled into a single
 application binary and run inside a single process.
 
-### API Method
+### API method
 
 An individual operation within an API. It is typically represented in Protocol
 Buffers by an `rpc` definition, and is mapped to a function in the API in most
 programming languages.
 
-### API Producer
+### API producer
 
-The entity that produces an API Service. For Google APIs, it typically is a
-Google team responsible for the API Service.
+The entity that produces an API service. For Google APIs, it typically is a
+Google team responsible for the API service.
 
-### API Product
+### API product
 
-An API Service and its related components, such as Terms of Service,
+An API service and its related components, such as Terms of Service,
 documentation, client libraries, and service support, are collectively presented
-to customers as a API Product. For example, Google Calendar API.
+to customers as a API product. For example, Google Calendar API.
 
-**Note:** people sometimes refer to an API Product simply as an API.
+**Note:** people sometimes refer to an API product simply as an API.
 
-### API Service
+### API service
 
 A deployed implementation of one or more APIs, exposed on one or more network
 addresses, such as the Cloud Pub/Sub API.
 
-### API Service Definition
+### API service definition
 
-The combination of API Definitions (`.proto` files) and API Service
-configurations (`.yaml` files) used to define an API Service. The schema for
-Google API Service Definition is `google.api.Service`.
+The combination of API definitions (`.proto` files) and API service
+configurations (`.yaml` files) used to define an API service. The schema for
+Google API service definition is `google.api.Service`.
 
-### API Service Endpoint
+### API service endpoint
 
-Refers to a network address that an API Service uses to handle incoming API
-Requests. One API Service may have multiple API Service Endpoints, such as
+Refers to a network address that an API service uses to handle incoming API
+requests. One API service may have multiple API service endpoints, such as
 `https://pubsub.googleapis.com` and `https://content-pubsub.googleapis.com`.
 
-### API Service Name
+### API service name
 
-Refers to the logical identifier of an API Service. Google APIs use RFC 1035 DNS
-compatible names as their API Service Names, such as `pubsub.googleapis.com`.
+Refers to the logical identifier of an API service. Google APIs use RFC 1035 DNS
+compatible names as their API service names, such as `pubsub.googleapis.com`.
 
-### API Title
+### API title
 
 Refers to the user-facing product title of an API service, such as "Cloud Pub/Sub
 API".
 
-### API Request
+### API request
 
-A single invocation of an API Method. It is often used as the unit for billing,
+A single invocation of an API method. It is often used as the unit for billing,
 logging, monitoring, and rate limiting.
 
-### API Version
+### API version
 
 The version of an API or a group of APIs if they are defined together. An API
-Version is often represented by a string, such as "v1", and presents in API
+version is often represented by a string, such as "v1", and presents in API
 requests and Protocol Buffers package names.
 
 ### Client
@@ -161,6 +161,7 @@ organizations separate from those that consume them.
 
 ## Changelog
 
+- **2024-12-18**: Downcase headings and terms as per dev docs style
 - **2024-10-23**: Add API Title entry
 - **2023-07-24**: Rename IaC to Declarative Clients
 - **2023-04-01**: Adding definition of IaC


### PR DESCRIPTION
Fix heading and term capitalization as per https://developers.google.com/style/capitalization. Subsequent words in a heading are lower case, and the terms defined in this glossary are cased to align with the headings.

cc: @toddkopriva

Internal bug http://b/378893272