### PR TITLE
Clarify method naming

### DIFF
--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -41,7 +41,9 @@ resource. Custom methods can be associated with resources, collections, or
 services. The bullets below apply in all three cases.
 
 - The name of the method **should** be a verb (for resource-based and collection-based
-  custom methods) or a verb followed by a noun (for stateless methods).
+  custom methods where the method refers to the resource or collection itself) or a verb
+  followed by a noun (for resource-based and collection-based which don't refer to the
+  resource or collection itself or for stateless methods).
   - The name **must not** contain prepositions ("for", "with", etc.).
   - The verb in the name **should not** contain any of the standard method verbs ([Get][],
     [List][], [Create][], [Update][], [Delete][]).

--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -40,7 +40,8 @@ rpc ArchiveBook(ArchiveBookRequest) returns (ArchiveBookResponse) {
 resource. Custom methods can be associated with resources, collections, or
 services. The bullets below apply in all three cases.
 
-- The name of the method **should** be a verb followed by a noun.
+- The name of the method **should** be a verb (for resource-based and collection-based
+  custom methods) or a verb followed by a noun (for stateless methods).
   - The name **must not** contain prepositions ("for", "with", etc.).
   - The verb in the name **should not** contain any of the standard method verbs ([Get][],
     [List][], [Create][], [Update][], [Delete][]).
@@ -185,6 +186,7 @@ languages.
 
 ## Changelog
 
+- **2025-03-20:** Clarify method naming: names for resource-base and collection-based methods can be a verb only.
 - **2025-01-09:** Add original rationale for disallowing prepositions in names.
 - **2023-11-16:** Included link to AIP-127 "HTTP and gRPC Transcoding" for guidance on body definition.
 - **2023-05-16:** Added prohibition of the term "async" within RPC names.


### PR DESCRIPTION
Names for resource-base and collection-based methods can be a verb only.