### PR TITLE
fix(AIP-1): Add guidance for including examples in proposals

### DIFF
--- a/aip/general/0001.md
+++ b/aip/general/0001.md
@@ -205,6 +205,18 @@ In order to propose an AIP, first [open an issue][] to circulate the
 fundamental idea for initial feedback. It should generally be possible to
 describe the idea in a couple of pages.
 
+When proposing a new AIP or changes to an existing one, it is best to reference
+prior art and/or example use cases that the proposal will impact, so as to
+ensure that the proposal is grounded in a realistic problem space. So, proposals
+**should** provide concrete references and/or well-defined examples. Appropriate
+material includes, but is not limited to, the following:
+
+- Existing external RFCs or standards
+- A corpus of APIs that have aligned on a similar pattern e.g. `Search` methods
+- A concrete use case that has yet to be solved that exists or could exist in
+  one or more APIs e.g. adding an AIP-202 Format for AIP-143 Unicode CLDR
+  region codes
+
 Once ready, create a PR with a new file in the AIP directory using a file
 titled `aip/new.md`. Ensure that the PR is editable by maintainers.
 
@@ -262,6 +274,7 @@ state, and will link to the new, current AIP.
 
 ## Changelog
 
+- **2025-01-09**: Add requirement to include references/examples in proposals.
 - **2024-09-04**: Updated names of current editors and remove TLs.
 - **2023-05-10**: Updated names of current and editors and TLs.
 - **2019-07-30**: Further clarified AIP quorum requirements.


### PR DESCRIPTION
Add guidance to AIP-1 "Proposing an AIP" with regards to providing examples and reference material to work with during design and review phase.