### PR TITLE
fix(AIP-203): copy resource etag exemption

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -26,6 +26,8 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 
 - APIs **must** apply the `google.api.field_behavior` annotation on every field
   on a message or sub-message used in a request.
+  - An exception to this is the [AIP-154][] `etag` field on a resource message,
+    which **should not** have any `google.api.field_behavior` assigned.
 - The annotation **must** include any [google.api.FieldBehavior][] values that
   accurately describe the behavior of the field.
   - `FIELD_BEHAVIOR_UNSPECIFIED` **must not** be used.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -26,7 +26,7 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 
 - APIs **must** apply the `google.api.field_behavior` annotation on every field
   on a message or sub-message used in a request.
-  - An exception to this is the [AIP-154][] `etag` field on a resource message,
+  - An exception to this is the AIP-154 `etag` field on a resource message,
     which **should not** have any `google.api.field_behavior` assigned.
 - The annotation **must** include any [google.api.FieldBehavior][] values that
   accurately describe the behavior of the field.


### PR DESCRIPTION
AIP-154 already states that the etag field of a resource should not have a field_behavior annotation due to the contextual nature of a resource message being used as input and output. Pull it into AIP-203 for posterity.

Internal bug http://b/520536049