### PR TITLE
chore(AIP-4221): change example retry policy values

### DIFF
--- a/aip/client-libraries/4221.md
+++ b/aip/client-libraries/4221.md
@@ -86,9 +86,9 @@ service, except for those that are explicitly named which get no `RetryPolicy`.
     "timeout": "60s",
     "retryPolicy": {
       "maxAttempts": 3,
-      "initialBackoff": "0.01s",
-      "maxBackoff": "60s",
-      "backoffMultiplier": 1.3,
+      "initialBackoff": "1s",
+      "maxBackoff": "10s",
+      "backoffMultiplier": 2,
       "retryableStatusCodes": ["UNAVAILABLE"]
     }
   },
@@ -102,7 +102,7 @@ service, except for those that are explicitly named which get no `RetryPolicy`.
       { "service": "google.example.library.v1.LibraryService", "method": "MoveBook" }
     ],
     "waitForReady": true,
-    "timeout": "60s"
+    "timeout": "10s"
   }]
 }
 ```


### PR DESCRIPTION
The original Google API Design Guide recommended 1s initial delay, which is more sensible than 0.01s. Azure recommends 5s.

2x is the most popular delay multiplier in the industry. As an example, we should use the most popular choice.

60s timeout often leads to thread exhaustion and user frustration and server overloading. Historically, all Google APIs use either 5s or 10s as the deadline. This is especially true for Google REST client libraries.