### PR TITLE
Clarify error propagation behavior for failures that occur during long-running operations.

### DIFF
--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -124,6 +124,10 @@ Operations that fail during their execution phase **must** return an
 error response ([AIP-193][]), placed in the `Operation.error` [google.rpc.Status][]
 field.
 
+Non-terminal errors that occur over the course of an operation **may** be placed
+in the metadata message and the field(s) **must** be [AIP-193][] compliant
+[google.rpc.Status][].
+
 ### Backwards compatibility
 
 Changing either the `response_type` or `metadata_type` of a long-running operation

--- a/aip/general/0151.md
+++ b/aip/general/0151.md
@@ -120,9 +120,9 @@ has elapsed after the operation completed.
 Errors that prevent a long-running operation from _starting_ **must** return an
 error response ([AIP-193][]), similar to any other method.
 
-Errors that occur over the course of an operation **may** be placed in the
-metadata message. The errors themselves **must** still be represented with a
-[google.rpc.Status][] object.
+Operations that fail during their execution phase **must** return an
+error response ([AIP-193][]), placed in the `Operation.error` [google.rpc.Status][]
+field.
 
 ### Backwards compatibility
 
@@ -163,6 +163,8 @@ updated status) but server don't need to maintain any additional state.
 
 ## Changelog
 
+- **2025-02-04**: Clarified error propagation behavior for failures
+  that occur during long-running operations.
 - **2024-04-23**: Provided pattern for validation on RPCs returning
   long-running operations.
 - **2022-05-31**: Added compatibility section.


### PR DESCRIPTION
Add details on how LRO's should propagate AIP-193 metadata when the operation fails during its execution.