### PR TITLE
fix(AIP-136): allow complex GET as POST

### DIFF
--- a/aip/general/0136.md
+++ b/aip/general/0136.md
@@ -51,6 +51,8 @@ services. The bullets below apply in all three cases.
     considered), a custom `CreateBookLongRunning` method could be introduced.
 - The HTTP method **must** be `GET` or `POST`:
   - `GET` **must** be used for methods retrieving data or resource state.
+    - `POST` **may** be used for data retieval methods if the request payload could
+      exceed URL size limitations, thus requiring a `body`.
   - `POST` **must** be used if the method has side effects or mutates resources
     or data.
 - The HTTP URI **must** use a `:` character followed by the custom verb
@@ -188,6 +190,7 @@ languages.
 
 ## Changelog
 
+- **2026-06-09:** Allow complex GET to be POST if necessary.
 - **2025-05-12:** Extend disallowing prepositions rationale.
 - **2025-01-09:** Add original rationale for disallowing prepositions in names.
 - **2023-11-16:** Included link to AIP-127 "HTTP and gRPC Transcoding" for guidance on body definition.


### PR DESCRIPTION
When a data retrieval method would result in extremely long URLs due to massive request payloads, it is reasonable to use POST as the HTTP method instead of GET, which will allow the specification of a `body`.