### PR TITLE
Link AIP-157 from AIP-161

### DIFF
--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -29,7 +29,7 @@ Field masks **must** always be relative to the resource:
 
 **Warning:** Read masks as a single field on the request message, for
 example: `google.protobuf.FieldMask read_mask` are **DEPRECATED**. Instead, see
-[AIP-157][].
+AIP-157.
 
 ```proto
 message UpdateBookRequest {

--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -28,7 +28,8 @@ common on Update requests (AIP-134).
 Field masks **must** always be relative to the resource:
 
 **Warning:** Read masks as a single field on the request message, for
-example: `google.protobuf.FieldMask read_mask` are **DEPRECATED**. Instead, see AIP-157.
+example: `google.protobuf.FieldMask read_mask` are **DEPRECATED**. Instead, see
+[AIP-157][].
 
 ```proto
 message UpdateBookRequest {

--- a/aip/general/0161.md
+++ b/aip/general/0161.md
@@ -28,7 +28,7 @@ common on Update requests (AIP-134).
 Field masks **must** always be relative to the resource:
 
 **Warning:** Read masks as a single field on the request message, for
-example: `google.protobuf.FieldMask read_mask` are **DEPRECATED**.
+example: `google.protobuf.FieldMask read_mask` are **DEPRECATED**. Instead, see AIP-157.
 
 ```proto
 message UpdateBookRequest {


### PR DESCRIPTION
Point out the alternative to the deprecated `read_mask` field.