### PR TITLE
Adds single quotes around the permission and resource

### DIFF
--- a/aip/general/0211.md
+++ b/aip/general/0211.md
@@ -23,8 +23,8 @@ authorization.
 
 If a request can not pass the authorization check for any reason, the service
 **must** error with `PERMISSION_DENIED`, and the corresponding error message
-**should** look like: "Permission `{p}` denied on resource `{r}` (or it might
-not exist)." This avoids leaking resource existence.
+**should** look like: "Permission '`{p}`' denied on resource '`{r}`' (or it
+might not exist)." This avoids leaking resource existence.
 
 If it is not possible to determine authorization for a resource because the
 resource does not exist, the service **should** check authorization to read


### PR DESCRIPTION
This aligns with how existing errors are returned.