### PR TITLE
feat(AIP-140): allow url field name in specific cases

### DIFF
--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -137,9 +137,14 @@ this case, services **may** use a `string`.
 
 ### URIs
 
-Field names representing URLs or URIs **should** always use `uri` rather than
-`url`. This is because while all URLs are URIs, not all URIs are URLs. Field
-names **may** use a prefix in front of `uri` as appropriate.
+Field names representing arbitrary URIs **should** always use `uri`. In
+particular, note that URLs are URIs but not all URIs are URLs.
+
+Field names **may** use a prefix in front of `uri` as appropriate.
+
+### URLs
+
+If a field can only represent a URL, the field name should always use `url`.
 
 ### Reserved words
 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -137,14 +137,29 @@ this case, services **may** use a `string`.
 
 ### URIs
 
-Field names representing arbitrary URIs **should** always use `uri`. In
-particular, note that URLs are URIs but not all URIs are URLs.
+Field names representing arbitrary URIs **should** use `uri`. In particular,
+note that URLs are URIs but not all URIs are URLs.
 
 Field names **may** use a prefix in front of `uri` as appropriate.
 
-### URLs
+Field names that can only represent a URL **should** use `url`.
 
-If a field can only represent a URL, the field name should use `url`.
+```proto
+message Book {
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+
+  // A URL pointing to an image of the book.
+  string image_url = 2;
+
+  // A URI identifying the book.
+  // This could be an ISBN or a URL.
+  string uri = 3;
+}
+```
+
+**Note:**
+APIs that have previously used `uri` for URL fields may continue to do so
+to avoid unnecessary API changes and to preserve local consistency.
 
 ### Reserved words
 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -144,7 +144,7 @@ Field names **may** use a prefix in front of `uri` as appropriate.
 
 ### URLs
 
-If a field can only represent a URL, the field name should always use `url`.
+If a field can only represent a URL, the field name should use `url`.
 
 ### Reserved words
 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -157,9 +157,8 @@ message Book {
 }
 ```
 
-**Note:**
-APIs that have previously used `uri` for URL fields may continue to do so
-to avoid unnecessary API changes and to preserve local consistency.
+**Note:** APIs that have previously used `uri` for URL fields may continue to
+do so to avoid unnecessary API changes and to preserve local consistency.
 
 ### Reserved words
 


### PR DESCRIPTION
This proposes to update the guidelines to advocate for clearer naming for fields that can only return URLs.

It appears to be possible to misinterpret AIP-0140 guidelines to infer that fields that return URLs MUST be named as if they could be URIs. It seems more accurate to indicate that fields that COULD be URIs should use `uri` in the name and fields that MUST be URLs should use `url` in the name.