### PR TITLE
docs: updates legacy pagination alternatives

### DIFF
--- a/aip/client-libraries/4233.md
+++ b/aip/client-libraries/4233.md
@@ -18,7 +18,9 @@ that it performs requests in the background on an as-needed basis).
 Pagination can be inferred for an RPC when _all_ of the following conditions
 are met:
 
-- The request message contains an `int32 page_size` field.
+- The request message contains an `int32 page_size` field (for legacy APIs,
+  a `UInt32Value max_results` field or a `Int32Value max_results` field is
+  permissible as an alternative to `int32 page_size`).
 - The request message contains a `string page_token` field.
 - The response message contains a `string next_page_token` field.
 - The response message contains one non-primitive `repeated` field.

--- a/aip/client-libraries/4233.md
+++ b/aip/client-libraries/4233.md
@@ -18,9 +18,10 @@ that it performs requests in the background on an as-needed basis).
 Pagination can be inferred for an RPC when _all_ of the following conditions
 are met:
 
-- The request message contains an `int32 page_size` field (for legacy APIs,
-  a `UInt32Value max_results` field or a `Int32Value max_results` field is
-  permissible as an alternative to `int32 page_size`).
+- The request message contains an `int32 page_size` field.
+  - For APIs that predate [AIP-158][], a field named `max_results` and/or
+    typed as `google.protobuf.UInt32Value` or `google.protobuf.Int32Value`
+    are permissible alternatives.
 - The request message contains a `string page_token` field.
 - The response message contains a `string next_page_token` field.
 - The response message contains one non-primitive `repeated` field.


### PR DESCRIPTION
This PR suggests an addition to the allowed criteria related to pagination to account for an existing legacy situation in the [BigQuery library](https://github.com/googleapis/python-bigquery).

Namely, in **legacy** APIs, it authorizes the use of:

* `max_results` as an alternative to `page_size` for identifying the maximum number of rows to return
* the use of a broader subset of integer wrapper values (to include `UInt32Value`, `Int32Value` as well as the currently accepted `int32`)

For more details and discussion regarding this suggestion, see internal Google CL 736898880

