### PR TITLE
chore(AIP-136): extend disallowing prepositions rationale

### DIFF
--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -162,9 +162,12 @@ without risk of runtime impact.
 Generally, method names with prepositions indicate that a new method is being
 used where a field should instead be added to an existing method, or the method
 should use a distinct verb. For example, if a `CreateBook` message already
-exists and you are considering adding `CreateBookFromDictation`, consider a `TranscribeBook` method instead. Similarly, if there is desire for a
+exists and you are considering adding `CreateBookFromDictation`, consider a
+`TranscribeBook` method instead. Similarly, if there is desire for a
 property-specific look-up method, instead of `GetBookByAuthor` consider a
-`SearchBooks` with an `author` field as a search dimension.
+`SearchBooks` with an `author` field as a search dimension. This helps prevent
+an explosion of hyper-focused methods that bloat API and client surfaces, and
+add complexity to both managing and consuming the API.
 
 [get]: ./0131.md
 [list]: ./0132.md
@@ -185,6 +188,7 @@ languages.
 
 ## Changelog
 
+- **2025-05-12:** Extend disallowing prepositions rationale.
 - **2025-01-09:** Add original rationale for disallowing prepositions in names.
 - **2023-11-16:** Included link to AIP-127 "HTTP and gRPC Transcoding" for guidance on body definition.
 - **2023-05-16:** Added prohibition of the term "async" within RPC names.


### PR DESCRIPTION
Extend rationale for disallowing use of prepositions in custom method names to include preventing bloated API surfaces.