### PR TITLE
fix(AIP-132): Require documentation for ordering not matching field type

### DIFF
--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -156,6 +156,10 @@ request message **should** contain a `string order_by` field.
   equivalent.
 - Subfields are specified with a `.` character, such as `foo.bar` or
   `address.street`.
+- The resulting list order **should** usually be numeric for number-typed fields
+  and lexicographic for other types. However, APIs **may** choose to use a
+  different ordering; if so, it **must** be documented in the `order_by`
+  definition.
 
 <!-- TODO(#220): Add a reference to AIP-161 once it is written. -->
 
@@ -205,6 +209,7 @@ NOT_FOUND errors][permission-denied].
 
 ## Changelog
 
+- **2025-02-22**: Require documentation for ordering not matching field type
 - **2023-03-22**: Fix guidance wording to mention AIP-159.
 - **2023-03-17**: Align with AIP-122 and make Get a must.
 - **2022-11-04**: Aggregated error guidance to AIP-193.

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -162,7 +162,7 @@ request message **should** contain a `string order_by` field.
   ordering; if so, it **must** be documented in the `order_by` definition.
   - Furthermore, [well-known][] types, like `Timestamp` and `Duration` are
     compared as their representative type; `Timestamp` is compared as time e.g.
-    before or after, `Duration` is compared numerically e.g. larger or smaller.
+    before or after, `Duration` is compared as a quantity e.g. more or less.
 
 <!-- TODO(#220): Add a reference to AIP-161 once it is written. -->
 

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -156,7 +156,7 @@ request message **should** contain a `string order_by` field.
   equivalent.
 - Subfields are specified with a `.` character, such as `foo.bar` or
   `address.street`.
-- The resulting list order **should** usually be numeric for number-typed fields
+- The resulting list order **should** be numeric for number-typed fields
   and lexicographic for other types. However, APIs **may** choose to use a
   different ordering; if so, it **must** be documented in the `order_by`
   definition.

--- a/aip/general/0132.md
+++ b/aip/general/0132.md
@@ -156,10 +156,13 @@ request message **should** contain a `string order_by` field.
   equivalent.
 - Subfields are specified with a `.` character, such as `foo.bar` or
   `address.street`.
-- The resulting list order **should** be numeric for number-typed fields
-  and lexicographic for other types. However, APIs **may** choose to use a
-  different ordering; if so, it **must** be documented in the `order_by`
-  definition.
+- The resulting list order **should** be based on the field type's natural
+  comparator e.g. numerics ordered numerically, strings ordered
+  lexicographically, etc. However, APIs **may** choose to use a different
+  ordering; if so, it **must** be documented in the `order_by` definition.
+  - Furthermore, [well-known][] types, like `Timestamp` and `Duration` are
+    compared as their representative type; `Timestamp` is compared as time e.g.
+    before or after, `Duration` is compared numerically e.g. larger or smaller.
 
 <!-- TODO(#220): Add a reference to AIP-161 once it is written. -->
 
@@ -206,10 +209,12 @@ NOT_FOUND errors][permission-denied].
 [reading across collections]: ./0159.md
 [singleton]: ./0156.md
 [soft delete]: ./0135.md#soft-delete
+[well-known]: https://protobuf.dev/reference/protobuf/google.protobuf
 
 ## Changelog
 
-- **2025-02-22**: Require documentation for ordering not matching field type
+- **2025-02-25**: Require documentation for ordering not matching field type
+  with clarification on ordering of well-known types.
 - **2023-03-22**: Fix guidance wording to mention AIP-159.
 - **2023-03-17**: Align with AIP-122 and make Get a must.
 - **2022-11-04**: Aggregated error guidance to AIP-193.


### PR DESCRIPTION
Using similar language to https://google.aip.dev/160#literals require that ordering differing from what's expected of a field (given its type) be documented.

Fixes https://github.com/aip-dev/google.aip.dev/issues/1483