### PR TITLE
fix(AIP-140): add uri guidance rationale

### DIFF
--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -173,8 +173,19 @@ field **should not** have a uniqueness requirement.
 - For naming fields representing quantities, see [AIP-141][].
 - For naming fields representing time, see [AIP-142][].
 
+## Rationale
+
+### URI vs URL
+
+The guidance itself mentions that all URLs are URIs, but not all URIs are URLs.
+The goal of aligning on URI is to enable a more generalizable field, that can
+handle a variety of use cases, as well as drive standardization across APIs,
+creating a more coherent surface. At the same time, the requirement being a
+**should** allows for more specific terms when it truly merits it.
+
 ## Changelog
 
+- **2025-03-10**: Add rationale for URI guidance.
 - **2024-12-20**: Copy over abbreviations guidance from old design site.
 - **2024-08-26**: Codify exception to string and base64 guidance 
 - **2024-05-18**: Documented the effect of field names on client surfaces.


### PR DESCRIPTION
Adds rationale for AIP-140 URI naming convention guidance.

Fixes #1489