### PR TITLE
chore(AIP-136): add rationale for disallowing prepositions

### DIFF
--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -157,6 +157,14 @@ read data have first-class concepts in some clients (DataSources in
 Terraform) and clearly indicate to a user which methods can be called
 without risk of runtime impact.
 
+### Disallowing prepositions
+
+Generally, method names with prepositions indicate that a new method is being
+used where a field should instead be added to an existing method, or the method
+should use a distinct verb. For example, if a `CreateBook` message already
+exists and you are considering adding `CreateBookFromDictation`, consider a `TranscribeBook` method instead. Similarly, if there is desire for a
+property-specific look-up method, instead of `GetBookByAuthor` consider a
+`SearchBooks` with an `author` field as a search dimension.
 
 [get]: ./0131.md
 [list]: ./0132.md

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -185,6 +185,7 @@ languages.
 
 ## Changelog
 
+- **2025-01-09:** Add original rationale for disallowing prepositions in names.
 - **2023-11-16:** Included link to AIP-127 "HTTP and gRPC Transcoding" for guidance on body definition.
 - **2023-05-16:** Added prohibition of the term "async" within RPC names.
 - **2023-05-09:** Adding guidance for POST and GET, require parent instead of


### PR DESCRIPTION
Copied this rationale from the original ([internal](http://cl/228979227)) style guide change to disallow prepositions that wasn't carried over in the PR to add the guidance here as well.

As a result of #1026