### PR TITLE
fix(AIP-9): add entry for API interface

### DIFF
--- a/aip/general/0009.md
+++ b/aip/general/0009.md
@@ -47,6 +47,13 @@ API frontend server is often called an API proxy.
 away from each other. In some cases, they can be compiled into a single
 application binary and run inside a single process.
 
+#### API interface
+
+The element of an API specification IDL that groups API methods, such as a
+Protocol Buffers `service` definition. It is typically mapped to a similar high
+level grouping mechanism in most programming languages, like a `class` or
+`interface`.
+
 ### API method
 
 An individual operation within an API. It is typically represented in Protocol
@@ -161,6 +168,7 @@ organizations separate from those that consume them.
 
 ## Changelog
 
+- **2025-08-13**: Add API inteface entry
 - **2024-12-18**: Downcase headings and terms as per dev docs style
 - **2024-10-23**: Add API Title entry
 - **2023-07-24**: Rename IaC to Declarative Clients


### PR DESCRIPTION
Adds entry for `API interface`. Definition agreed upon in this [internal doc](https://docs.google.com/document/d/19yE9wczbejpP1QcNZrjTHvI8fPTItM-6G84iFMtUMYU/edit?tab=t.0), but previously appeared in the now migrated Cloud Site api design guide.