### PR TITLE
fix(AIP-160): clarify unset field in traversal behavior

### DIFF
--- a/aip/general/0160.md
+++ b/aip/general/0160.md
@@ -138,6 +138,12 @@ the service **should** return an error with `INVALID_ARGUMENT`. A service
 **may** permit traversal to undefined keys on maps and structs, and **should**
 document how it behaves in this situation.
 
+When evaluating an expression involving a traversal, if any non-primitive field
+in the chain is not set on the entry being evaluated, the entry **should** be
+skipped i.e. not match the filter expression. In the examples above, if resource
+field `a` is not set on the resource instance, that instance is skipped as a
+non-match.
+
 **Important:** The `.` operator **must not** be used to traverse through a
 repeated field or list, except for specific use with the `:` operator.
 
@@ -224,4 +230,5 @@ Schematic validation refers, but is not limited to, the following:
 
 ## Changelog
 
+- **2025-01-07**: Clarify behavior for unset field in traversal operator chain.
 - **2024-12-11**: Move non-compliant filter guidance to Validation section.

--- a/aip/general/0160.md
+++ b/aip/general/0160.md
@@ -140,9 +140,10 @@ document how it behaves in this situation.
 
 When evaluating an expression involving a traversal, if any non-primitive field
 in the chain is not set on the entry being evaluated, the entry **should** be
-skipped i.e. not match the filter expression. In the examples above, if resource
-field `a` is not set on the resource instance, that instance is skipped as a
-non-match.
+skipped i.e. not match the filter expression. This applies even when the
+comparison is a `!=`, which would imply matching on empty values. In the
+examples above, if resource field `a` is not set on the resource instance, that
+instance is skipped as a non-match.
 
 **Important:** The `.` operator **must not** be used to traverse through a
 repeated field or list, except for specific use with the `:` operator.


### PR DESCRIPTION
Clarify the expected behavior when a non-primitive field in a traversal operator's chain of fields is not set, it should be skipped i.e. not matched. This has been the expected behavior since inception, but was undocumented.

Internal bug http://b/388065878